### PR TITLE
[bug] Handle numeric types in OutputArray.toString

### DIFF
--- a/output.go
+++ b/output.go
@@ -615,6 +615,28 @@ func (output *OutputArray) toString(val interface{}) string {
 		return strings.Join(converted, output.Settings.GetSeparator())
 	case int:
 		return strconv.Itoa(converted)
+	case int8:
+		return strconv.FormatInt(int64(converted), 10)
+	case int16:
+		return strconv.FormatInt(int64(converted), 10)
+	case int32:
+		return strconv.FormatInt(int64(converted), 10)
+	case int64:
+		return strconv.FormatInt(converted, 10)
+	case uint:
+		return strconv.FormatUint(uint64(converted), 10)
+	case uint8:
+		return strconv.FormatUint(uint64(converted), 10)
+	case uint16:
+		return strconv.FormatUint(uint64(converted), 10)
+	case uint32:
+		return strconv.FormatUint(uint64(converted), 10)
+	case uint64:
+		return strconv.FormatUint(converted, 10)
+	case float32:
+		return strconv.FormatFloat(float64(converted), 'f', -1, 32)
+	case float64:
+		return strconv.FormatFloat(converted, 'f', -1, 64)
 	case bool:
 		if converted {
 			if output.Settings.UseEmoji {
@@ -629,5 +651,5 @@ func (output *OutputArray) toString(val interface{}) string {
 			return "No"
 		}
 	}
-	return fmt.Sprintf("%s", val)
+	return fmt.Sprintf("%v", val)
 }

--- a/output_test.go
+++ b/output_test.go
@@ -112,6 +112,10 @@ func TestOutputArray_toString(t *testing.T) {
 		{"Emoji Bool false", fields{Settings: &withEmoji}, args{val: false}, "❌"},
 		{"Slice json format", fields{Settings: &jsonFormat}, args{val: []string{"first", "second"}}, "first, second"},
 		{"Slice table format", fields{Settings: &tableFormat}, args{val: []string{"first", "second"}}, "first\nsecond"},
+		{"Float64", fields{Settings: &noEmoji}, args{val: 123.456}, "123.456"},
+		{"Float32", fields{Settings: &noEmoji}, args{val: float32(78.9)}, "78.9"},
+		{"Int64", fields{Settings: &noEmoji}, args{val: int64(9223372036854775807)}, "9223372036854775807"},
+		{"Uint", fields{Settings: &noEmoji}, args{val: uint(42)}, "42"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- extend `OutputArray.toString` with additional cases for numeric types
- format fallback using `%v`
- add tests covering floats and larger integers

## Testing
- `go test ./... -v`
- `golangci-lint run`

------
https://chatgpt.com/codex/tasks/task_e_6860c6c6ef5483339060f85a8db17b9f