### PR TITLE
Fix T-251: Prettyprogress Handle Signals Nil Context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Unreleased
 
 ### Fixed
+- **Pretty Progress Signal Context Safety** - Fixed startup panic in `NewPrettyProgress` when `handleSignals` accessed `p.ctx.Done()` before `SetContext` initialized the context
+  - Initialize a default cancellable background context before starting signal handling
+  - Added nil-safe context channel handling and closed-signal channel exit in `handleSignals`
+  - Added regression test `TestPrettyProgress_HandleSignals_NilContext_DoesNotPanic`
 - **S3 Output Panic Prevention** - Fixed panic in `PrintByteSlice` when S3Output has Bucket set but S3Client is nil
   - Added validation guard clause to return clear error message instead of panicking
   - Error message guides users to use `SetS3Bucket()` for proper S3 configuration

--- a/specs/bugfixes/prettyprogress-handle-signals-nil-context/report.md
+++ b/specs/bugfixes/prettyprogress-handle-signals-nil-context/report.md
@@ -1,0 +1,84 @@
+# Bugfix Report: prettyprogress-handle-signals-nil-context
+
+**Date:** 2026-02-28
+**Status:** Fixed
+
+## Description of the Issue
+
+`NewPrettyProgress` starts `handleSignals` immediately, but `handleSignals` selected on `p.ctx.Done()` even when `SetContext` had not been called yet. That caused a nil pointer dereference panic at startup.
+
+**Reproduction steps:**
+1. Create a `prettyProgress` instance with `ctx == nil`.
+2. Start `handleSignals`.
+3. Observe panic: `invalid memory address or nil pointer dereference`.
+
+**Impact:** Pretty progress startup could panic before any work is done when context was not initialized yet.
+
+## Investigation Summary
+
+Systematic inspection of pretty progress startup and signal handling found an unconditional dereference in the signal loop.
+
+- **Symptoms examined:** Panic in `handleSignals` before `SetContext`.
+- **Code inspected:** `v2/progress_pretty.go`, `v2/progress_core_test.go`.
+- **Hypotheses tested:** Uninitialized `p.ctx` used in `select`; confirmed by a focused failing regression test.
+
+## Discovered Root Cause
+
+`handleSignals` always evaluated `p.ctx.Done()` without checking whether `p.ctx` was nil.
+
+**Defect type:** Missing nil guard / nil pointer dereference.
+
+**Why it occurred:** Signal handling goroutine starts during constructor setup, but context initialization was deferred to optional `SetContext`.
+
+**Contributing factors:** Existing pretty progress tests often run with non-TTY fallback, so this startup path was not explicitly regression-tested.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `v2/progress_pretty.go:48-56` - Initialize a default cancelable background context in `NewPrettyProgress`.
+- `v2/progress_pretty.go:85-104` - Handle closed signal channels and use `contextDone()` to safely return nil channel when context is nil.
+- `v2/progress_core_test.go:793-820` - Added regression test for nil-context `handleSignals` startup behavior.
+
+**Approach rationale:** Initialize context at construction and make signal handling nil-safe so startup cannot panic even if context is absent.
+
+**Alternatives considered:**
+- Guarding only constructor context initialization - not chosen alone because direct nil-context handling remained brittle without explicit guard.
+
+## Regression Test
+
+**Test file:** `v2/progress_core_test.go`
+**Test name:** `TestPrettyProgress_HandleSignals_NilContext_DoesNotPanic`
+
+**What it verifies:** `handleSignals` does not panic when `p.ctx` is nil and exits cleanly when signal channel closes.
+
+**Run command:** `cd v2 && go test ./... -run TestPrettyProgress_HandleSignals_NilContext_DoesNotPanic -count=1`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `v2/progress_pretty.go` | Added safe default context initialization and nil-safe signal/context handling |
+| `v2/progress_core_test.go` | Added regression test reproducing the nil-context panic scenario |
+| `specs/bugfixes/prettyprogress-handle-signals-nil-context/report.md` | Added bugfix investigation and verification report |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Linters/validators pass
+
+**Manual verification:**
+- Confirmed regression test failed before fix with nil pointer panic.
+- Confirmed regression test passes after fix.
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Initialize lifecycle contexts at constructor boundaries when goroutines depend on them.
+- Use helper methods that safely return nil channels for optional contexts in `select` statements.
+- Add targeted tests for startup goroutines that run before optional configuration methods are called.
+
+## Related
+
+- Transit ticket: `T-251`

--- a/v2/progress_core_test.go
+++ b/v2/progress_core_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -786,6 +787,35 @@ func TestPrettyProgress_ThreadSafety(t *testing.T) {
 	// Should not panic and should complete successfully
 	if progress.IsActive() {
 		t.Error("progress should not be active after completion")
+	}
+}
+
+func TestPrettyProgress_HandleSignals_NilContext_DoesNotPanic(t *testing.T) {
+	p := &prettyProgress{
+		signals: make(chan os.Signal, 1),
+	}
+
+	done := make(chan struct{})
+	panicCh := make(chan any, 1)
+
+	go func() {
+		defer close(done)
+		defer func() {
+			if r := recover(); r != nil {
+				panicCh <- r
+			}
+		}()
+		p.handleSignals()
+	}()
+
+	close(p.signals)
+
+	select {
+	case r := <-panicCh:
+		t.Fatalf("handleSignals panicked with nil context: %v", r)
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("handleSignals did not exit after signals channel close")
 	}
 }
 

--- a/v2/progress_pretty.go
+++ b/v2/progress_pretty.go
@@ -45,10 +45,14 @@ func NewPrettyProgress(opts ...ProgressOption) Progress {
 		return NewProgress(opts...)
 	}
 
+	ctx, cancel := context.WithCancel(context.Background())
+
 	p := &prettyProgress{
 		config:    config,
 		startTime: time.Now(),
 		active:    true,
+		ctx:       ctx,
+		cancel:    cancel,
 		signals:   make(chan os.Signal, 1),
 	}
 
@@ -78,15 +82,25 @@ func NewPrettyProgress(opts ...ProgressOption) Progress {
 func (p *prettyProgress) handleSignals() {
 	for {
 		select {
-		case sig := <-p.signals:
+		case sig, ok := <-p.signals:
+			if !ok {
+				return
+			}
 			if p.isSIGWINCH(sig) {
 				// Terminal was resized - go-pretty handles this automatically
 				continue
 			}
-		case <-p.ctx.Done():
+		case <-p.contextDone():
 			return
 		}
 	}
+}
+
+func (p *prettyProgress) contextDone() <-chan struct{} {
+	if p.ctx == nil {
+		return nil
+	}
+	return p.ctx.Done()
 }
 
 // SetTotal sets the total number of units to be processed


### PR DESCRIPTION
## Summary
- fix startup panic in pretty progress where signal handling selected on `p.ctx.Done()` before context initialization
- initialize a default cancellable context in `NewPrettyProgress` and make `handleSignals` nil-safe
- add focused regression test `TestPrettyProgress_HandleSignals_NilContext_DoesNotPanic`
- add formal bugfix report at `specs/bugfixes/prettyprogress-handle-signals-nil-context/report.md`

## Root cause
`handleSignals` always selected on `p.ctx.Done()`, but `p.ctx` was nil until `SetContext` was called.

## Validation
- `make lint`
- `make test-all`
- `cd v2 && go test ./... -run TestPrettyProgress_HandleSignals_NilContext_DoesNotPanic -count=1`
