### PR TITLE
[feature] progress factory integration

### DIFF
--- a/docs/plans/progress-indicator-plan.md
+++ b/docs/plans/progress-indicator-plan.md
@@ -56,7 +56,7 @@
 ### Step 4: Add Factory Function and Integration
 **File**: `format.go` (modifications)
 
-- [ ] Add progress-related fields to `OutputSettings`:
+ - [x] Add progress-related fields to `OutputSettings`:
   ```go
   type OutputSettings struct {
       // existing fields...
@@ -64,17 +64,17 @@
       ProgressOptions ProgressOptions
   }
   ```
-- [ ] Create `NewProgress(settings *OutputSettings) Progress` function
-- [ ] Add format detection logic:
-  - [ ] Return `NoOpProgress` for JSON format
-  - [ ] Return `NoOpProgress` for YAML format
-  - [ ] Return `NoOpProgress` for CSV format
-  - [ ] Return `NoOpProgress` for DOT format
-  - [ ] Return `PrettyProgress` for table format
-  - [ ] Return `PrettyProgress` for markdown format
-  - [ ] Return `PrettyProgress` for HTML format (consider future enhancement)
-- [ ] Add `EnableProgress()` and `DisableProgress()` methods to OutputSettings
-- [ ] Add environment variable check (e.g., `GO_OUTPUT_PROGRESS=false` to disable)
+ - [x] Create `NewProgress(settings *OutputSettings) Progress` function
+ - [x] Add format detection logic:
+  - [x] Return `NoOpProgress` for JSON format
+  - [x] Return `NoOpProgress` for YAML format
+  - [x] Return `NoOpProgress` for CSV format
+  - [x] Return `NoOpProgress` for DOT format
+  - [x] Return `PrettyProgress` for table format
+  - [x] Return `PrettyProgress` for markdown format
+  - [x] Return `PrettyProgress` for HTML format (consider future enhancement)
+ - [x] Add `EnableProgress()` and `DisableProgress()` methods to OutputSettings
+ - [x] Add environment variable check (e.g., `GO_OUTPUT_PROGRESS=false` to disable)
 
 ### Step 5: Handle Edge Cases and Cleanup
 **Files**: Various

--- a/outputsettings.go
+++ b/outputsettings.go
@@ -1,6 +1,7 @@
 package format
 
 import (
+	"os"
 	"strings"
 
 	"github.com/ArjenSchwarz/go-output/drawio"
@@ -67,6 +68,10 @@ type OutputSettings struct {
 	UseColors bool
 	// Should emoji be shown in the output
 	UseEmoji bool
+	// Should progress output be shown
+	ProgressEnabled bool
+	// ProgressOptions configures the progress indicator
+	ProgressOptions ProgressOptions
 }
 
 type S3Output struct {
@@ -88,6 +93,12 @@ func NewOutputSettings() *OutputSettings {
 		TableStyle:          table.StyleDefault,
 		TableMaxColumnWidth: 50,
 		MermaidSettings:     &mermaid.Settings{},
+	}
+	env := strings.ToLower(os.Getenv("GO_OUTPUT_PROGRESS"))
+	if env == "false" {
+		settings.ProgressEnabled = false
+	} else {
+		settings.ProgressEnabled = true
 	}
 	return &settings
 }
@@ -156,4 +167,14 @@ func (settings *OutputSettings) GetSeparator() string {
 	default:
 		return ", "
 	}
+}
+
+// EnableProgress turns on progress output.
+func (settings *OutputSettings) EnableProgress() {
+	settings.ProgressEnabled = true
+}
+
+// DisableProgress turns off progress output.
+func (settings *OutputSettings) DisableProgress() {
+	settings.ProgressEnabled = false
 }

--- a/progress_factory.go
+++ b/progress_factory.go
@@ -1,0 +1,21 @@
+package format
+
+import "strings"
+
+// NewProgress returns a progress implementation based on the output format and settings.
+func NewProgress(settings *OutputSettings) Progress {
+	if settings == nil {
+		settings = NewOutputSettings()
+	}
+	if !settings.ProgressEnabled {
+		return newNoOpProgress(settings)
+	}
+	switch strings.ToLower(settings.OutputFormat) {
+	case "json", "yaml", "csv", "dot":
+		return newNoOpProgress(settings)
+	case "table", "markdown", "html":
+		return newPrettyProgress(settings)
+	default:
+		return newNoOpProgress(settings)
+	}
+}

--- a/progress_factory_test.go
+++ b/progress_factory_test.go
@@ -1,0 +1,22 @@
+package format
+
+import "testing"
+
+func TestNewProgressSelection(t *testing.T) {
+	settings := NewOutputSettings()
+
+	settings.OutputFormat = "json"
+	if _, ok := NewProgress(settings).(*NoOpProgress); !ok {
+		t.Errorf("expected NoOpProgress for json format")
+	}
+
+	settings.OutputFormat = "table"
+	if _, ok := NewProgress(settings).(*PrettyProgress); !ok {
+		t.Errorf("expected PrettyProgress for table format")
+	}
+
+	settings.ProgressEnabled = false
+	if _, ok := NewProgress(settings).(*NoOpProgress); !ok {
+		t.Errorf("expected NoOpProgress when disabled")
+	}
+}

--- a/progress_pretty.go
+++ b/progress_pretty.go
@@ -63,6 +63,7 @@ func (pp *PrettyProgress) start() {
 		defer func() {
 			if r := recover(); r != nil {
 				// ensure progress stops on panic
+				_ = r
 			}
 			pp.stop()
 		}()


### PR DESCRIPTION
## Summary
- add progress fields to `OutputSettings`
- create `NewProgress` factory with format checks
- expose methods to enable and disable progress output
- disable progress with GO_OUTPUT_PROGRESS env var
- fix panic recovery lint warning
- mark Phase 1 Step 4 tasks as done
- test factory selection

## Testing
- `go test ./... -v`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_68483988afa88333952ee4c820e927f0