### PR TITLE
Fix T-1086: Schema Key Order Leaks Mutable Slices

### DIFF
--- a/v2/content.go
+++ b/v2/content.go
@@ -140,8 +140,17 @@ func (t *TableContent) Title() string {
 	return t.title
 }
 
-// Schema returns the table schema
+// Schema returns a defensive copy of the table schema.
+// A copy is returned so callers cannot mutate the built table's schema
+// (e.g. via SetKeyOrder) and change its rendered key order after Build().
 func (t *TableContent) Schema() *Schema {
+	return t.schema.clone()
+}
+
+// getSchema returns the live (non-copied) schema for internal package use.
+// Internal callers must only read from the returned schema, never mutate it.
+// External callers must use the public Schema() accessor, which returns a copy.
+func (t *TableContent) getSchema() *Schema {
 	return t.schema
 }
 
@@ -168,19 +177,7 @@ func (t *TableContent) Clone() Content {
 	}
 
 	// Deep copy schema
-	var newSchema *Schema
-	if t.schema != nil {
-		newFields := make([]Field, len(t.schema.Fields))
-		copy(newFields, t.schema.Fields)
-
-		newKeyOrder := make([]string, len(t.schema.keyOrder))
-		copy(newKeyOrder, t.schema.keyOrder)
-
-		newSchema = &Schema{
-			Fields:   newFields,
-			keyOrder: newKeyOrder,
-		}
-	}
+	newSchema := t.schema.clone()
 
 	// Shallow copy transformations (share same operation instances)
 	var newTransformations []Operation

--- a/v2/csv_renderer.go
+++ b/v2/csv_renderer.go
@@ -91,12 +91,12 @@ func (c *csvRenderer) renderDocumentCSVTo(ctx context.Context, doc *Document, w 
 			// CSV format doesn't support comments in a standard way
 
 			// Write headers for first table or when schema differs from previous table
-			writeHeaders := !keyOrdersEqual(lastKeyOrder, content.Schema().GetKeyOrder())
+			writeHeaders := !keyOrdersEqual(lastKeyOrder, content.getSchema().GetKeyOrder())
 			if err := c.renderTableContentCSV(content, csvWriter, writeHeaders); err != nil {
 				return fmt.Errorf("failed to render table %s: %w", content.ID(), err)
 			}
 
-			lastKeyOrder = content.Schema().GetKeyOrder()
+			lastKeyOrder = content.getSchema().GetKeyOrder()
 
 		case *SectionContent:
 			// Extract and render tables from sections
@@ -116,11 +116,11 @@ func (c *csvRenderer) renderDocumentCSVTo(ctx context.Context, doc *Document, w 
 						}
 					}
 
-					writeHeaders := !keyOrdersEqual(lastKeyOrder, nestedTable.Schema().GetKeyOrder())
+					writeHeaders := !keyOrdersEqual(lastKeyOrder, nestedTable.getSchema().GetKeyOrder())
 					if err := c.renderTableContentCSV(nestedTable, csvWriter, writeHeaders); err != nil {
 						return fmt.Errorf("failed to render table %s: %w", nestedTable.ID(), err)
 					}
-					lastKeyOrder = nestedTable.Schema().GetKeyOrder()
+					lastKeyOrder = nestedTable.getSchema().GetKeyOrder()
 				} else if nestedSection, ok := nestedTransformed.(*SectionContent); ok {
 					// Recursively handle nested sections
 					for _, deepContent := range nestedSection.Contents() {
@@ -134,11 +134,11 @@ func (c *csvRenderer) renderDocumentCSVTo(ctx context.Context, doc *Document, w 
 									return fmt.Errorf("failed to write separator row: %w", err)
 								}
 							}
-							writeHeaders := !keyOrdersEqual(lastKeyOrder, deepTable.Schema().GetKeyOrder())
+							writeHeaders := !keyOrdersEqual(lastKeyOrder, deepTable.getSchema().GetKeyOrder())
 							if err := c.renderTableContentCSV(deepTable, csvWriter, writeHeaders); err != nil {
 								return fmt.Errorf("failed to render table %s: %w", deepTable.ID(), err)
 							}
-							lastKeyOrder = deepTable.Schema().GetKeyOrder()
+							lastKeyOrder = deepTable.getSchema().GetKeyOrder()
 						}
 					}
 				}
