### PR TITLE
T-315: fix GenerateID fallback returning constant ID

### DIFF
--- a/v2/content.go
+++ b/v2/content.go
@@ -5,6 +5,7 @@ import (
 	"encoding"
 	"fmt"
 	"maps"
+	"sync/atomic"
 )
 
 const (
@@ -61,13 +62,16 @@ type Content interface {
 	encoding.BinaryAppender
 }
 
+// idCounter is used as a fallback when crypto/rand is unavailable.
+var idCounter atomic.Uint64
+
 // GenerateID creates a unique identifier for content
 func GenerateID() string {
 	// Generate 8 random bytes
 	bytes := make([]byte, 8)
 	if _, err := rand.Read(bytes); err != nil {
 		// Fallback to a simple counter if crypto/rand fails
-		return fmt.Sprintf("content-%d", len(bytes))
+		return fmt.Sprintf("content-%d", idCounter.Add(1))
 	}
 	return fmt.Sprintf("content-%x", bytes)
 }


### PR DESCRIPTION
## Summary

Replace `len(bytes)` with an atomic counter so the fallback path in `GenerateID()` returns unique IDs (`content-1`, `content-2`, ...) instead of always returning `content-8`.

## Changes

- Added `sync/atomic.Uint64` counter as package-level var
- Fallback now calls `idCounter.Add(1)` for each invocation

## Testing

- All existing tests pass (`make check` clean)