### PR TITLE
[bug] fix linting issues

### DIFF
--- a/drawio/output.go
+++ b/drawio/output.go
@@ -6,7 +6,6 @@ import (
 	"encoding/csv"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -33,7 +32,11 @@ func CreateCSV(drawIOHeader Header, headerRow []string, contents []map[string]st
 		if err != nil {
 			log.Fatal(err)
 		}
-		defer file.Close()
+		defer func() {
+			if cerr := file.Close(); cerr != nil {
+				log.Println(cerr)
+			}
+		}()
 		target = bufio.NewWriter(file)
 	}
 	buf := new(bytes.Buffer)
@@ -85,7 +88,7 @@ func GetContentsFromFileAsStringMaps(filename string) []map[string]string {
 // getContentsFromFile returns the headers of a CSV in a string slice and the remaining rows separately
 // It filters away all of the comments
 func getContentsFromFile(filename string) ([]string, [][]string) {
-	originalfile, err := ioutil.ReadFile(filename)
+	originalfile, err := os.ReadFile(filename)
 	if err != nil {
 		panic(err)
 	}

--- a/outputcolors.go
+++ b/outputcolors.go
@@ -31,7 +31,7 @@ func (settings *OutputSettings) StringWarningInline(text string) string {
 func (settings *OutputSettings) StringSuccess(text interface{}) string {
 	green := color.New(color.FgGreen)
 	greenbold := green.Add(color.Bold)
-	greenbold.Println("")
+	_, _ = greenbold.Println("")
 	success := "OK"
 	if settings.UseEmoji {
 		success = "✅"


### PR DESCRIPTION
## Summary
- address `errcheck` warnings by checking file close operations
- replace deprecated `ioutil` functions
- ignore color Println return value

## Testing
- `go test ./... -v`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6846f2d8781c8333bf548852a2f19a33