### PR TITLE
Fix T-1254: Progress SetContext Replacement Fails Progress

### DIFF
--- a/specs/bugfixes/progress-setcontext-replacement-fails/report.md
+++ b/specs/bugfixes/progress-setcontext-replacement-fails/report.md
@@ -1,0 +1,131 @@
+# Bugfix Report: progress-setcontext-replacement-fails
+
+**Date:** 2026-05-24
+**Status:** Fixed
+
+## Description of the Issue
+
+`textProgress.SetContext` installs a cancellation watcher goroutine each time it
+is called. The watcher read `p.ctx` (the shared struct field) instead of the
+context it was created for. When `SetContext` was called a second time, the old
+watcher was released by `p.cancel()`, and after the new context was installed
+the released watcher could mark the progress as failed and set `p.err` from the
+new `p.ctx.Err()`.
+
+**Reproduction steps:**
+1. Create a text progress: `p := NewProgress(...)`.
+2. Install a live context: `p.SetContext(ctx1)`.
+3. Replace it with another live context: `p.SetContext(ctx2)`.
+4. Observe (under `go test -race`) a data race on `p.ctx` between the watcher
+   goroutine and `SetContext`, and a possible spurious failure of the progress.
+
+**Impact:** Replacing a progress context (a supported v1-compatibility
+operation) could mark a healthy progress as failed and corrupt `p.err`, plus a
+data race on the `p.ctx` field. Medium severity; affects any caller that calls
+`SetContext` more than once on a `textProgress`.
+
+## Investigation Summary
+
+- **Symptoms examined:** Spurious `failed=true`/`err` after a second
+  `SetContext`; data race reported by `go test -race`.
+- **Code inspected:** `v2/progress_text.go` (`SetContext` and the watcher
+  goroutine), `v2/progress.go` (`NewProgress`), existing tests in
+  `v2/progress_core_test.go`. The same pattern exists in
+  `v2/progress_pretty.go` but is out of scope for this ticket (T-1254 scopes the
+  fix to `textProgress`).
+- **Hypotheses tested:** Confirmed via `-race` that the watcher reads `p.ctx`
+  (progress_text.go:243) concurrently with the reassignment in `SetContext`
+  (progress_text.go:239). Confirmed the watcher's `Err()` was read from the
+  shared field rather than its own context.
+
+## Discovered Root Cause
+
+The watcher goroutine closed over the receiver `p` and dereferenced the shared
+field `p.ctx` in both `<-p.ctx.Done()` and `p.ctx.Err()`, assuming it would not
+change. A subsequent `SetContext` reassigns `p.ctx`/`p.cancel` and cancels the
+prior derived context, releasing the old watcher. The released watcher then
+operated against whatever `p.ctx` had become, so a context replacement was
+treated like a real cancellation/failure.
+
+**Defect type:** Concurrency bug — data race plus stale-closure / incorrect
+shared-state read.
+
+**Why it occurred:** The goroutine read mutable shared state (`p.ctx`) instead
+of capturing the specific derived context and cancel token it was created to
+watch.
+
+**Contributing factors:** No existing test exercised replacing the context, and
+CI does not run with `-race`, so the race went undetected.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `v2/progress_text.go` (`SetContext`) - The watcher now captures its own
+  derived context (`watchedCtx`) as a local variable rather than reading
+  `p.ctx`. When it fires, it ignores the completion if `p.ctx != watchedCtx`
+  (i.e. it has been superseded by a later `SetContext`). Also tidied the
+  nil-context path to clear `p.ctx`/`p.cancel` instead of leaving a derived
+  context installed.
+
+**Approach rationale:** Capturing the context/cancel token per watcher removes
+the data race entirely (the goroutine never reads the shared `p.ctx` for its
+wait) and makes stale completions explicitly ignorable via the identity check
+under the lock. This matches the ticket's expectation that each watcher capture
+its own derived context.
+
+**Alternatives considered:**
+- Using a generation counter (e.g. an int incremented per `SetContext`) checked
+  by the watcher - rejected because the captured-context identity check is
+  simpler and needs no extra field.
+- Not deriving a child context and watching the caller's context directly -
+  rejected because the derived context/cancel is needed for `Close()` to stop
+  the watcher.
+
+## Regression Test
+
+**Test file:** `v2/progress_core_test.go`
+**Test name:** `TestProgress_SetContext_Replacement_DoesNotFail`
+
+**What it verifies:** After replacing the progress context with a second live
+context, the progress remains active and is not marked failed (no spurious
+`failed`/`err`), and the current (live) context can still fail the progress when
+cancelled. Run under `-race`, it also proves the `p.ctx` data race is gone.
+
+**Run command:**
+`cd v2 && go test -race -run TestProgress_SetContext_Replacement_DoesNotFail -count=1 .`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `v2/progress_text.go` | Watcher captures its own derived context/cancel and ignores stale (replaced) completions; nil-context path clears state |
+| `v2/progress_core_test.go` | Added regression test for context replacement not failing the progress |
+| `specs/bugfixes/progress-setcontext-replacement-fails/report.md` | This report |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes (and fails under `-race` before the fix)
+- [x] Full test suite passes (`make test`, and `go test -race .`)
+- [x] Linters/validators pass for changed files (pre-existing unrelated
+  `goconst` warnings in `s3_writer.go`/`transformer*.go` remain)
+
+**Manual verification:**
+- Confirmed the regression test produced a data race (progress_text.go:239 vs
+  :243) under `go test -race` before the fix.
+- Confirmed it passes deterministically under `-race` (5x) after the fix.
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Goroutines should capture the specific values they operate on as locals rather
+  than reading mutable receiver fields after they may have changed.
+- When a long-lived goroutine acts on shared state, verify identity (or a
+  generation token) under the lock before acting, to ignore stale work.
+- Consider running CI with `-race`; this class of bug is invisible without it.
+
+## Related
+
+- Transit ticket: `T-1254`
+- Same watcher pattern exists in `v2/progress_pretty.go` (`prettyProgress.SetContext`)
+  and may warrant a follow-up ticket; out of scope for T-1254.