@@ -184,7 +184,7 @@ func (c *csvRenderer) renderTableContentCSV(table *TableContent, csvWriter *csv.
 		return fmt.Errorf("failed to process collapsible fields: %w", err)
 	}
 
-	keyOrder := enhancedTable.Schema().GetKeyOrder()
+	keyOrder := enhancedTable.getSchema().GetKeyOrder()
 	if len(keyOrder) == 0 {
 		return nil // No columns to write
 	}
@@ -265,8 +265,8 @@ func (c *csvRenderer) formatValueForCSV(val any) string {
 // handleCollapsibleFields analyzes table schema and creates additional "_details" columns
 // for fields that produce CollapsibleValue content (Requirement 8.1)
 func (c *csvRenderer) handleCollapsibleFields(table *TableContent) (*TableContent, error) {
-	originalFields := table.Schema().Fields
-	originalKeyOrder := table.Schema().GetKeyOrder()
+	originalFields := table.getSchema().Fields
+	originalKeyOrder := table.getSchema().GetKeyOrder()
 	originalRecords := table.Records()
 
 	// Analyze which fields contain CollapsibleValue content
@@ -312,7 +312,7 @@ func (c *csvRenderer) handleCollapsibleFields(table *TableContent) (*TableConten
 		// Process each original field
 		for _, key := range originalKeyOrder {
 			val := record[key]
-			field := table.Schema().FindField(key)
+			field := table.getSchema().FindField(key)
 
 			// Apply field formatter if present
 			if field != nil && field.Formatter != nil {
@@ -362,7 +362,7 @@ func (c *csvRenderer) detectCollapsibleFields(table *TableContent) map[string]bo
 	}
 
 	// Check each field by applying its formatter to sample data
-	for _, field := range table.Schema().Fields {
+	for _, field := range table.getSchema().Fields {
 		if field.Formatter == nil {
 			continue
 		}

--- a/v2/html_renderer.go
+++ b/v2/html_renderer.go
@@ -161,7 +161,7 @@ func (h *htmlRenderer) renderTableContentHTML(table *TableContent) ([]byte, erro
 	result.WriteString("  <table class=\"data-table\">\n")
 
 	// Get key order from schema
-	keyOrder := table.Schema().GetKeyOrder()
+	keyOrder := table.getSchema().GetKeyOrder()
 	if len(keyOrder) == 0 {
 		result.WriteString("  </table>\n</div>\n")
 		return []byte(result.String()), nil // No columns to render
@@ -184,7 +184,7 @@ func (h *htmlRenderer) renderTableContentHTML(table *TableContent) ([]byte, erro
 			var cellValue string
 			if val, exists := record[key]; exists {
 				// Apply field formatter if available
-				field := table.Schema().FindField(key)
+				field := table.getSchema().FindField(key)
 				cellValue = h.formatCellValue(val, field)
 			}
 			fmt.Fprintf(&result, "        <td>%s</td>\n", cellValue)

--- a/v2/json_yaml_renderer.go
+++ b/v2/json_yaml_renderer.go
@@ -203,7 +203,7 @@ func (j *jsonRenderer) renderTableContentJSON(table *TableContent) ([]byte, erro
 	}
 
 	// Convert records to ordered map preserving key order
-	keyOrder := table.Schema().GetKeyOrder()
+	keyOrder := table.getSchema().GetKeyOrder()
 	var tableData []map[string]any
 
 	for _, record := range table.Records() {
@@ -214,7 +214,7 @@ func (j *jsonRenderer) renderTableContentJSON(table *TableContent) ([]byte, erro
 		for _, key := range keyOrder {
 			if val, exists := record[key]; exists {
 				// Find field for this key to apply formatter
-				field := table.Schema().FindField(key)
+				field := table.getSchema().FindField(key)
 				// Process field value and handle CollapsibleValue
 				processedVal := j.formatValueForJSON(val, field)
 				orderedRecord[key] = processedVal
@@ -227,7 +227,7 @@ func (j *jsonRenderer) renderTableContentJSON(table *TableContent) ([]byte, erro
 	result[keyData] = tableData
 	result["schema"] = map[string]any{
 		keyKeys:   keyOrder,
-		keyFields: j.convertFieldsToJSON(table.Schema()),
+		keyFields: j.convertFieldsToJSON(table.getSchema()),
 	}
 
 	return json.MarshalIndent(result, "", "  ")
@@ -334,10 +334,10 @@ func (j *jsonRenderer) renderTableContentJSONStream(table *TableContent, w io.Wr
 	}
 
 	// Add schema information
-	keyOrder := table.Schema().GetKeyOrder()
+	keyOrder := table.getSchema().GetKeyOrder()
 	result["schema"] = map[string]any{
 		keyKeys:   keyOrder,
-		keyFields: j.convertFieldsToJSON(table.Schema()),
+		keyFields: j.convertFieldsToJSON(table.getSchema()),
 	}
 
 	// For streaming, we need to handle data differently
@@ -379,7 +379,7 @@ func (j *jsonRenderer) renderTableContentJSONStream(table *TableContent, w io.Wr
 	if _, err := w.Write([]byte("    \"fields\": [\n")); err != nil {
 		return fmt.Errorf("failed to write fields header: %w", err)
 	}
-	fields := j.convertFieldsToJSON(table.Schema())
+	fields := j.convertFieldsToJSON(table.getSchema())
 	for i, field := range fields {
 		if i > 0 {
 			if _, err := w.Write([]byte(",\n")); err != nil {
@@ -421,7 +421,7 @@ func (j *jsonRenderer) renderTableContentJSONStream(table *TableContent, w io.Wr
 		for _, key := range keyOrder {
 			if val, exists := record[key]; exists {
 				// Find field for this key to apply formatter
-				field := table.Schema().FindField(key)
+				field := table.getSchema().FindField(key)
 				// Process field value and handle CollapsibleValue
 				processedVal := j.formatValueForJSON(val, field)
 				orderedRecord[key] = processedVal
@@ -696,7 +696,7 @@ func (y *yamlRenderer) renderTableContentYAML(table *TableContent) ([]byte, erro
 	schemaNode := &yaml.Node{Kind: yaml.MappingNode}
 
 	// Add keys array
-	keyOrder := table.Schema().GetKeyOrder()
+	keyOrder := table.getSchema().GetKeyOrder()
 	keysArrayNode := &yaml.Node{Kind: yaml.SequenceNode}
 	for _, key := range keyOrder {
 		keysArrayNode.Content = append(keysArrayNode.Content,
@@ -711,7 +711,7 @@ func (y *yamlRenderer) renderTableContentYAML(table *TableContent) ([]byte, erro
 
 	// Add fields array
 	fieldsArrayNode := &yaml.Node{Kind: yaml.SequenceNode}
-	for _, field := range table.Schema().Fields {
+	for _, field := range table.getSchema().Fields {
 		fieldNode := &yaml.Node{Kind: yaml.MappingNode}
 		fieldNode.Content = append(fieldNode.Content,
 			&yaml.Node{Kind: yaml.ScalarNode, Value: keyName},
@@ -743,7 +743,7 @@ func (y *yamlRenderer) renderTableContentYAML(table *TableContent) ([]byte, erro
 		for _, key := range keyOrder {
 			if val, exists := record[key]; exists {
 				// Find field for this key to apply formatter
-				field := table.Schema().FindField(key)
+				field := table.getSchema().FindField(key)
 				// Process field value and handle CollapsibleValue
 				processedVal := y.formatValueForYAML(val, field)
 				recordNode.Content = append(recordNode.Content,
@@ -896,9 +896,9 @@ func (y *yamlRenderer) renderTableContentYAMLStream(table *TableContent, w io.Wr
 	}
 
 	// Add schema information
-	keyOrder := table.Schema().GetKeyOrder()
-	fields := make([]map[string]any, 0, len(table.Schema().Fields))
-	for _, field := range table.Schema().Fields {
+	keyOrder := table.getSchema().GetKeyOrder()
+	fields := make([]map[string]any, 0, len(table.getSchema().Fields))
+	for _, field := range table.getSchema().Fields {
 		fieldMap := map[string]any{
 			keyName:   field.Name,
 			keyType:   field.Type,
@@ -921,7 +921,7 @@ func (y *yamlRenderer) renderTableContentYAMLStream(table *TableContent, w io.Wr
 		for _, key := range keyOrder {
 			if val, exists := record[key]; exists {
 				// Find field for this key to apply formatter
-				field := table.Schema().FindField(key)
+				field := table.getSchema().FindField(key)
 				// Process field value and handle CollapsibleValue
 				processedVal := y.formatValueForYAML(val, field)
 				orderedRecord[key] = processedVal

--- a/v2/markdown_renderer.go
+++ b/v2/markdown_renderer.go
@@ -176,7 +176,7 @@ func (m *markdownRenderer) renderTableContentMarkdown(table *TableContent) ([]by
 	}
 
 	// Get key order from schema
-	keyOrder := table.Schema().GetKeyOrder()
+	keyOrder := table.getSchema().GetKeyOrder()
 	if len(keyOrder) == 0 {
 		return []byte(""), nil // No columns to render
 	}
@@ -202,7 +202,7 @@ func (m *markdownRenderer) renderTableContentMarkdown(table *TableContent) ([]by
 			var cellValue string
 			if val, exists := record[key]; exists {
 				// Apply field formatter if available
-				field := table.Schema().FindField(key)
+				field := table.getSchema().FindField(key)
 				cellValue = m.formatCellValue(val, field)
 			}
 			// Escape markdown and handle newlines in table cells

--- a/v2/schema.go
+++ b/v2/schema.go
@@ -1,5 +1,7 @@
 package output
 
+import "slices"
+
 // Schema defines table structure with explicit key ordering
 type Schema struct {
 	Fields   []Field
@@ -14,18 +16,20 @@ type Field struct {
 	Hidden    bool
 }
 
-// GetKeyOrder returns the preserved key order for the schema
+// GetKeyOrder returns a copy of the preserved key order for the schema.
+// A copy is returned so callers cannot mutate the schema's internal key order.
 func (s *Schema) GetKeyOrder() []string {
 	if s.keyOrder != nil {
-		return s.keyOrder
+		return slices.Clone(s.keyOrder)
 	}
 	// If keyOrder is not set, extract from fields
 	return extractKeyOrder(s.Fields)
 }
 
-// SetKeyOrder explicitly sets the key order for the schema
+// SetKeyOrder explicitly sets the key order for the schema.
+// The provided slice is cloned so later caller mutations cannot change the schema.
 func (s *Schema) SetKeyOrder(keys []string) {
-	s.keyOrder = keys
+	s.keyOrder = slices.Clone(keys)
 }
 
 // extractKeyOrder preserves the exact order of fields
@@ -39,15 +43,17 @@ func extractKeyOrder(fields []Field) []string {
 	return keys
 }
 
-// NewSchemaFromFields creates a schema from field definitions with preserved order
+// NewSchemaFromFields creates a schema from field definitions with preserved order.
+// The provided slice is cloned so later caller mutations cannot change the schema.
 func NewSchemaFromFields(fields []Field) *Schema {
 	return &Schema{
-		Fields:   fields,
+		Fields:   slices.Clone(fields),
 		keyOrder: extractKeyOrder(fields),
 	}
 }
 
-// NewSchemaFromKeys creates a schema from simple key list
+// NewSchemaFromKeys creates a schema from simple key list.
+// The provided slice is cloned so later caller mutations cannot change the schema.
 func NewSchemaFromKeys(keys []string) *Schema {
 	fields := make([]Field, len(keys))
 	for i, key := range keys {
@@ -55,7 +61,7 @@ func NewSchemaFromKeys(keys []string) *Schema {
 	}
 	return &Schema{
 		Fields:   fields,
-		keyOrder: keys,
+		keyOrder: slices.Clone(keys),
 	}
 }
 
@@ -88,4 +94,16 @@ func (s *Schema) VisibleFieldCount() int {
 // GetFieldNames returns the field names in their preserved order
 func (s *Schema) GetFieldNames() []string {
 	return s.GetKeyOrder()
+}
+
+// clone returns a defensive copy of the schema with independent slices.
+// Field values are copied (formatters are shared, as functions are immutable).
+func (s *Schema) clone() *Schema {
+	if s == nil {
+		return nil
+	}
+	return &Schema{
+		Fields:   slices.Clone(s.Fields),
+		keyOrder: slices.Clone(s.keyOrder),
+	}
 }

--- a/v2/schema_test.go
+++ b/v2/schema_test.go
@@ -273,3 +273,65 @@ func TestFormatterFunction(t *testing.T) {
 		t.Errorf("Formatter result = %v, want 123", result)
 	}
 }
+
+// TestSchemaKeyOrderDefensiveCopy verifies that schema/key-order APIs do not leak
+// mutable caller-owned slices, which would break documented immutability of tables
+// (T-1086). Each subtest mutates a caller-owned slice (input or returned) and asserts
+// the schema's internal key order is unaffected.
+func TestSchemaKeyOrderDefensiveCopy(t *testing.T) {
+	t.Run("NewSchemaFromKeys does not retain caller slice", func(t *testing.T) {
+		keys := []string{"a", "b", "c"}
+		schema := NewSchemaFromKeys(keys)
+
+		// Mutate the caller's slice after passing it in.
+		keys[0] = "MUTATED"
+
+		got := schema.GetKeyOrder()
+		want := []string{"a", "b", "c"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("after mutating input slice, GetKeyOrder() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("SetKeyOrder does not retain caller slice", func(t *testing.T) {
+		schema := NewSchemaFromKeys([]string{"x"})
+		keys := []string{"a", "b", "c"}
+		schema.SetKeyOrder(keys)
+
+		// Mutate the caller's slice after setting it.
+		keys[1] = "MUTATED"
+
+		got := schema.GetKeyOrder()
+		want := []string{"a", "b", "c"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("after mutating input slice, GetKeyOrder() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("GetKeyOrder returns a copy", func(t *testing.T) {
+		schema := NewSchemaFromKeys([]string{"a", "b", "c"})
+
+		// Mutate the returned slice.
+		returned := schema.GetKeyOrder()
+		returned[0] = "MUTATED"
+
+		got := schema.GetKeyOrder()
+		want := []string{"a", "b", "c"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("after mutating returned slice, GetKeyOrder() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("NewSchemaFromFields does not retain caller fields slice", func(t *testing.T) {
+		fields := []Field{{Name: "a"}, {Name: "b"}, {Name: "c"}}
+		schema := NewSchemaFromFields(fields)
+
+		// Mutate the caller's slice after passing it in.
+		fields[0] = Field{Name: "MUTATED"}
+
+		if schema.Fields[0].Name != "a" {
+			t.Errorf("after mutating input fields, schema.Fields[0].Name = %q, want %q",
+				schema.Fields[0].Name, "a")
+		}
+	})
+}

--- a/v2/specs/bugfixes/schema-key-order-leaks-slices/report.md
+++ b/v2/specs/bugfixes/schema-key-order-leaks-slices/report.md
@@ -1,0 +1,127 @@
+# Bugfix Report: Schema Key Order Leaks Mutable Slices
+
+**Date:** 2026-05-24
+**Status:** Fixed
+
+## Description of the Issue
+
+The v2 schema/key-order APIs exposed and stored mutable caller-owned slices. This
+broke the documented immutability of `Document`/`TableContent` and allowed the
+rendered column order of a table to change after the table had been created
+(and after `Build()`).
+
+**Reproduction steps:**
+1. Create a table with `output.WithKeys("a", "b", "c")` (or build a `Schema` via
+   `NewSchemaFromKeys`/`NewSchemaFromFields`).
+2. Either mutate the slice that was passed in, mutate the slice returned by
+   `Schema().GetKeyOrder()`, or call `table.Schema().SetKeyOrder(...)` on a built
+   table.
+3. Observe that subsequent JSON/CSV/table/markdown/HTML renders use the changed
+   key order, violating the immutability/key-order guarantees.
+
+**Impact:** Medium. Any caller that retains a reference to an input slice, the
+returned key-order slice, or the schema pointer could silently corrupt the column
+order of an already-constructed table. The corruption is non-obvious because it
+happens through aliasing rather than an explicit API call.
+
+## Investigation Summary
+
+- **Symptoms examined:** Aliasing of caller-owned slices into schema internals and
+  exposure of schema internals to callers.
+- **Code inspected:** `v2/schema.go` (`GetKeyOrder`, `SetKeyOrder`,
+  `NewSchemaFromKeys`, `NewSchemaFromFields`), `v2/table_options.go` (`WithKeys`,
+  `WithSchema`), `v2/content.go` (`NewTableContent`, `TableContent.Schema()`), and
+  all read-side callers in the renderers/operations.
+- **Hypotheses tested:** Confirmed each leak point individually with targeted unit
+  tests that mutate a caller-owned slice and assert the schema's internal state is
+  unaffected. Verified that all renderer/operation call sites only read from the
+  schema (via `GetKeyOrder()`/`Fields`), so returning a copy from `Schema()` does
+  not break internal behaviour.
+
+## Discovered Root Cause
+
+The schema type stored slices by reference and returned them by reference without
+defensive copying. Go variadic spreads (`WithKeys(keys...)`, `WithSchema(fields...)`)
+pass the caller's backing array rather than a fresh copy, so even the options API
+leaked caller state.
+
+**Defect type:** Missing defensive copy / reference aliasing (immutability violation).
+
+**Why it occurred:** The schema constructors and accessors were written to assign
+and return slices directly. Slices in Go are reference types, so storing/returning
+them without copying shares the underlying backing array with the caller.
+
+**Contributing factors:** `keyOrder` is computed independently of `Fields`, which
+masked the `Fields` leak in any test that only checked key order — so the `Fields`
+aliasing was easy to miss.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `v2/schema.go` `GetKeyOrder()` - returns a copy of the key-order slice (and of the
+  extracted key order when `keyOrder` is nil).
+- `v2/schema.go` `SetKeyOrder()` - clones the caller slice before storing.
+- `v2/schema.go` `NewSchemaFromKeys()` - clones the caller `keys` slice.
+- `v2/schema.go` `NewSchemaFromFields()` - clones the caller `fields` slice.
+- `v2/table_options.go` `WithSchema()` - clones the variadic `fields` slice.
+- `v2/table_options.go` `WithKeys()` - clones the variadic `keys` slice.
+- `v2/content.go` `TableContent.Schema()` - returns a defensive copy of the schema so
+  callers cannot mutate the built table's schema internals.
+
+**Approach rationale:** Defensive copying on both input and output is the minimal,
+localized fix that restores the documented immutability without changing any public
+signatures. Returning a schema copy from `Schema()` prevents post-build mutation
+while keeping all internal read-only callers working unchanged.
+
+**Alternatives considered:**
+- Returning an unexported read-only schema view - More invasive; would require a new
+  type and touch every read call site. Rejected for being heavier than necessary.
+- Documenting the slices as "do not mutate" instead of copying - Rejected because it
+  does not actually enforce immutability and contradicts the existing `Records()`
+  pattern which already returns copies.
+
+## Regression Test
+
+**Test files:** `v2/schema_test.go`, `v2/table_options_test.go`
+**Test names:** `TestSchemaKeyOrderDefensiveCopy`, `TestTableSchemaDefensiveCopy`
+
+**What it verifies:** That mutating an input slice (`NewSchemaFromKeys`,
+`SetKeyOrder`, `NewSchemaFromFields`, `WithKeys`, `WithSchema`), mutating the slice
+returned from `GetKeyOrder()`, or calling `SetKeyOrder()` on a built table's schema
+does not alter the table's internal key order or fields.
+
+**Run command:**
+`cd v2 && go test . -run 'TestSchemaKeyOrderDefensiveCopy|TestTableSchemaDefensiveCopy'`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `v2/schema.go` | Clone slices in `GetKeyOrder`, `SetKeyOrder`, `NewSchemaFromKeys`, `NewSchemaFromFields` |
+| `v2/table_options.go` | Clone variadic slices in `WithKeys` and `WithSchema` |
+| `v2/content.go` | Return a defensive schema copy from `TableContent.Schema()` |
+| `v2/schema_test.go` | Add `TestSchemaKeyOrderDefensiveCopy` regression test |
+| `v2/table_options_test.go` | Add `TestTableSchemaDefensiveCopy` regression test |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Linters/validators pass
+
+**Manual verification:**
+- Confirmed all renderer/operation call sites only read from the schema, so the
+  `Schema()` copy does not change rendered output.
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Treat all slice/map fields on "immutable" types as copy-on-input and copy-on-output,
+  matching the existing `Records()` pattern.
+- When testing immutability, mutate the underlying field directly (e.g. `schema.Fields`)
+  rather than only checking derived values that may be computed independently.
+
+## Related
+
+- Transit ticket T-1086

--- a/v2/table_options.go
+++ b/v2/table_options.go
@@ -1,6 +1,9 @@
 package output
 
-import "sort"
+import (
+	"slices"
+	"sort"
+)
 
 // tableConfig holds configuration for table creation
 type tableConfig struct {
@@ -14,21 +17,23 @@ type tableConfig struct {
 // TableOption configures table creation
 type TableOption func(*tableConfig)
 
-// WithSchema explicitly sets the table schema with key order
+// WithSchema explicitly sets the table schema with key order.
+// The fields are cloned so later caller mutations cannot change the schema.
 func WithSchema(fields ...Field) TableOption {
 	return func(tc *tableConfig) {
 		tc.schema = &Schema{
-			Fields:   fields,
+			Fields:   slices.Clone(fields),
 			keyOrder: extractKeyOrder(fields),
 		}
 		tc.autoSchema = false
 	}
 }
 
-// WithKeys sets explicit key ordering (for v1 compatibility)
+// WithKeys sets explicit key ordering (for v1 compatibility).
+// The keys are cloned so later caller mutations cannot change the key order.
 func WithKeys(keys ...string) TableOption {
 	return func(tc *tableConfig) {
-		tc.keys = keys
+		tc.keys = slices.Clone(keys)
 		tc.autoSchema = false
 	}
 }

--- a/v2/table_options_test.go
+++ b/v2/table_options_test.go
@@ -274,3 +274,59 @@ func TestOptionsPreserveKeyOrder(t *testing.T) {
 		t.Errorf("WithAutoSchemaOrdered keys = %v, want %v", tc3.keys, orderedKeys)
 	}
 }
+
+// TestTableSchemaDefensiveCopy verifies that table options and built tables do not
+// leak mutable caller-owned slices into the resulting schema, preserving documented
+// table immutability after creation (T-1086).
+func TestTableSchemaDefensiveCopy(t *testing.T) {
+	data := []Record{{"a": 1, "b": 2, "c": 3}}
+
+	t.Run("WithKeys does not retain caller slice", func(t *testing.T) {
+		keys := []string{"a", "b", "c"}
+		table, err := NewTableContent("test", data, WithKeys(keys...))
+		if err != nil {
+			t.Fatalf("NewTableContent() error = %v", err)
+		}
+
+		// Mutate the caller's backing array after building the table.
+		keys[0] = "MUTATED"
+
+		got := table.Schema().GetKeyOrder()
+		want := []string{"a", "b", "c"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("after mutating WithKeys slice, key order = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("WithSchema does not retain caller fields", func(t *testing.T) {
+		fields := []Field{{Name: "a"}, {Name: "b"}, {Name: "c"}}
+		table, err := NewTableContent("test", data, WithSchema(fields...))
+		if err != nil {
+			t.Fatalf("NewTableContent() error = %v", err)
+		}
+
+		// Mutate the caller's backing array after building the table.
+		fields[0] = Field{Name: "MUTATED"}
+
+		if table.Schema().Fields[0].Name != "a" {
+			t.Errorf("after mutating WithSchema fields, schema.Fields[0].Name = %q, want %q",
+				table.Schema().Fields[0].Name, "a")
+		}
+	})
+
+	t.Run("post-build Schema mutation does not affect table", func(t *testing.T) {
+		table, err := NewTableContent("test", data, WithKeys("a", "b", "c"))
+		if err != nil {
+			t.Fatalf("NewTableContent() error = %v", err)
+		}
+
+		// A caller obtains the schema and attempts to reorder it after Build().
+		table.Schema().SetKeyOrder([]string{"c", "b", "a"})
+
+		got := table.Schema().GetKeyOrder()
+		want := []string{"a", "b", "c"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("after post-build SetKeyOrder, key order = %v, want %v", got, want)
+		}
+	})
+}

--- a/v2/table_renderer.go
+++ b/v2/table_renderer.go
@@ -192,7 +192,7 @@ func (t *tableRenderer) renderTable(tableContent *TableContent) table.Writer {
 	}
 
 	// Get key order from schema
-	keyOrder := tableContent.Schema().GetKeyOrder()
+	keyOrder := tableContent.getSchema().GetKeyOrder()
 	if len(keyOrder) == 0 {
 		return tw // Return empty table
 	}
@@ -222,7 +222,7 @@ func (t *tableRenderer) renderTable(tableContent *TableContent) table.Writer {
 		for i, key := range keyOrder {
 			if val, exists := record[key]; exists {
 				// Apply field formatter if available and format cell value
-				field := tableContent.Schema().FindField(key)
+				field := tableContent.getSchema().FindField(key)
 				row[i] = t.formatCellValue(val, field)
 			} else {
 				row[i] = ""


### PR DESCRIPTION
## Bug

The v2 schema/key-order APIs exposed and stored mutable caller-owned slices, breaking the documented immutability of `Document`/`TableContent`. A caller could change a built table's rendered column order after creation by:

- mutating a slice passed to `WithKeys` / `WithSchema` / `NewSchemaFromKeys` / `NewSchemaFromFields`,
- mutating the slice returned by `Schema().GetKeyOrder()`, or
- calling `table.Schema().SetKeyOrder(...)` on a built table.

Subsequent JSON/CSV/table/markdown/HTML renders then used the changed order. (T-1086)

## Root Cause

Slices are reference types in Go. The schema constructors/accessors assigned and returned slices directly without defensive copies, and Go variadic spreads (`WithKeys(keys...)`, `WithSchema(fields...)`) pass the caller's backing array rather than a copy. This shared the underlying array between the caller and the table's schema.

## Fix

Defensive copy on input and output:

- `GetKeyOrder()` returns a copy; `SetKeyOrder`, `NewSchemaFromKeys`, and `NewSchemaFromFields` clone their inputs.
- `WithKeys` and `WithSchema` clone their variadic slices.
- `TableContent.Schema()` returns a defensive copy via a new `Schema.clone()` helper (also reused by `Clone()`).
- Internal renderers switch to a new unexported `getSchema()` accessor that returns the live schema, avoiding per-call/per-row copies on read-only render paths.

No public signatures change.

## Tests

Added regression tests covering every leak point:

- `TestSchemaKeyOrderDefensiveCopy` (`v2/schema_test.go`)
- `TestTableSchemaDefensiveCopy` (`v2/table_options_test.go`)

These fail on the unfixed code and pass after the fix. Full unit suite passes; `gofmt`/`go vet` clean. Remaining `golangci-lint` `goconst` warnings are pre-existing and unrelated (count unchanged vs. baseline).

See `v2/specs/bugfixes/schema-key-order-leaks-slices/report.md` for the full bugfix report.