### PR TITLE
Fix T-1100: GroupBy Can Merge Distinct Composite Keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Unreleased
 
 ### Fixed
+- **GroupBy Composite Key Collision** - Fixed `GroupByOp.createGroupKey` merging distinct groups when grouped values contain the `||` separator (e.g. `{a:"x||y", b:"z"}` and `{a:"x", b:"y||z"}` both produced key `x||y||z`)
+  - Replaced fixed-delimiter concatenation with a collision-safe length-prefixed encoding (`<len>:<value>` per column)
+  - Missing values now use a distinct `nil:` marker so they no longer collide with the literal string `"<nil>"`
+  - Added regression test `TestGroupByCompositeKeyCollision`
 - **Pretty Progress Signal Context Safety** - Fixed startup panic in `NewPrettyProgress` when `handleSignals` accessed `p.ctx.Done()` before `SetContext` initialized the context
   - Initialize a default cancellable background context before starting signal handling
   - Added nil-safe context channel handling and closed-signal channel exit in `handleSignals`

--- a/specs/bugfixes/groupby-merges-composite-keys/report.md
+++ b/specs/bugfixes/groupby-merges-composite-keys/report.md
@@ -1,0 +1,118 @@
+# Bugfix Report: GroupBy Merges Distinct Composite Keys
+
+**Date:** 2026-05-24
+**Status:** Fixed
+
+## Description of the Issue
+
+`GroupByOp` builds a composite group key by concatenating the grouped column
+values with the literal separator `||`. Because the separator can also appear
+inside a value, distinct value tuples can serialize to the same key string and
+get incorrectly merged into a single group. The aggregated output then reports
+one group instead of two, and the group's sample column values come from
+whichever tuple was seen first.
+
+**Reproduction steps:**
+1. Group a table by columns `["a", "b"]`.
+2. Provide two records whose values collide under `||` joining:
+   - `{a: "x||y", b: "z"}`  -> key `x||y||z`
+   - `{a: "x", b: "y||z"}`  -> key `x||y||z`
+3. Observe that the result has 1 group instead of 2.
+
+A related collision exists for missing values: a missing column serialized to
+the literal string `<nil>`, colliding with a record whose value is literally
+the string `"<nil>"`.
+
+**Impact:** Silent data corruption in aggregation. Any caller grouping over
+string columns whose values can contain `||` (or the literal `<nil>`) could get
+under-counted groups and incorrect aggregate results. Severity is moderate:
+correctness bug, no crash, limited to specific data shapes.
+
+## Investigation Summary
+
+- **Symptoms examined:** Two distinct records merged into one group.
+- **Code inspected:** `v2/operations.go` — `GroupByOp.Apply` (grouping loop) and
+  `GroupByOp.createGroupKey` (key construction).
+- **Hypotheses tested:** Ruled out the grouping loop and aggregate functions —
+  they operate correctly on whatever keys `createGroupKey` returns. The defect
+  is isolated to the key construction.
+
+## Discovered Root Cause
+
+`createGroupKey` produced a non-injective encoding of the value tuple. Joining
+values with a fixed `||` delimiter means the boundary between values is
+indistinguishable from a `||` that occurs inside a value, so different tuples
+can map to the same string. The missing-value sentinel `<nil>` had the same
+flaw against the literal string `"<nil>"`.
+
+**Defect type:** Logic error — ambiguous (non-injective) serialization.
+
+**Why it occurred:** The original implementation assumed `||` would never occur
+in data, which is not guaranteed for arbitrary string columns.
+
+**Contributing factors:** No test covered values containing the separator.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `v2/operations.go` — `GroupByOp.createGroupKey` now builds a length-prefixed
+  encoding. Each value is serialized with `fmt.Sprintf("%v", val)`, then written
+  to a `strings.Builder` as `<byteLen>:<value>`. Missing values are encoded with
+  a distinct `nil:` marker rather than the ambiguous `<nil>` string. Because each
+  segment carries its own length, the concatenation is unambiguous regardless of
+  value content — no value can be confused with a delimiter.
+
+**Approach rationale:** Length-prefixing makes the encoding injective with no
+escaping rules to get wrong, and it stays a plain `string` key so the existing
+`map[string][]Record` grouping is unchanged. It is also cheap (no hashing, no
+allocation per value beyond the builder).
+
+**Alternatives considered:**
+- **Escaping `||` and the escape char in values** — Works but is fiddlier and
+  easier to get subtly wrong than length-prefixing.
+- **Hashing the joined values (e.g. SHA-256)** — Adds cost and a (tiny) collision
+  risk; unnecessary when an exact injective encoding is available.
+- **Using a struct/slice key** — Slices aren't comparable so can't be map keys
+  directly; would require an array or a separate index structure, more invasive
+  than needed.
+
+## Regression Test
+
+**Test file:** `v2/operations_aggregate_test.go`
+**Test name:** `TestGroupByCompositeKeyCollision`
+
+**What it verifies:**
+- Two records whose values contain `||` and would collide under naive joining
+  produce two distinct groups, each with count 1.
+- A literal `"<nil>"` string value is not merged with a record that is missing
+  the grouped column.
+
+**Run command:** `cd v2 && go test -run TestGroupByCompositeKeyCollision`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `v2/operations.go` | Length-prefixed, collision-safe composite key encoding in `createGroupKey` |
+| `v2/operations_aggregate_test.go` | Added `TestGroupByCompositeKeyCollision` regression test |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Linters/validators pass
+
+**Manual verification:**
+- Confirmed the regression test fails before the fix and passes after.
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Prefer injective (length-prefixed or escaped) encodings whenever composing a
+  composite key from arbitrary user data — never assume a delimiter is absent.
+- Use a distinct sentinel for "missing" that cannot be produced by a real value.
+
+## Related
+
+- Transit ticket: T-1100

