### PR TITLE
[feature] add go-pretty progress wrapper

### DIFF
--- a/docs/plans/progress-indicator-plan.md
+++ b/docs/plans/progress-indicator-plan.md
@@ -26,23 +26,23 @@
 ### Step 2: Implement go-pretty Progress Wrapper
 **File**: `progress_pretty.go`
 
-- [ ] Create `PrettyProgress` struct with go-pretty progress.Writer and tracker
-- [ ] Implement constructor `newPrettyProgress(settings *OutputSettings) *PrettyProgress`
-- [ ] Implement `SetTotal(total int)` method
-- [ ] Implement `SetCurrent(current int)` method
-- [ ] Implement `Increment(n int)` method
-- [ ] Implement `SetStatus(status string)` with message updates
-- [ ] Implement `SetColor(color ProgressColor)` with style mapping
-  - [ ] Map ProgressColorGreen to go-pretty green style
-  - [ ] Map ProgressColorRed to go-pretty red style
-  - [ ] Map ProgressColorYellow to go-pretty yellow style
-  - [ ] Map ProgressColorBlue to go-pretty blue style
-- [ ] Implement `Complete()` with success styling
-- [ ] Implement `Fail(err error)` with error styling and message
-- [ ] Implement `IsActive() bool` to check progress state
-- [ ] Add internal `start()` and `stop()` methods for lifecycle
-- [ ] Handle terminal detection (check if stdout is TTY)
-- [ ] Add cleanup in case of panic/unexpected exit
++ [x] Create `PrettyProgress` struct with go-pretty progress.Writer and tracker
++ [x] Implement constructor `newPrettyProgress(settings *OutputSettings) *PrettyProgress`
++ [x] Implement `SetTotal(total int)` method
++ [x] Implement `SetCurrent(current int)` method
++ [x] Implement `Increment(n int)` method
++ [x] Implement `SetStatus(status string)` with message updates
++ [x] Implement `SetColor(color ProgressColor)` with style mapping
+  - [x] Map ProgressColorGreen to go-pretty green style
+  - [x] Map ProgressColorRed to go-pretty red style
+  - [x] Map ProgressColorYellow to go-pretty yellow style
+  - [x] Map ProgressColorBlue to go-pretty blue style
++ [x] Implement `Complete()` with success styling
++ [x] Implement `Fail(err error)` with error styling and message
++ [x] Implement `IsActive() bool` to check progress state
++ [x] Add internal `start()` and `stop()` methods for lifecycle
++ [x] Handle terminal detection (check if stdout is TTY)
++ [x] Add cleanup in case of panic/unexpected exit
 
 ### Step 3: Create No-op Implementation
 **File**: `progress_noop.go`

