### PR TITLE
Fix T-1317: Collapsible Sections Alias Caller-Owned Mutable Data

### DIFF
--- a/v2/collapsible_section.go
+++ b/v2/collapsible_section.go
@@ -37,10 +37,15 @@ type DefaultCollapsibleSection struct {
 
 // NewCollapsibleSection creates a new collapsible section
 func NewCollapsibleSection(title string, content []Content, opts ...CollapsibleSectionOption) *DefaultCollapsibleSection {
+	// Defensively copy the content slice so later mutation of the caller's
+	// slice cannot change this section's rendering (T-1317).
+	contentCopy := make([]Content, len(content))
+	copy(contentCopy, content)
+
 	cs := &DefaultCollapsibleSection{
 		id:              GenerateID(),
 		title:           title,
-		content:         content,
+		content:         contentCopy,
 		defaultExpanded: false,
 		level:           0,
 		formatHints:     make(map[string]map[string]any),
@@ -76,7 +81,9 @@ func WithSectionLevel(level int) CollapsibleSectionOption {
 // WithSectionFormatHint adds format-specific hints for the section
 func WithSectionFormatHint(format string, hints map[string]any) CollapsibleSectionOption {
 	return func(cs *DefaultCollapsibleSection) {
-		cs.formatHints[format] = hints
+		// Defensively copy the hints map so later mutation of the caller's
+		// map cannot alter renderer behavior (T-1317).
+		cs.formatHints[format] = maps.Clone(hints)
 	}
 }
 
@@ -109,7 +116,8 @@ func (cs *DefaultCollapsibleSection) Level() int {
 // FormatHint provides renderer-specific hints
 func (cs *DefaultCollapsibleSection) FormatHint(format string) map[string]any {
 	if hints, exists := cs.formatHints[format]; exists {
-		return hints
+		// Return a copy so callers cannot mutate the stored hints (T-1317).
+		return maps.Clone(hints)
 	}
 	return nil
 }

--- a/v2/collapsible_section_test.go
+++ b/v2/collapsible_section_test.go
@@ -342,6 +342,75 @@ func TestCollapsibleSectionNestedScenario(t *testing.T) {
 	}
 }
 
+// TestCollapsibleSectionContentSliceImmutability verifies that mutating the
+// caller-provided content slice after construction does not affect the section.
+// Regression test for T-1317: NewCollapsibleSection stored the caller slice directly.
+func TestCollapsibleSectionContentSliceImmutability(t *testing.T) {
+	text1 := NewTextContent("First content")
+	text2 := NewTextContent("Second content")
+
+	input := []Content{text1, text2}
+	section := NewCollapsibleSection("Test Section", input)
+
+	// Mutate the caller-owned slice after construction.
+	input[0] = NewTextContent("Mutated content")
+
+	// The section must still reference the original content.
+	got := section.Content()
+	if got[0] != text1 {
+		t.Errorf("mutating caller slice changed section content: got %v, want %v", got[0], text1)
+	}
+	if got[1] != text2 {
+		t.Errorf("section content[1] changed unexpectedly: got %v, want %v", got[1], text2)
+	}
+}
+
+// TestCollapsibleSectionFormatHintInputImmutability verifies that mutating the
+// caller-provided hints map after construction does not affect renderer behavior.
+// Regression test for T-1317: WithSectionFormatHint stored the caller map directly.
+func TestCollapsibleSectionFormatHintInputImmutability(t *testing.T) {
+	hints := map[string]any{"class": "expandable-section"}
+
+	section := NewCollapsibleSection("Test Section", []Content{},
+		WithSectionFormatHint("markdown", hints))
+
+	// Mutate the caller-owned map after construction.
+	hints["class"] = "mutated"
+	hints["extra"] = "added"
+
+	got := section.FormatHint("markdown")
+	if got["class"] != "expandable-section" {
+		t.Errorf("mutating caller hints map changed stored hints: got %v, want %v", got["class"], "expandable-section")
+	}
+	if _, exists := got["extra"]; exists {
+		t.Error("adding a key to the caller hints map leaked into stored hints")
+	}
+}
+
+// TestCollapsibleSectionFormatHintOutputImmutability verifies that mutating the
+// map returned by FormatHint does not affect the section's internal state.
+// Regression test for T-1317: FormatHint returned the stored map directly.
+func TestCollapsibleSectionFormatHintOutputImmutability(t *testing.T) {
+	hints := map[string]any{"class": "expandable-section"}
+
+	section := NewCollapsibleSection("Test Section", []Content{},
+		WithSectionFormatHint("markdown", hints))
+
+	// Mutate the returned map.
+	returned := section.FormatHint("markdown")
+	returned["class"] = "mutated"
+	returned["extra"] = "added"
+
+	// A fresh read must be unaffected.
+	got := section.FormatHint("markdown")
+	if got["class"] != "expandable-section" {
+		t.Errorf("mutating returned hints map changed stored hints: got %v, want %v", got["class"], "expandable-section")
+	}
+	if _, exists := got["extra"]; exists {
+		t.Error("adding a key to the returned hints map leaked into stored hints")
+	}
+}
+
 // Helper function for error creation in tests
 func errorf(format string, args ...any) error {
 	return &testError{message: sprintf(format, args...)}


### PR DESCRIPTION
## Bug

`DefaultCollapsibleSection` did not fully preserve immutability, violating the v2 immutability/thread-safety design. It held references to caller-owned mutable data instead of defensive copies.

## Root cause

Three missing defensive copies in `v2/collapsible_section.go`:

1. `NewCollapsibleSection` stored the caller-provided `[]Content` slice directly, so replacing elements in that slice after construction changed later section rendering.
2. `WithSectionFormatHint` stored the caller-provided hints map directly, so mutating the original map after construction altered renderer behavior.
3. `FormatHint` returned the stored hints map directly, so callers could mutate the section's internal state.

(`Content()` already copied on output, which masked the construction-time aliasing in existing tests.)

## Fix

- Copy the content slice into a new backing array on construction.
- Store `maps.Clone(hints)` in `WithSectionFormatHint`.
- Return `maps.Clone(hints)` from `FormatHint`.

This matches the existing `Content()` and `Clone()` patterns. `maps.Clone(nil)` returns nil, so the non-existent-format path is unchanged, and the `maps` package was already imported.

## Tests

Added three regression tests in `v2/collapsible_section_test.go`, each confirmed to fail before the fix and pass after:

- `TestCollapsibleSectionContentSliceImmutability`
- `TestCollapsibleSectionFormatHintInputImmutability`
- `TestCollapsibleSectionFormatHintOutputImmutability`

Full unit suite passes (`make test`). Lint shows only pre-existing `goconst` issues in unrelated files; none in the changed files.

## Follow-up note

`DefaultCollapsibleValue` in `v2/collapsible.go` has the same aliasing pattern in `WithFormatHint`/`FormatHint`. Out of scope for this ticket; worth a separate follow-up.

Closes T-1317.