--- a/v2/operations.go
+++ b/v2/operations.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strings"
 	"time"
 )
 
@@ -510,20 +511,25 @@ func (o *GroupByOp) Apply(ctx context.Context, content Content) (Content, error)
 	return cloned, nil
 }
 
-// createGroupKey creates a string key from groupBy column values
+// createGroupKey creates a collision-safe string key from groupBy column values.
+//
+// Each value is encoded with an explicit byte length prefix ("<len>:<value>")
+// so the boundary between values is unambiguous. This avoids collisions that a
+// fixed delimiter (e.g. "||") would cause when a value itself contains the
+// delimiter: distinct tuples like {a:"x||y", b:"z"} and {a:"x", b:"y||z"} now
+// produce different keys. A missing value uses a distinct "nil:" marker so it
+// cannot collide with the literal string "<nil>".
 func (o *GroupByOp) createGroupKey(record Record) string {
-	key := ""
-	for i, column := range o.groupBy {
-		if i > 0 {
-			key += "||" // Separator to avoid collisions
-		}
+	var key strings.Builder
+	for _, column := range o.groupBy {
 		if val, exists := record[column]; exists {
-			key += fmt.Sprintf("%v", val)
+			s := fmt.Sprintf("%v", val)
+			fmt.Fprintf(&key, "%d:%s", len(s), s)
 		} else {
-			key += "<nil>"
+			key.WriteString("nil:")
 		}
 	}
-	return key
+	return key.String()
 }
 
 // inferFieldFromAggregateName tries to infer field name from aggregate name

--- a/v2/operations_aggregate_test.go
+++ b/v2/operations_aggregate_test.go
@@ -566,3 +566,88 @@ func TestBuiltInAggregateFunctions(t *testing.T) {
 		}
 	})
 }
