### PR TITLE
[feature] make tracker length configurable

### DIFF
--- a/progress.go
+++ b/progress.go
@@ -48,6 +48,9 @@ type ProgressOptions struct {
 	Color ProgressColor
 	// Status sets an optional initial status message.
 	Status string
+	// TrackerLength sets the width of the progress bar. Values <= 0
+	// use a sensible default.
+	TrackerLength int
 }
 
 // Progress describes an abstract progress indicator. Implementations

--- a/progress_pretty.go
+++ b/progress_pretty.go
@@ -38,7 +38,11 @@ func newPrettyProgress(settings *OutputSettings) *PrettyProgress {
 	if isatty.IsTerminal(os.Stdout.Fd()) {
 		w := progress.NewWriter()
 		w.SetAutoStop(false)
-		w.SetTrackerLength(40)
+		length := pp.options.TrackerLength
+		if length <= 0 {
+			length = 40
+		}
+		w.SetTrackerLength(length)
 		w.SetUpdateFrequency(time.Millisecond * 100)
 		w.SetTrackerPosition(progress.PositionRight)
 		w.SetOutputWriter(os.Stdout)

--- a/progress_pretty_test.go
+++ b/progress_pretty_test.go
@@ -139,6 +139,22 @@ func TestPrettyProgressConcurrent(t *testing.T) {
 	}
 }
 
+func TestPrettyProgressTrackerLength(t *testing.T) {
+	r, w, _ := os.Pipe()
+	orig := os.Stdout
+	os.Stdout = w
+	settings := NewOutputSettings()
+	settings.ProgressOptions.TrackerLength = 60
+	pp := newPrettyProgress(settings)
+	os.Stdout = orig
+	_ = r.Close()
+	_ = w.Close()
+
+	if pp.options.TrackerLength != 60 {
+		t.Errorf("expected tracker length 60, got %d", pp.options.TrackerLength)
+	}
+}
+
 func TestPrettyProgressTTYDetection(t *testing.T) {
 	r, w, _ := os.Pipe()
 	orig := os.Stdout


### PR DESCRIPTION
## Summary
- add TrackerLength to ProgressOptions
- respect TrackerLength in pretty progress writer
- test custom tracker length

## Testing
- `go test ./... -v`
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_6860c03e8c748333a040f7887153d5c2