### PR TITLE
[test] add progress indicator tests

### DIFF
--- a/docs/plans/progress-indicator-plan.md
+++ b/docs/plans/progress-indicator-plan.md
@@ -97,33 +97,33 @@
 ### Step 6: Testing
 **File**: `progress_test.go`, `progress_pretty_test.go`, `progress_noop_test.go`
 
-- [ ] Test Progress interface compliance for both implementations
-- [ ] Test basic progress operations:
-  - [ ] SetTotal and SetCurrent
-  - [ ] Increment with various values
-  - [ ] SetStatus with different messages
-- [ ] Test color changes:
-  - [ ] Each color constant
-  - [ ] Color changes during progress
-  - [ ] Color in Complete() and Fail() states
-- [ ] Test completion and failure states:
-  - [ ] Normal completion
-  - [ ] Failure with error message
-  - [ ] State after completion/failure
-- [ ] Test no-op implementation:
-  - [ ] Ensure no output is produced
-  - [ ] Verify state tracking works
-- [ ] Test factory function logic:
-  - [ ] Correct implementation for each format
-  - [ ] Settings propagation
-- [ ] Test concurrent usage:
-  - [ ] Multiple goroutines updating progress
+- [x] Test Progress interface compliance for both implementations
+- [x] Test basic progress operations:
+  - [x] SetTotal and SetCurrent
+  - [x] Increment with various values
+  - [x] SetStatus with different messages
+- [x] Test color changes:
+  - [x] Each color constant
+  - [x] Color changes during progress
+  - [x] Color in Complete() and Fail() states
+- [x] Test completion and failure states:
+  - [x] Normal completion
+  - [x] Failure with error message
+  - [x] State after completion/failure
+- [x] Test no-op implementation:
+  - [x] Ensure no output is produced
+  - [x] Verify state tracking works
+- [x] Test factory function logic:
+  - [x] Correct implementation for each format
+  - [x] Settings propagation
+- [x] Test concurrent usage:
+  - [x] Multiple goroutines updating progress
   - [ ] Race condition detection
-- [ ] Mock terminal for testing:
-  - [ ] Test TTY detection
-  - [ ] Test non-TTY fallback
-- [ ] Integration tests:
-  - [ ] Progress with table output
+- [x] Mock terminal for testing:
+  - [x] Test TTY detection
+  - [x] Test non-TTY fallback
+- [x] Integration tests:
+  - [x] Progress with table output
   - [ ] Progress with multiple outputs
 
 ### Step 7: Documentation and Examples