--- a/progress_pretty.go
+++ b/progress_pretty.go
@@ -1,0 +1,160 @@
+package format
+
+import (
+	"os"
+	"runtime"
+	"sync"
+	"time"
+
+	"github.com/jedib0t/go-pretty/v6/progress"
+	"github.com/jedib0t/go-pretty/v6/text"
+	"github.com/mattn/go-isatty"
+)
+
+// PrettyProgress wraps go-pretty's progress.Writer to implement the Progress interface.
+type PrettyProgress struct {
+	writer  progress.Writer
+	tracker *progress.Tracker
+	options ProgressOptions
+	active  bool
+	mutex   sync.Mutex
+}
+
+// newPrettyProgress creates a new PrettyProgress instance.
+func newPrettyProgress(settings *OutputSettings) *PrettyProgress {
+	pp := &PrettyProgress{}
+	pp.tracker = &progress.Tracker{}
+	if settings != nil {
+		pp.options = ProgressOptions{}
+		pp.tracker.Message = ""
+	}
+	if isatty.IsTerminal(os.Stdout.Fd()) {
+		w := progress.NewWriter()
+		w.SetAutoStop(false)
+		w.SetTrackerLength(40)
+		w.SetUpdateFrequency(time.Millisecond * 100)
+		w.SetTrackerPosition(progress.PositionRight)
+		w.SetOutputWriter(os.Stdout)
+		w.SetNumTrackersExpected(1)
+		style := progress.StyleDefault
+		style.Visibility.TrackerOverall = false
+		w.SetStyle(style)
+		w.AppendTracker(pp.tracker)
+		pp.writer = w
+		pp.start()
+	}
+	pp.SetColor(pp.options.Color)
+	runtime.SetFinalizer(pp, func(p *PrettyProgress) { p.stop() })
+	return pp
+}
+
+func (pp *PrettyProgress) start() {
+	if pp.writer == nil {
+		return
+	}
+	pp.mutex.Lock()
+	if pp.active {
+		pp.mutex.Unlock()
+		return
+	}
+	pp.active = true
+	pp.mutex.Unlock()
+	go func() {
+		defer func() {
+			if r := recover(); r != nil {
+				// ensure progress stops on panic
+			}
+			pp.stop()
+		}()
+		pp.writer.Render()
+	}()
+}
+
+func (pp *PrettyProgress) stop() {
+	pp.mutex.Lock()
+	defer pp.mutex.Unlock()
+	if pp.writer != nil && pp.active {
+		pp.writer.Stop()
+	}
+	pp.active = false
+}
+
+// SetTotal sets the expected total value.
+func (pp *PrettyProgress) SetTotal(total int) {
+	if pp.tracker != nil {
+		pp.tracker.UpdateTotal(int64(total))
+	}
+}
+
+// SetCurrent sets the current progress value.
+func (pp *PrettyProgress) SetCurrent(current int) {
+	if pp.tracker != nil {
+		pp.tracker.SetValue(int64(current))
+	}
+}
+
+// Increment increases the progress by n.
+func (pp *PrettyProgress) Increment(n int) {
+	if pp.tracker != nil {
+		pp.tracker.Increment(int64(n))
+	}
+}
+
+// SetStatus updates the status message.
+func (pp *PrettyProgress) SetStatus(status string) {
+	if pp.tracker != nil {
+		pp.tracker.UpdateMessage(status)
+	}
+}
+
+// SetColor changes the progress bar color.
+func (pp *PrettyProgress) SetColor(color ProgressColor) {
+	pp.options.Color = color
+	if pp.writer == nil {
+		return
+	}
+	style := *pp.writer.Style()
+	var c text.Colors
+	switch color {
+	case ProgressColorGreen:
+		c = text.Colors{text.FgGreen}
+	case ProgressColorRed:
+		c = text.Colors{text.FgRed}
+	case ProgressColorYellow:
+		c = text.Colors{text.FgYellow}
+	case ProgressColorBlue:
+		c = text.Colors{text.FgBlue}
+	default:
+		c = text.Colors{}
+	}
+	style.Colors.Message = c
+	style.Colors.Tracker = c
+	style.Colors.Value = c
+	pp.writer.SetStyle(style)
+}
+
+// Complete marks the progress as done successfully.
+func (pp *PrettyProgress) Complete() {
+	pp.SetColor(ProgressColorGreen)
+	if pp.tracker != nil {
+		pp.tracker.MarkAsDone()
+	}
+	pp.stop()
+}
+
+// Fail marks the progress as failed with the error message.
+func (pp *PrettyProgress) Fail(err error) {
+	pp.SetColor(ProgressColorRed)
+	if pp.tracker != nil {
+		pp.tracker.UpdateMessage(err.Error())
+		pp.tracker.MarkAsErrored()
+	}
+	pp.stop()
+}
+
+// IsActive reports if progress output is running.
+func (pp *PrettyProgress) IsActive() bool {
+	pp.mutex.Lock()
+	defer pp.mutex.Unlock()
+	return pp.active
+}

--- a/progress_pretty_test.go
+++ b/progress_pretty_test.go
@@ -1,0 +1,40 @@
+package format
+
+import (
+	"testing"
+)
+
+func TestPrettyProgressBasics(t *testing.T) {
+	settings := NewOutputSettings()
+	pp := newPrettyProgress(settings)
+
+	pp.SetTotal(10)
+	pp.Increment(3)
+	if v := pp.tracker.Value(); v != 3 {
+		t.Errorf("expected value 3, got %d", v)
+	}
+
+	pp.SetCurrent(5)
+	if v := pp.tracker.Value(); v != 5 {
+		t.Errorf("expected value 5, got %d", v)
+	}
+
+	pp.Complete()
+	if pp.IsActive() {
+		t.Errorf("progress should not be active after completion")
+	}
+}
+
+func TestPrettyProgressFail(t *testing.T) {
+	settings := NewOutputSettings()
+	pp := newPrettyProgress(settings)
+	pp.SetTotal(2)
+	pp.Fail(assertError("boom"))
+	if pp.IsActive() {
+		t.Errorf("progress should stop on failure")
+	}
+}
+
+type assertError string
+
+func (e assertError) Error() string { return string(e) }


### PR DESCRIPTION
## Summary
- implement `PrettyProgress` using go-pretty Writer
- add basic tests for PrettyProgress
- mark Phase 1 Step 2 items complete in plan

## Testing
- `go test ./... -v`
- `golangci-lint run` *(fails: unsupported configuration)*

------
https://chatgpt.com/codex/tasks/task_e_6846dd9ad3748333a5a07638e7e88a3c