### PR TITLE
Fix T-1271: Migration Example Fails Go Test Vet Checks

### DIFF
--- a/v2/examples/migration_example/main.go
+++ b/v2/examples/migration_example/main.go
@@ -23,7 +23,7 @@ type Product struct {
 }
 
 func main() {
-	fmt.Println("=== Pipeline API vs Per-Content Transformations ===\n")
+	fmt.Println("=== Pipeline API vs Per-Content Transformations ===")
 
 	// Sample data
 	users := []output.Record{
@@ -58,8 +58,8 @@ func main() {
 
 // oldWay demonstrates the deprecated Pipeline API (REMOVED in v2.4.0)
 func oldWay(users []output.Record) {
-	fmt.Println("The Pipeline API was removed in v2.4.0. Here's what the old code looked like:\n")
-	fmt.Println(`
+	fmt.Println("The Pipeline API was removed in v2.4.0. Here's what the old code looked like:")
+	fmt.Printf("%s", `
 	// Step 1: Build document with table
 	builder := output.New()
 	builder.Table("users", users, output.WithKeys("name", "email", "age"))
@@ -91,7 +91,7 @@ func oldWay(users []output.Record) {
 	fmt.Println("2. Required intermediate 'transformed' document")
 	fmt.Println("3. Could only transform entire documents, not individual tables")
 	fmt.Println("4. Pipeline state management was error-prone")
-	fmt.Println("\nSee the NEW WAY below for the improved approach...\n")
+	fmt.Println("\nSee the NEW WAY below for the improved approach...")
 }
 
 // newWay demonstrates per-content transformations


### PR DESCRIPTION
## Bug

`go test ./...` / `go vet ./...` inside `v2/examples/migration_example` failed during the vet/build phase with four findings in `main.go`:

- `main.go:26`, `:61`, `:94` — `fmt.Println arg list ends with redundant newline`
- `main.go:62` — `fmt.Println call has possible Printf formatting directive %v`

The standalone example module did not pass standard Go validation. The root `make test` only exercises the v2 module, so this never broke the main build but left the example unvalidatable.

## Root cause

Two distinct `go vet` `printf` rules were violated:

1. **Redundant trailing newline** (lines 26, 61, 94): `fmt.Println` already appends a newline, so string arguments ending in `\n` double up and trip the analyzer.
2. **Possible Printf directive in a non-format call** (line 62): the raw string literal passed to `fmt.Println` contained `%v` (an embedded `log.Fatalf("Pipeline error: %v", err)` code snippet). The analyzer scans the final argument of all `Print`-family calls.

## Fix

- Dropped the redundant trailing `\n` from the three `fmt.Println` calls (kept the leading `\n` on line 94 for spacing).
- Changed line 62 from `fmt.Println(`...`)` to `fmt.Printf("%s", `...`)` so the literal containing `%v` is a data argument rather than a format string. The displayed `%v` and the snippet's spacing are preserved.

Switching line 62 to `fmt.Print` alone was insufficient — vet scans the final argument of `Print` too, so `Printf("%s", ...)` is required.

## Verification

- `cd v2/examples/migration_example && go vet ./...` — clean (exit 0)
- `cd v2/examples/migration_example && go test ./...` — passes
- `gofmt -l .` — no issues
- Main v2 module `make test` — passes

Closes T-1271.