--- a/progress_factory_test.go
+++ b/progress_factory_test.go
@@ -4,19 +4,49 @@ import "testing"
 
 func TestNewProgressSelection(t *testing.T) {
 	settings := NewOutputSettings()
-
-	settings.OutputFormat = "json"
-	if _, ok := NewProgress(settings).(*NoOpProgress); !ok {
-		t.Errorf("expected NoOpProgress for json format")
+	formats := map[string]bool{
+		"json":     false,
+		"yaml":     false,
+		"csv":      false,
+		"dot":      false,
+		"table":    true,
+		"markdown": true,
+		"html":     true,
 	}
-
-	settings.OutputFormat = "table"
-	if _, ok := NewProgress(settings).(*PrettyProgress); !ok {
-		t.Errorf("expected PrettyProgress for table format")
+	for format, pretty := range formats {
+		settings.OutputFormat = format
+		p := NewProgress(settings)
+		if pretty {
+			if _, ok := p.(*PrettyProgress); !ok {
+				t.Errorf("expected PrettyProgress for %s format", format)
+			}
+		} else {
+			if _, ok := p.(*NoOpProgress); !ok {
+				t.Errorf("expected NoOpProgress for %s format", format)
+			}
+		}
 	}
 
 	settings.ProgressEnabled = false
 	if _, ok := NewProgress(settings).(*NoOpProgress); !ok {
 		t.Errorf("expected NoOpProgress when disabled")
+	}
+}
+
+func TestNewProgressPropagatesOptions(t *testing.T) {
+	settings := NewOutputSettings()
+	settings.OutputFormat = "table"
+	settings.ProgressOptions.Color = ProgressColorBlue
+	settings.ProgressOptions.Status = "init"
+	p := NewProgress(settings)
+	pp, ok := p.(*PrettyProgress)
+	if !ok {
+		t.Fatalf("expected PrettyProgress")
+	}
+	if pp.options.Color != ProgressColorBlue {
+		t.Errorf("expected color blue")
+	}
+	if pp.tracker.Message != "init" {
+		t.Errorf("expected status propagated")
 	}
 }

--- a/progress_noop.go
+++ b/progress_noop.go
@@ -23,7 +23,7 @@ type NoOpProgress struct {
 func newNoOpProgress(settings *OutputSettings) *NoOpProgress {
 	nop := &NoOpProgress{}
 	if settings != nil {
-		nop.options = ProgressOptions{}
+		nop.options = settings.ProgressOptions
 	}
 	return nop
 }

--- a/progress_noop_test.go
+++ b/progress_noop_test.go
@@ -1,7 +1,9 @@
 package format
 
 import (
+	"bytes"
 	"context"
+	"log"
 	"testing"
 	"time"
 )
@@ -46,5 +48,37 @@ func TestNoOpProgressContextCancel(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	if np.IsActive() {
 		t.Errorf("progress should remain inactive")
+	}
+}
+
+func TestNoOpProgressColorAndStatus(t *testing.T) {
+	settings := NewOutputSettings()
+	settings.ProgressOptions.Color = ProgressColorGreen
+	settings.ProgressOptions.Status = "go"
+	np := newNoOpProgress(settings)
+	if np.options.Color != ProgressColorGreen {
+		t.Errorf("expected color to be propagated")
+	}
+
+	np.SetColor(ProgressColorRed)
+	if np.options.Color != ProgressColorRed {
+		t.Errorf("expected color red after SetColor")
+	}
+
+	np.SetStatus("running")
+	// only ensures no panic; NoOpProgress doesn't store status
+}
+
+func TestNoOpProgressNoOutput(t *testing.T) {
+	buf := &bytes.Buffer{}
+	log.SetOutput(buf)
+	settings := NewOutputSettings()
+	np := newNoOpProgress(settings)
+	np.SetTotal(1)
+	np.SetCurrent(1)
+	np.Increment(1)
+	np.Complete()
+	if buf.Len() != 0 {
+		t.Errorf("expected no log output, got %s", buf.String())
 	}
 }

--- a/progress_pretty.go
+++ b/progress_pretty.go
@@ -30,8 +30,8 @@ func newPrettyProgress(settings *OutputSettings) *PrettyProgress {
 	pp := &PrettyProgress{ctx: context.Background()}
 	pp.tracker = &progress.Tracker{}
 	if settings != nil {
-		pp.options = ProgressOptions{}
-		pp.tracker.Message = ""
+		pp.options = settings.ProgressOptions
+		pp.tracker.Message = settings.ProgressOptions.Status
 	}
 	if isatty.IsTerminal(os.Stdout.Fd()) {
 		w := progress.NewWriter()

--- a/progress_pretty_test.go
+++ b/progress_pretty_test.go
@@ -2,6 +2,8 @@ package format
 
 import (
 	"context"
+	"os"
+	"sync"
 	"testing"
 	"time"
 )
@@ -46,6 +48,128 @@ func TestPrettyProgressContextCancel(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 	if pp.IsActive() {
 		t.Errorf("progress should stop when context is cancelled")
+	}
+}
+
+func TestPrettyProgressStatusAndColor(t *testing.T) {
+	r, w, _ := os.Pipe()
+	orig := os.Stdout
+	os.Stdout = w
+	settings := NewOutputSettings()
+	settings.ProgressOptions.Status = "starting"
+	settings.ProgressOptions.Color = ProgressColorBlue
+	pp := newPrettyProgress(settings)
+	os.Stdout = orig
+	_ = r.Close()
+	_ = w.Close()
+
+	if pp.tracker.Message != "starting" {
+		t.Errorf("expected status 'starting', got %s", pp.tracker.Message)
+	}
+	if pp.options.Color != ProgressColorBlue {
+		t.Errorf("expected color blue, got %v", pp.options.Color)
+	}
+
+	pp.SetStatus("running")
+	if pp.tracker.Message != "running" {
+		t.Errorf("expected message 'running', got %s", pp.tracker.Message)
+	}
+
+	pp.SetColor(ProgressColorYellow)
+	if pp.options.Color != ProgressColorYellow {
+		t.Errorf("expected color yellow, got %v", pp.options.Color)
+	}
+}
+
+func TestPrettyProgressCompletionStates(t *testing.T) {
+	r, w, _ := os.Pipe()
+	orig := os.Stdout
+	os.Stdout = w
+	settings := NewOutputSettings()
+	pp := newPrettyProgress(settings)
+	os.Stdout = orig
+	_ = r.Close()
+	_ = w.Close()
+
+	pp.SetTotal(1)
+	pp.Complete()
+	if pp.options.Color != ProgressColorGreen {
+		t.Errorf("expected green color on complete, got %v", pp.options.Color)
+	}
+	if pp.IsActive() {
+		t.Errorf("progress should be inactive after Complete")
+	}
+
+	pp = newPrettyProgress(settings)
+	pp.SetTotal(1)
+	pp.Fail(assertError("bad"))
+	if pp.options.Color != ProgressColorRed {
+		t.Errorf("expected red color on fail, got %v", pp.options.Color)
+	}
+	if pp.IsActive() {
+		t.Errorf("progress should be inactive after Fail")
+	}
+}
+
+func TestPrettyProgressConcurrent(t *testing.T) {
+	r, w, _ := os.Pipe()
+	orig := os.Stdout
+	os.Stdout = w
+	settings := NewOutputSettings()
+	pp := newPrettyProgress(settings)
+	os.Stdout = orig
+	_ = r.Close()
+	_ = w.Close()
+
+	pp.SetTotal(100)
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			pp.Increment(2)
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	if v := pp.tracker.Value(); v != 100 {
+		t.Errorf("expected value 100, got %d", v)
+	}
+}
+
+func TestPrettyProgressTTYDetection(t *testing.T) {
+	r, w, _ := os.Pipe()
+	orig := os.Stdout
+	os.Stdout = w
+	settings := NewOutputSettings()
+	pp := newPrettyProgress(settings)
+	os.Stdout = orig
+	_ = r.Close()
+	_ = w.Close()
+
+	if pp.writer != nil {
+		t.Errorf("expected writer to be nil for non TTY stdout")
+	}
+}
+
+func TestPrettyProgressIntegrationTableOutput(t *testing.T) {
+	r, w, _ := os.Pipe()
+	orig := os.Stdout
+	os.Stdout = w
+	settings := NewOutputSettings()
+	settings.OutputFormat = "table"
+	pp := newPrettyProgress(settings)
+	oa := OutputArray{
+		Settings: settings,
+		Contents: []OutputHolder{{Contents: map[string]interface{}{"col": "val"}}},
+		Keys:     []string{"col"},
+	}
+	oa.Write()
+	os.Stdout = orig
+	_ = r.Close()
+	_ = w.Close()
+
+	if pp.IsActive() {
+		t.Errorf("progress should stop before output is written")
 	}
 }
 

--- a/progress_test.go
+++ b/progress_test.go
@@ -1,0 +1,4 @@
+package format
+
+var _ Progress = (*PrettyProgress)(nil)
+var _ Progress = (*NoOpProgress)(nil)


### PR DESCRIPTION
## Summary
- expand progress tests for interface compliance, colors and status handling, factory logic
- verify concurrency safety and tty detection
- propagate ProgressOptions in constructors
- mark completed tasks in progress-indicator plan

## Testing
- `go test ./... -v`
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_684841e887cc8333bfe8000e7009516e