### PR TITLE
Fix T-1256: Progress Nil Writer Panics On Draw

### DIFF
--- a/v2/progress.go
+++ b/v2/progress.go
@@ -82,9 +82,14 @@ type ProgressConfig struct {
 // ProgressOption configures a ProgressConfig
 type ProgressOption func(*ProgressConfig)
 
-// WithProgressWriter sets the output writer for progress display
+// WithProgressWriter sets the output writer for progress display.
+// A nil writer is ignored so the existing (default os.Stderr) writer is kept,
+// preventing a nil pointer dereference when progress output is rendered.
 func WithProgressWriter(w io.Writer) ProgressOption {
 	return func(pc *ProgressConfig) {
+		if w == nil {
+			return
+		}
 		pc.Writer = w
 	}
 }

--- a/v2/progress_core_test.go
+++ b/v2/progress_core_test.go
@@ -1124,3 +1124,48 @@ func TestProgressForFormat_Integration(t *testing.T) {
 		t.Errorf("Close() should not return error, got %v", err)
 	}
 }
+
+// TestTextProgress_NilWriter is a regression test for T-1256.
+//
+// WithProgressWriter(nil) used to store a nil io.Writer in ProgressConfig
+// without validation. The draw/drawFinal methods then called
+// fmt.Fprintf(p.config.Writer, ...) which panicked with a nil writer when any
+// drawing operation (SetTotal, SetStatus, Complete, Fail, Close) ran.
+//
+// Expected: a nil writer is normalized to the default writer, so none of the
+// drawing operations panic.
+func TestTextProgress_NilWriter(t *testing.T) {
+	t.Run("explicit nil writer does not panic on draw operations", func(t *testing.T) {
+		// Passing nil must not result in a nil Writer being used for rendering.
+		progress := NewProgress(
+			WithProgressWriter(nil),
+			WithUpdateInterval(0), // No throttling so every call draws
+		)
+
+		// Each of these triggers draw()/drawFinal(); with the bug present any
+		// of them would panic on fmt.Fprintf(nil, ...).
+		progress.SetTotal(100)
+		progress.SetCurrent(25)
+		progress.Increment(25)
+		progress.SetStatus("processing data")
+		progress.Complete()
+
+		if err := progress.Close(); err != nil {
+			t.Errorf("Close() should not return error, got %v", err)
+		}
+	})
+
+	t.Run("explicit nil writer does not panic on Fail", func(t *testing.T) {
+		progress := NewProgress(
+			WithProgressWriter(nil),
+			WithUpdateInterval(0),
+		)
+
+		progress.SetTotal(10)
+		progress.Fail(errors.New("boom"))
+
+		if err := progress.Close(); err != nil {
+			t.Errorf("Close() should not return error, got %v", err)
+		}
+	})
+}


### PR DESCRIPTION
## Bug

`WithProgressWriter(nil)` stored a nil `io.Writer` in `ProgressConfig`, overwriting the default `os.Stderr`. The text progress indicator's `draw`/`drawFinal` then called `fmt.Fprintf(p.config.Writer, ...)` with the nil writer, causing a nil pointer dereference panic. Any drawing operation triggered it: `SetTotal`, `SetCurrent`, `Increment`, `SetStatus`, `Complete`, `Fail`, or `Close`.

## Root cause

`WithProgressWriter` assigned its argument directly to `pc.Writer` with no nil check, discarding the sensible `os.Stderr` default set by `defaultProgressConfig`. No guard existed between option application and rendering.

## Fix

Guard `WithProgressWriter` so a nil writer is ignored, leaving the existing default in place (`v2/progress.go`). Because the nil is never stored, both `NewProgress` and `NewPrettyProgress` are protected without touching `progress_text.go` (kept scoped to avoid overlap with the concurrent T-1254 change there).

Added `TestTextProgress_NilWriter` in `v2/progress_core_test.go`, which fails (nil pointer dereference at `progress_text.go:109`) before the fix and passes after.

## Verification

- Regression test passes
- Full unit test suite passes (`make test`)
- `golangci-lint` reports no issues in the changed files (pre-existing `goconst` findings in `s3_writer.go`/`transformer.go`/`transformers.go` are unrelated)