+
+// TestGroupByCompositeKeyCollision is a regression test for T-1100.
+//
+// The bug: createGroupKey joined grouped column values with the literal
+// separator "||". When a value itself contains "||", distinct value tuples
+// can serialize to the same key and get incorrectly merged into one group.
+//
+// Example collision for groupBy [a, b]:
+//   - record 1: {a: "x||y", b: "z"}  -> "x||y||z"
+//   - record 2: {a: "x", b: "y||z"}  -> "x||y||z"
+//
+// Expected: two distinct groups. Actual (before fix): one merged group.
+func TestGroupByCompositeKeyCollision(t *testing.T) {
+	t.Run("does not merge distinct values that contain the separator", func(t *testing.T) {
+		groupByOp := &GroupByOp{
+			groupBy: []string{"a", "b"},
+			aggregates: map[string]AggregateFunc{
+				"count": CountAggregate(),
+			},
+		}
+
+		doc := New().
+			Table("test", []Record{
+				{"a": "x||y", "b": "z"},
+				{"a": "x", "b": "y||z"},
+			}).
+			Build()
+
+		tableContent := doc.GetContents()[0].(*TableContent)
+		result, err := groupByOp.Apply(context.Background(), tableContent)
+		if err != nil {
+			t.Fatalf("Apply() failed: %v", err)
+		}
+
+		resultTable := result.(*TableContent)
+		if len(resultTable.records) != 2 {
+			t.Fatalf("expected 2 distinct groups, got %d (distinct composite keys were merged)", len(resultTable.records))
+		}
+
+		// Verify each original tuple survives as its own group with count 1.
+		seen := make(map[string]int)
+		for _, record := range resultTable.records {
+			a := record["a"].(string)
+			b := record["b"].(string)
+			count := record["count"].(int)
+			seen[a+"|sep|"+b] = count
+		}
+
+		if seen["x||y|sep|z"] != 1 {
+			t.Errorf("expected group {a:x||y, b:z} with count 1, got %d", seen["x||y|sep|z"])
+		}
+		if seen["x|sep|y||z"] != 1 {
+			t.Errorf("expected group {a:x, b:y||z} with count 1, got %d", seen["x|sep|y||z"])
+		}
+	})
+
+	t.Run("distinguishes nil from the literal nil string", func(t *testing.T) {
+		// A missing value previously serialized to "<nil>", which collides
+		// with a record whose value is literally the string "<nil>".
+		groupByOp := &GroupByOp{
+			groupBy: []string{"a"},
+			aggregates: map[string]AggregateFunc{
+				"count": CountAggregate(),
+			},
+		}
+
+		doc := New().
+			Table("test", []Record{
+				{"a": "<nil>"}, // literal string
+				{"b": "other"}, // "a" is missing -> nil
+			}).
+			Build()
+
+		tableContent := doc.GetContents()[0].(*TableContent)
+		result, err := groupByOp.Apply(context.Background(), tableContent)
+		if err != nil {
+			t.Fatalf("Apply() failed: %v", err)
+		}
+
+		resultTable := result.(*TableContent)
+		if len(resultTable.records) != 2 {
+			t.Fatalf("expected 2 distinct groups (literal \"<nil>\" vs missing), got %d", len(resultTable.records))
+		}
+	})
+}


### PR DESCRIPTION
## Bug

`GroupByOp.createGroupKey` (in `v2/operations.go`) built composite group keys by concatenating grouped column values with the literal separator `||`. When a value itself contains `||`, distinct value tuples serialize to the same key and get incorrectly merged into one group.

Example collision for `groupBy: ["a", "b"]`:
- record 1: `{a: "x||y", b: "z"}` -> `x||y||z`
- record 2: `{a: "x", b: "y||z"}` -> `x||y||z`

Both records were merged into a single group, producing under-counted groups and incorrect aggregate results. A related collision existed for missing values, whose `<nil>` sentinel collided with a literal `"<nil>"` string.

## Root Cause

The key encoding was non-injective: a fixed `||` delimiter is indistinguishable from a `||` occurring inside a value, so different tuples can map to the same string.

## Fix

Replace the ad-hoc concatenation with a collision-safe length-prefixed encoding. Each value is written as `<byteLen>:<value>`, so each segment carries its own length and the concatenation is unambiguous regardless of value content. Missing values use a distinct `nil:` marker rather than the ambiguous `<nil>` string.

## Tests

- Added `TestGroupByCompositeKeyCollision` in `v2/operations_aggregate_test.go`, covering both the `||`-in-value collision and the literal-`<nil>` vs missing-value collision. The test fails before the fix and passes after.
- Full unit suite passes (`make test`). No new lint issues introduced (the pre-existing `goconst` warnings are unrelated to changed files).

See `specs/bugfixes/groupby-merges-composite-keys/report.md` for the full bugfix report.

Closes T-1100.