### PR TITLE
T-322: fix CSV renderer dropping headers for later tables

### DIFF
--- a/v2/csv_renderer.go
+++ b/v2/csv_renderer.go
@@ -60,8 +60,8 @@ func (c *csvRenderer) renderDocumentCSVTo(ctx context.Context, doc *Document, w 
 	csvWriter := csv.NewWriter(w)
 	defer csvWriter.Flush()
 
-	// Track if we've written any headers to avoid multiple header rows
-	hasWrittenHeaders := false
+	// Track the last written header schema to detect schema changes
+	var lastKeyOrder []string
 
 	for i, content := range contents {
 		// Check for context cancellation
@@ -81,7 +81,7 @@ func (c *csvRenderer) renderDocumentCSVTo(ctx context.Context, doc *Document, w 
 		switch content := transformed.(type) {
 		case *TableContent:
 			// Add a blank line between tables (except for the first table)
-			if i > 0 && hasWrittenHeaders {
+			if i > 0 && lastKeyOrder != nil {
 				if err := csvWriter.Write([]string{}); err != nil {
 					return fmt.Errorf("failed to write separator row: %w", err)
 				}
@@ -90,13 +90,13 @@ func (c *csvRenderer) renderDocumentCSVTo(ctx context.Context, doc *Document, w 
 			// Skip table title for CSV as it breaks parsing
 			// CSV format doesn't support comments in a standard way
 
-			// Write headers for first table or when headers differ
-			writeHeaders := !hasWrittenHeaders
+			// Write headers for first table or when schema differs from previous table
+			writeHeaders := !keyOrdersEqual(lastKeyOrder, content.Schema().GetKeyOrder())
 			if err := c.renderTableContentCSV(content, csvWriter, writeHeaders); err != nil {
 				return fmt.Errorf("failed to render table %s: %w", content.ID(), err)
 			}
 
-			hasWrittenHeaders = true
+			lastKeyOrder = content.Schema().GetKeyOrder()
 
 		case *SectionContent:
 			// Extract and render tables from sections
@@ -110,17 +110,17 @@ func (c *csvRenderer) renderDocumentCSVTo(ctx context.Context, doc *Document, w 
 
 				if nestedTable, ok := nestedTransformed.(*TableContent); ok {
 					// Add separator between tables
-					if hasWrittenHeaders {
+					if lastKeyOrder != nil {
 						if err := csvWriter.Write([]string{}); err != nil {
 							return fmt.Errorf("failed to write separator row: %w", err)
 						}
 					}
 
-					writeHeaders := !hasWrittenHeaders
+					writeHeaders := !keyOrdersEqual(lastKeyOrder, nestedTable.Schema().GetKeyOrder())
 					if err := c.renderTableContentCSV(nestedTable, csvWriter, writeHeaders); err != nil {
 						return fmt.Errorf("failed to render table %s: %w", nestedTable.ID(), err)
 					}
-					hasWrittenHeaders = true
+					lastKeyOrder = nestedTable.Schema().GetKeyOrder()
 				} else if nestedSection, ok := nestedTransformed.(*SectionContent); ok {
 					// Recursively handle nested sections
 					for _, deepContent := range nestedSection.Contents() {
@@ -129,16 +129,16 @@ func (c *csvRenderer) renderDocumentCSVTo(ctx context.Context, doc *Document, w 
 							return err
 						}
 						if deepTable, ok := deepTransformed.(*TableContent); ok {
-							if hasWrittenHeaders {
+							if lastKeyOrder != nil {
 								if err := csvWriter.Write([]string{}); err != nil {
 									return fmt.Errorf("failed to write separator row: %w", err)
 								}
 							}
-							writeHeaders := !hasWrittenHeaders
+							writeHeaders := !keyOrdersEqual(lastKeyOrder, deepTable.Schema().GetKeyOrder())
 							if err := c.renderTableContentCSV(deepTable, csvWriter, writeHeaders); err != nil {
 								return fmt.Errorf("failed to render table %s: %w", deepTable.ID(), err)
 							}
-							hasWrittenHeaders = true
+							lastKeyOrder = deepTable.Schema().GetKeyOrder()
 						}
 					}
 				}
@@ -146,12 +146,16 @@ func (c *csvRenderer) renderDocumentCSVTo(ctx context.Context, doc *Document, w 
 
 		case *DefaultCollapsibleSection:
 			// Handle CollapsibleSection with metadata comments (Requirement 15.8)
-			if err := c.renderCollapsibleSectionCSV(content, csvWriter, &hasWrittenHeaders); err != nil {
+			hasWritten := lastKeyOrder != nil
+			if err := c.renderCollapsibleSectionCSV(content, csvWriter, &hasWritten); err != nil {
 				return fmt.Errorf("failed to render collapsible section %s: %w", content.ID(), err)
+			}
+			if hasWritten && lastKeyOrder == nil {
+				lastKeyOrder = []string{"_collapsible"}
 			}
 
 		default:
-			if !hasWrittenHeaders {
+			if lastKeyOrder == nil {
 				// For non-table content, write as a single-column CSV row
 				// Only if no tables have been written yet (to avoid mixing formats)
 				contentText, err := content.AppendText(nil)
@@ -163,7 +167,7 @@ func (c *csvRenderer) renderDocumentCSVTo(ctx context.Context, doc *Document, w 
 					if err := csvWriter.Write([]string{c.formatValueForCSV(string(contentText))}); err != nil {
 						return fmt.Errorf("failed to write content row: %w", err)
 					}
-					hasWrittenHeaders = true
+					lastKeyOrder = []string{"content"}
 				}
 			}
 		}
@@ -473,4 +477,17 @@ func (c *csvRenderer) renderCollapsibleSectionCSV(section *DefaultCollapsibleSec
 	}
 
 	return nil
+}
+
+// keyOrdersEqual returns true if two key order slices are identical
+func keyOrdersEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/v2/csv_renderer_multischema_test.go
+++ b/v2/csv_renderer_multischema_test.go
@@ -1,0 +1,92 @@
+package output
+
+import (
+	"context"
+	"encoding/csv"
+	"strings"
+	"testing"
+)
+
+func TestCSVRenderer_MultipleTablesWithDifferentSchemas(t *testing.T) {
+	doc := New().
+		Table("employees", []map[string]any{
+			{"Name": "Alice", "Department": "Engineering"},
+			{"Name": "Bob", "Department": "Marketing"},
+		}, WithKeys("Name", "Department")).
+		Table("projects", []map[string]any{
+			{"Project": "Alpha", "Status": "Active", "Budget": 100000},
+			{"Project": "Beta", "Status": "Complete", "Budget": 50000},
+		}, WithKeys("Project", "Status", "Budget")).
+		Build()
+
+	renderer := &csvRenderer{}
+	result, err := renderer.Render(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+
+	csvReader := csv.NewReader(strings.NewReader(string(result)))
+	csvReader.FieldsPerRecord = -1 // allow variable field counts
+	records, err := csvReader.ReadAll()
+	if err != nil {
+		t.Fatalf("Failed to parse CSV: %v", err)
+	}
+
+	// Expected structure:
+	// Row 0: Name,Department (header for table 1)
+	// Row 1: Alice,Engineering
+	// Row 2: Bob,Marketing
+	// Row 3: (blank separator)
+	// Row 4: Project,Status,Budget (header for table 2)
+	// Row 5: Alpha,Active,100000
+	// Row 6: Beta,Complete,50000
+
+	// Find the second header row
+	foundSecondHeader := false
+	for _, row := range records {
+		if len(row) >= 3 && row[0] == "Project" && row[1] == "Status" && row[2] == "Budget" {
+			foundSecondHeader = true
+			break
+		}
+	}
+
+	if !foundSecondHeader {
+		t.Errorf("Expected headers for second table with different schema, got:\n%s", string(result))
+	}
+}
+
+func TestCSVRenderer_MultipleTablesWithSameSchema(t *testing.T) {
+	doc := New().
+		Table("team1", []map[string]any{
+			{"Name": "Alice", "Score": 95},
+		}, WithKeys("Name", "Score")).
+		Table("team2", []map[string]any{
+			{"Name": "Bob", "Score": 87},
+		}, WithKeys("Name", "Score")).
+		Build()
+
+	renderer := &csvRenderer{}
+	result, err := renderer.Render(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+
+	csvReader := csv.NewReader(strings.NewReader(string(result)))
+	csvReader.FieldsPerRecord = -1
+	records, err := csvReader.ReadAll()
+	if err != nil {
+		t.Fatalf("Failed to parse CSV: %v", err)
+	}
+
+	// With same schema, headers should only appear once
+	headerCount := 0
+	for _, row := range records {
+		if len(row) >= 2 && row[0] == "Name" && row[1] == "Score" {
+			headerCount++
+		}
+	}
+
+	if headerCount != 1 {
+		t.Errorf("Expected exactly 1 header row for tables with same schema, got %d.\nOutput:\n%s", headerCount, string(result))
+	}
+}


### PR DESCRIPTION
## Summary

Replace `hasWrittenHeaders` boolean with `lastKeyOrder` slice tracking. Headers are now written whenever the current table's column schema differs from the previous table's. Tables with the same schema still share a single header row.

## Changes

- `v2/csv_renderer.go`: replaced boolean with schema-aware tracking; added `keyOrdersEqual()` helper
- `v2/csv_renderer_multischema_test.go`: new tests for multi-schema and same-schema table rendering

## Testing

- All existing tests pass (`make check` clean)
- New tests verify both different-schema (headers written) and same-schema (no duplicate headers) cases