--- a/v2/progress_core_test.go
+++ b/v2/progress_core_test.go
@@ -438,6 +438,64 @@ func TestProgress_V1Compatibility_SetContext(t *testing.T) {
 	progress.Close()
 }
 
+// TestProgress_SetContext_Replacement_DoesNotFail is a regression test for T-1254.
+//
+// SetContext cancels the previously derived context when a new context is
+// installed. The watcher goroutine for the old context must NOT mark the
+// progress as failed when it is released by that replacement cancellation.
+//
+// Bug: the old watcher read p.ctx (the shared struct field) instead of the
+// context it was created for, so after replacement it saw the new context's
+// error (or none) and set p.failed = true, failing a still-healthy progress.
+//
+// Expected: replacing a progress context leaves the progress active and
+// unfailed; only the live context's cancellation should fail it.
+func TestProgress_SetContext_Replacement_DoesNotFail(t *testing.T) {
+	var buf bytes.Buffer
+	progress := NewProgress(WithProgressWriter(&buf))
+
+	tp, ok := progress.(*textProgress)
+	if !ok {
+		t.Fatalf("NewProgress() returned %T, expected *textProgress", progress)
+	}
+
+	// Install the first context.
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	defer cancel1()
+	progress.SetContext(ctx1)
+
+	// Replace it with a fresh, live context. This cancels the first derived
+	// context internally and releases the first watcher goroutine.
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+	progress.SetContext(ctx2)
+
+	// Give the released first watcher time to (incorrectly) run and fail us.
+	time.Sleep(50 * time.Millisecond)
+
+	// The progress must still be active and unfailed: replacing the context
+	// is not a failure condition.
+	if !progress.IsActive() {
+		t.Error("progress should remain active after the context is replaced")
+	}
+
+	tp.mu.RLock()
+	failed, err := tp.failed, tp.err
+	tp.mu.RUnlock()
+	if failed {
+		t.Errorf("progress should not be marked failed after context replacement, err=%v", err)
+	}
+
+	// The live context must still be able to fail the progress.
+	cancel2()
+	time.Sleep(50 * time.Millisecond)
+	if progress.IsActive() {
+		t.Error("progress should fail when the live (current) context is cancelled")
+	}
+
+	progress.Close()
+}
+
 func TestProgress_V1Compatibility_ProgressOptions(t *testing.T) {
 	var buf bytes.Buffer
 	progress := NewProgress(

--- a/v2/progress_text.go
+++ b/v2/progress_text.go
@@ -227,27 +227,44 @@ func (p *textProgress) IsActive() bool {
 func (p *textProgress) SetContext(ctx context.Context) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.ctx = ctx
 
-	// Cancel any existing context
+	// Cancel any existing context. This releases the previous watcher
+	// goroutine, but that goroutine ignores its own (replacement) cancellation
+	// because the context it watches is no longer p.ctx (see below).
 	if p.cancel != nil {
 		p.cancel()
 	}
 
-	// Create new context with cancellation
-	if ctx != nil {
-		p.ctx, p.cancel = context.WithCancel(ctx)
-
-		// Start goroutine to watch for cancellation
-		go func() {
-			<-p.ctx.Done()
-			p.mu.Lock()
-			if !p.completed && !p.failed {
-				p.failed = true
-				p.err = p.ctx.Err()
-				p.drawFinal()
-			}
-			p.mu.Unlock()
-		}()
+	if ctx == nil {
+		p.ctx = nil
+		p.cancel = nil
+		return
 	}
+
+	// Create a new derived context with cancellation.
+	watchedCtx, cancel := context.WithCancel(ctx)
+	p.ctx = watchedCtx
+	p.cancel = cancel
+
+	// Start a goroutine to watch for cancellation. The watcher captures its
+	// own derived context (watchedCtx) rather than reading the shared p.ctx
+	// field, so a later SetContext call cannot make this watcher read the
+	// wrong context. When this watcher fires it only fails the progress if its
+	// context is still the current one; if it has been replaced, the
+	// completion is stale and ignored.
+	go func() {
+		<-watchedCtx.Done()
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		if p.ctx != watchedCtx {
+			// This context was replaced by a newer SetContext call. Its
+			// cancellation is the result of replacement, not a real failure.
+			return
+		}
+		if !p.completed && !p.failed {
+			p.failed = true
+			p.err = watchedCtx.Err()
+			p.drawFinal()
+		}
+	}()
 }


### PR DESCRIPTION
## Bug

`textProgress.SetContext` (v2/progress_text.go) starts a cancellation watcher goroutine each time it is called. The watcher read the shared `p.ctx` struct field instead of the context it was created for. When `SetContext` was called a second time, the old watcher was released by `p.cancel()`, and after the new context was installed the stale watcher could mark a healthy progress as failed and set `p.err` from the new `p.ctx.Err()`. It was also a data race on `p.ctx` (the watcher's `<-p.ctx.Done()` raced with the reassignment in `SetContext`).

## Root cause

The watcher goroutine closed over the receiver `p` and dereferenced the mutable shared field `p.ctx` in both `<-p.ctx.Done()` and `p.ctx.Err()`, assuming it would not change. A later `SetContext` reassigns `p.ctx`/`p.cancel` and cancels the prior derived context, releasing the old watcher, which then acted against whatever `p.ctx` had become. So a context replacement was treated like a real cancellation/failure.

## Fix

The watcher now captures its own derived context (`watchedCtx`) and cancel token as locals rather than reading `p.ctx`. When it fires, it ignores the completion if the progress's current context has been replaced (`p.ctx != watchedCtx`). This removes the data race (the goroutine never reads the shared field for its wait) and ensures replacing a context does not fail the progress. The nil-context path now clears `p.ctx`/`p.cancel` rather than leaving a derived context installed.

Scope is limited to `textProgress` per the ticket. `prettyProgress.SetContext` has the same pattern and is noted as a possible follow-up.

## Verification

- Added regression test `TestProgress_SetContext_Replacement_DoesNotFail` (v2/progress_core_test.go). It fails under `go test -race` before the fix (data race + spurious failure) and passes deterministically after.
- `make test` passes; `go test -race ./...` passes for the package.
- No new lint issues in changed files (pre-existing `goconst` warnings in unrelated files remain).

See `specs/bugfixes/progress-setcontext-replacement-fails/report.md` for the full investigation.

Closes T-1254.