### PR TITLE
[refactor] simplify number formatting

### DIFF
--- a/output.go
+++ b/output.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
@@ -613,21 +612,26 @@ func (output *OutputArray) toString(val interface{}) string {
 	switch converted := val.(type) {
 	case []string:
 		return strings.Join(converted, output.Settings.GetSeparator())
-	case int:
-		return strconv.Itoa(converted)
 	case bool:
 		if converted {
 			if output.Settings.UseEmoji {
 				return "✅"
-			} else {
-				return "Yes"
 			}
+			return "Yes"
 		}
 		if output.Settings.UseEmoji {
 			return "❌"
-		} else {
-			return "No"
 		}
+		return "No"
+	case int, int8, int16, int32, int64,
+		uint, uint8, uint16, uint32, uint64,
+		float32, float64:
+		return formatNumber(val)
 	}
-	return fmt.Sprintf("%s", val)
+	return fmt.Sprintf("%v", val)
+}
+
+// formatNumber provides consistent string formatting for numeric values.
+func formatNumber(val interface{}) string {
+	return fmt.Sprintf("%v", val)
 }

--- a/output_test.go
+++ b/output_test.go
@@ -112,6 +112,10 @@ func TestOutputArray_toString(t *testing.T) {
 		{"Emoji Bool false", fields{Settings: &withEmoji}, args{val: false}, "❌"},
 		{"Slice json format", fields{Settings: &jsonFormat}, args{val: []string{"first", "second"}}, "first, second"},
 		{"Slice table format", fields{Settings: &tableFormat}, args{val: []string{"first", "second"}}, "first\nsecond"},
+		{"Float64", fields{Settings: &noEmoji}, args{val: 123.456}, "123.456"},
+		{"Float32", fields{Settings: &noEmoji}, args{val: float32(78.9)}, "78.9"},
+		{"Int64", fields{Settings: &noEmoji}, args{val: int64(9223372036854775807)}, "9223372036854775807"},
+		{"Uint", fields{Settings: &noEmoji}, args{val: uint(42)}, "42"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- streamline `OutputArray.toString` by consolidating numeric cases
- add `formatNumber` helper

## Testing
- `go test ./... -v`
- `golangci-lint run`


------
https://chatgpt.com/codex/tasks/task_e_6860c6c6ef5483339060f85a8db17b9f