### PR TITLE
Fix T-1203: TableContent Aliases Caller Record Maps

### DIFF
--- a/v2/content.go
+++ b/v2/content.go
@@ -261,24 +261,43 @@ func formatValue(val any) string {
 	return fmt.Sprint(val)
 }
 
-// convertToRecords converts various data types to records
+// copyRecord returns a shallow copy of the given map as a new Record. Copying
+// here ensures TableContent does not retain references to caller-owned maps,
+// which would otherwise allow post-build mutation of the caller's input to
+// change the stored records (violating immutability).
+func copyRecord[M ~map[string]any](m M) Record {
+	r := make(Record, len(m))
+	maps.Copy(r, m)
+	return r
+}
+
+// convertToRecords converts various data types to records.
+//
+// Each input record/map is copied into a freshly allocated Record so the
+// resulting TableContent is independent of the caller's input. Without this,
+// mutating the original data after building a table would change the table's
+// records and renders.
 func convertToRecords(data any) ([]Record, error) {
 	switch v := data.(type) {
 	case []Record:
-		return v, nil
+		records := make([]Record, len(v))
+		for i, m := range v {
+			records[i] = copyRecord(m)
+		}
+		return records, nil
 	case []map[string]any:
 		records := make([]Record, len(v))
 		for i, m := range v {
-			records[i] = Record(m)
+			records[i] = copyRecord(m)
 		}
 		return records, nil
 	case map[string]any:
-		return []Record{Record(v)}, nil
+		return []Record{copyRecord(v)}, nil
 	case []any:
 		records := make([]Record, 0, len(v))
 		for _, item := range v {
 			if m, ok := item.(map[string]any); ok {
-				records = append(records, Record(m))
+				records = append(records, copyRecord(m))
 			} else {
 				return nil, fmt.Errorf("unsupported item type in slice: %T", item)
 			}

--- a/v2/table_content_test.go
+++ b/v2/table_content_test.go
@@ -580,3 +580,98 @@ func TestTableContent_OperationInstancesShared(t *testing.T) {
 		}
 	}
 }
+
+// TestTableContent_DoesNotAliasCallerInput is a regression test for T-1203.
+//
+// NewTableContent must not retain references to caller-owned maps. Previously
+// convertToRecords returned Record(m) / the input []Record without copying, so
+// mutating the caller's input after building a table also mutated the table's
+// stored records, violating v2 immutability.
+//
+// Each subtest builds a table, mutates the original input, and asserts the
+// table's stored value is unchanged.
+func TestTableContent_DoesNotAliasCallerInput(t *testing.T) {
+	t.Run("Record (single map[string]any value)", func(t *testing.T) {
+		// A bare Record passed via []Record.
+		row := Record{"name": "before"}
+		table, err := NewTableContent("users", []Record{row}, WithKeys("name"))
+		if err != nil {
+			t.Fatalf("NewTableContent: %v", err)
+		}
+
+		// Mutate the caller-owned map after building.
+		row["name"] = "after"
+
+		if got := table.Records()[0]["name"]; got != "before" {
+			t.Errorf("table aliases caller Record: got %q, want %q", got, "before")
+		}
+	})
+
+	t.Run("[]Record", func(t *testing.T) {
+		records := []Record{
+			{"name": "alice"},
+			{"name": "bob"},
+		}
+		table, err := NewTableContent("users", records, WithKeys("name"))
+		if err != nil {
+			t.Fatalf("NewTableContent: %v", err)
+		}
+
+		// Mutate a value and replace a slice element.
+		records[0]["name"] = "mutated"
+		records[1] = Record{"name": "replaced"}
+
+		if got := table.Records()[0]["name"]; got != "alice" {
+			t.Errorf("table aliases caller []Record value: got %q, want %q", got, "alice")
+		}
+		if got := table.Records()[1]["name"]; got != "bob" {
+			t.Errorf("table aliases caller []Record slice: got %q, want %q", got, "bob")
+		}
+	})
+
+	t.Run("map[string]any", func(t *testing.T) {
+		m := map[string]any{"name": "before"}
+		table, err := NewTableContent("users", m, WithKeys("name"))
+		if err != nil {
+			t.Fatalf("NewTableContent: %v", err)
+		}
+
+		m["name"] = "after"
+
+		if got := table.Records()[0]["name"]; got != "before" {
+			t.Errorf("table aliases caller map[string]any: got %q, want %q", got, "before")
+		}
+	})
+
+	t.Run("[]map[string]any", func(t *testing.T) {
+		data := []map[string]any{
+			{"name": "alice"},
+			{"name": "bob"},
+		}
+		table, err := NewTableContent("users", data, WithKeys("name"))
+		if err != nil {
+			t.Fatalf("NewTableContent: %v", err)
+		}
+
+		data[0]["name"] = "mutated"
+
+		if got := table.Records()[0]["name"]; got != "alice" {
+			t.Errorf("table aliases caller []map[string]any: got %q, want %q", got, "alice")
+		}
+	})
+
+	t.Run("[]any of maps", func(t *testing.T) {
+		inner := map[string]any{"name": "before"}
+		data := []any{inner}
+		table, err := NewTableContent("users", data, WithKeys("name"))
+		if err != nil {
+			t.Fatalf("NewTableContent: %v", err)
+		}
+
+		inner["name"] = "after"
+
+		if got := table.Records()[0]["name"]; got != "before" {
+			t.Errorf("table aliases caller []any map: got %q, want %q", got, "before")
+		}
+	})
+}


### PR DESCRIPTION
## Bug

`NewTableContent` retained references to caller-owned map values instead of copying them. When data was supplied as `Record`, `[]Record`, `map[string]any`, `[]map[string]any`, or `[]any` (of maps), the resulting `TableContent` shared the same underlying maps as the caller. Mutating the original input after building the table changed the table's stored records and rendered output, violating the v2 immutability goal.

Repro:
```go
row := output.Record{"name": "before"}
table, _ := output.NewTableContent("users", []output.Record{row}, output.WithKeys("name"))
row["name"] = "after"
fmt.Println(table.Records()[0]["name"]) // was "after", should be "before"
```

## Root cause

`convertToRecords` returned the caller's maps by reference for every map-bearing branch:
- `[]Record` returned the input slice directly (sharing both the slice and its map elements).
- `[]map[string]any`, `map[string]any`, and `[]any` used `Record(m)`, which is a type conversion that shares the underlying map.

Immutability was only enforced on read (`Records()`, `Clone()`), not at ingestion.

## Fix

`convertToRecords` now deep-copies each input record/map into a freshly allocated `Record` (new `copyRecord` helper) for all input shapes, so the resulting `TableContent` is independent of caller input. The per-key copy semantics match the existing `Records()`/`Clone()` behaviour.

## Tests

Added `TestTableContent_DoesNotAliasCallerInput` (in `table_content_test.go`) covering all five input shapes: `Record` via `[]Record`, `[]Record` (value mutation and slice-element replacement), `map[string]any`, `[]map[string]any`, and `[]any` of maps. Tests fail before the fix and pass after.

## Verification

- Regression test passes.
- Full unit suite passes (`make test`).
- No new lint issues: `goconst` baseline is 70 issues both with and without this change; no new findings in `content.go` or the test file.