### PR TITLE
T-1343: Fix goconst lint failures breaking CI baseline

### DIFF
--- a/v2/base_renderer.go
+++ b/v2/base_renderer.go
@@ -36,12 +36,12 @@ type RendererConfig struct {
 var DefaultRendererConfig = RendererConfig{
 	ForceExpansion:       false,
 	MaxDetailLength:      500,
-	TruncateIndicator:    "[...truncated]",
+	TruncateIndicator:    truncateIndicatorText,
 	TableHiddenIndicator: "[details hidden - use --expand for full view]",
 	HTMLCSSClasses: map[string]string{
-		"details": "collapsible-cell",
-		"summary": "collapsible-summary",
-		"content": "collapsible-details",
+		keyDetails: "collapsible-cell",
+		keySummary: "collapsible-summary",
+		keyContent: "collapsible-details",
 	},
 	DataTransformers: make([]*TransformerAdapter, 0),
 	ByteTransformers: NewTransformPipeline(),

--- a/v2/collapsible.go
+++ b/v2/collapsible.go
@@ -58,7 +58,7 @@ func NewCollapsibleValue(summary string, details any, opts ...CollapsibleOption)
 		details:           details,
 		defaultExpanded:   false,
 		maxDetailLength:   500, // Default from requirements
-		truncateIndicator: "[...truncated]",
+		truncateIndicator: truncateIndicatorText,
 		formatHints:       make(map[string]map[string]any),
 		// Initialize performance optimization fields (Requirements 10.3, 10.5)
 		detailsProcessed: false,

--- a/v2/constants.go
+++ b/v2/constants.go
@@ -1,0 +1,52 @@
+package output
+
+// Content type name constants used by ContentType.String and renderers.
+const (
+	contentTypeNameRaw     = "raw"
+	contentTypeNameSection = "section"
+)
+
+// File extension constants that do not map directly to a format name.
+const (
+	extYML = "yml"
+)
+
+// Transformer name constants.
+const (
+	transformerNameColor = "color"
+)
+
+// Truncation indicator shared by collapsible rendering.
+const (
+	truncateIndicatorText = "[...truncated]"
+)
+
+// HTML document metadata defaults.
+const (
+	htmlCharsetUTF8 = "UTF-8"
+	htmlViewport    = "width=device-width, initial-scale=1.0"
+)
+
+// Field key constants used when building generic JSON/YAML representations
+// and CSV/collapsible output. These values are part of the serialization
+// contract, so they are defined once and reused.
+const (
+	keyType     = "type"
+	keyContent  = "content"
+	keyFormat   = "format"
+	keyData     = "data"
+	keyKeys     = "keys"
+	keyFields   = "fields"
+	keySummary  = "summary"
+	keyDetails  = "details"
+	keyExpanded = "expanded"
+	keyTitle    = "title"
+	keyLevel    = "level"
+	keyName     = "name"
+	keyHidden   = "hidden"
+	keyBold     = "bold"
+	keyItalic   = "italic"
+	keyColor    = "color"
+	keySize     = "size"
+	keyHeader   = "header"
+)

--- a/v2/content.go
+++ b/v2/content.go
@@ -31,13 +31,13 @@ const (
 func (ct ContentType) String() string {
 	switch ct {
 	case ContentTypeTable:
-		return "table"
+		return FormatTable
 	case ContentTypeText:
-		return "text"
+		return FormatText
 	case ContentTypeRaw:
-		return "raw"
+		return contentTypeNameRaw
 	case ContentTypeSection:
-		return "section"
+		return contentTypeNameSection
 	default:
 		return unknownValue
 	}
@@ -481,19 +481,19 @@ func (r *RawContent) AppendBinary(b []byte) ([]byte, error) {
 func isValidFormat(format string) bool {
 	// Define known valid formats
 	validFormats := map[string]bool{
-		"html":     true,
-		"css":      true,
-		"js":       true,
-		"json":     true,
-		"xml":      true,
-		"yaml":     true,
-		"markdown": true,
-		"text":     true,
-		"csv":      true,
-		"dot":      true,
-		"mermaid":  true,
-		"drawio":   true,
-		"svg":      true,
+		FormatHTML:     true,
+		"css":          true,
+		"js":           true,
+		FormatJSON:     true,
+		"xml":          true,
+		FormatYAML:     true,
+		FormatMarkdown: true,
+		FormatText:     true,
+		FormatCSV:      true,
+		FormatDOT:      true,
+		FormatMermaid:  true,
+		FormatDrawIO:   true,
+		"svg":          true,
 	}
 
 	return validFormats[format]

--- a/v2/csv_renderer.go
+++ b/v2/csv_renderer.go
@@ -18,7 +18,7 @@ type csvRenderer struct {
 }
 
 func (c *csvRenderer) Format() string {
-	return "csv"
+	return FormatCSV
 }
 
 func (c *csvRenderer) Render(ctx context.Context, doc *Document) ([]byte, error) {
@@ -161,13 +161,13 @@ func (c *csvRenderer) renderDocumentCSVTo(ctx context.Context, doc *Document, w 
 				contentText, err := content.AppendText(nil)
 				if err == nil && len(contentText) > 0 {
 					// Write simple header and content as CSV
-					if err := csvWriter.Write([]string{"content"}); err != nil {
+					if err := csvWriter.Write([]string{keyContent}); err != nil {
 						return fmt.Errorf("failed to write content header: %w", err)
 					}
 					if err := csvWriter.Write([]string{c.formatValueForCSV(string(contentText))}); err != nil {
 						return fmt.Errorf("failed to write content row: %w", err)
 					}
-					lastKeyOrder = []string{"content"}
+					lastKeyOrder = []string{keyContent}
 				}
 			}
 		}

--- a/v2/file_writer.go
+++ b/v2/file_writer.go
@@ -228,16 +228,16 @@ func (fw *FileWriter) validateFilename(filename string) error {
 // defaultExtensions returns the default format to extension mappings
 func defaultExtensions() map[string]string {
 	return map[string]string{
-		FormatJSON:     "json",
-		FormatYAML:     "yaml",
-		"yml":          "yml",
-		FormatCSV:      "csv",
-		FormatHTML:     "html",
+		FormatJSON:     FormatJSON,
+		FormatYAML:     FormatYAML,
+		extYML:         extYML,
+		FormatCSV:      FormatCSV,
+		FormatHTML:     FormatHTML,
 		FormatTable:    "txt",
 		FormatMarkdown: "md",
-		FormatDOT:      "dot",
+		FormatDOT:      FormatDOT,
 		FormatMermaid:  "mmd",
-		FormatDrawIO:   "csv", // Draw.io CSV format
+		FormatDrawIO:   FormatCSV, // Draw.io CSV format
 	}
 }
 

--- a/v2/format_aware.go
+++ b/v2/format_aware.go
@@ -16,32 +16,32 @@ func NewFormatDetector() *FormatDetector {
 
 // IsTextBasedFormat checks if a format supports text-based transformations
 func (fd *FormatDetector) IsTextBasedFormat(format string) bool {
-	textFormats := []string{"table", "markdown", "html", "csv", "yaml"}
+	textFormats := []string{FormatTable, FormatMarkdown, FormatHTML, FormatCSV, FormatYAML}
 	return slices.Contains(textFormats, format)
 }
 
 // IsStructuredFormat checks if a format is structured (like JSON, YAML)
 func (fd *FormatDetector) IsStructuredFormat(format string) bool {
-	structuredFormats := []string{"json", "yaml"}
+	structuredFormats := []string{FormatJSON, FormatYAML}
 	return slices.Contains(structuredFormats, format)
 }
 
 // IsTabularFormat checks if a format represents tabular data
 func (fd *FormatDetector) IsTabularFormat(format string) bool {
-	tabularFormats := []string{"table", "csv", "html", "markdown"}
+	tabularFormats := []string{FormatTable, FormatCSV, FormatHTML, FormatMarkdown}
 	return slices.Contains(tabularFormats, format)
 }
 
 // IsGraphFormat checks if a format is for graph/diagram output
 func (fd *FormatDetector) IsGraphFormat(format string) bool {
-	graphFormats := []string{"dot", "mermaid", "drawio"}
+	graphFormats := []string{FormatDOT, FormatMermaid, FormatDrawIO}
 	return slices.Contains(graphFormats, format)
 }
 
 // SupportsColors checks if a format supports ANSI color codes
 func (fd *FormatDetector) SupportsColors(format string) bool {
 	// Only terminal/console formats support ANSI colors
-	return format == "table"
+	return format == FormatTable
 }
 
 // SupportsEmoji checks if a format supports emoji characters
@@ -53,11 +53,11 @@ func (fd *FormatDetector) SupportsEmoji(format string) bool {
 // RequiresEscaping checks if a format requires special character escaping
 func (fd *FormatDetector) RequiresEscaping(format string) bool {
 	escapingFormats := map[string]bool{
-		"html":     true,
-		"markdown": true,
-		"csv":      true,
-		"json":     true,
-		"yaml":     true,
+		FormatHTML:     true,
+		FormatMarkdown: true,
+		FormatCSV:      true,
+		FormatJSON:     true,
+		FormatYAML:     true,
 	}
 	return escapingFormats[format]
 }
@@ -107,7 +107,7 @@ func (fat *FormatAwareTransformer) CanTransform(format string) bool {
 	switch fat.transformer.Name() {
 	case "emoji":
 		return fat.detector.SupportsEmoji(format)
-	case "color":
+	case transformerNameColor:
 		return fat.detector.SupportsColors(format)
 	case "sort":
 		return fat.detector.SupportsSorting(format)

--- a/v2/graph_content.go
+++ b/v2/graph_content.go
@@ -463,7 +463,7 @@ func DefaultDrawIOHeader() DrawIOHeader {
 		Label:        "%Name%",
 		Style:        "%Image%",
 		Ignore:       "Image",
-		Layout:       "auto",
+		Layout:       DrawIOLayoutAuto,
 		NodeSpacing:  40,
 		LevelSpacing: 100,
 		EdgeSpacing:  40,

--- a/v2/graph_renderers.go
+++ b/v2/graph_renderers.go
@@ -9,13 +9,40 @@ import (
 	"strings"
 )
 
+// Capitalised column-header tokens reused across the graph renderers.
+const (
+	colNameFrom        = "From"
+	colNameTo          = "To"
+	colNameLabel       = "Label"
+	colNameName        = "Name"
+	colNameDescription = "Description"
+)
+
+// Common column-name candidates used when extracting graph data from tables.
+// Defined once and shared by the DOT and Mermaid renderers to avoid repeating
+// the same string literals across functions.
+var (
+	graphFromColumns  = []string{"from", colNameFrom, "source", "Source", "start", "Start"}
+	graphToColumns    = []string{"to", colNameTo, "target", "Target", "end", "End", "dest", "Dest"}
+	graphLabelColumns = []string{"label", colNameLabel, "name", colNameName, "description", colNameDescription}
+
+	// Draw.io column-detection candidates extend the common candidates with a
+	// few additional names recognised by the Draw.io renderer.
+	drawioFromColumns  = append(append([]string{}, graphFromColumns...), "parent", "Parent")
+	drawioToColumns    = append(append([]string{}, graphToColumns...), "name", colNameName)
+	drawioLabelColumns = []string{"label", colNameLabel, "description", colNameDescription, "title", "Title"}
+
+	// drawioCSVColumnNames is the header row written for Draw.io CSV output.
+	drawioCSVColumnNames = []string{colNameName, colNameFrom, colNameTo, colNameLabel}
+)
+
 // dotRenderer implements DOT (Graphviz) output format
 type dotRenderer struct {
 	baseRenderer
 }
 
 func (d *dotRenderer) Format() string {
-	return "dot"
+	return FormatDOT
 }
 
 func (d *dotRenderer) Render(ctx context.Context, doc *Document) ([]byte, error) {
@@ -92,9 +119,9 @@ func (d *dotRenderer) renderGraphContent(buf *bytes.Buffer, graph *GraphContent)
 // extractGraphFromTable attempts to extract graph data from a table
 func (d *dotRenderer) extractGraphFromTable(table *TableContent) *GraphContent {
 	// Look for common from/to column names
-	fromColumns := []string{"from", "From", "source", "Source", "start", "Start"}
-	toColumns := []string{"to", "To", "target", "Target", "end", "End", "dest", "Dest"}
-	labelColumns := []string{"label", "Label", "name", "Name", "description", "Description"}
+	fromColumns := graphFromColumns
+	toColumns := graphToColumns
+	labelColumns := graphLabelColumns
 
 	var fromCol, toCol, labelCol string
 
@@ -137,7 +164,7 @@ type mermaidRenderer struct {
 }
 
 func (m *mermaidRenderer) Format() string {
-	return "mermaid"
+	return FormatMermaid
 }
 
 func (m *mermaidRenderer) Render(ctx context.Context, doc *Document) ([]byte, error) {
@@ -371,9 +398,9 @@ func (m *mermaidRenderer) renderFlowchartContent(buf *bytes.Buffer, chart *Chart
 // extractGraphFromTable attempts to extract graph data from a table
 func (m *mermaidRenderer) extractGraphFromTable(table *TableContent) *GraphContent {
 	// Look for common from/to column names
-	fromColumns := []string{"from", "From", "source", "Source", "start", "Start"}
-	toColumns := []string{"to", "To", "target", "Target", "end", "End", "dest", "Dest"}
-	labelColumns := []string{"label", "Label", "name", "Name", "description", "Description"}
+	fromColumns := graphFromColumns
+	toColumns := graphToColumns
+	labelColumns := graphLabelColumns
 
 	var fromCol, toCol, labelCol string
 
@@ -440,7 +467,7 @@ type drawioRenderer struct {
 }
 
 func (d *drawioRenderer) Format() string {
-	return "drawio"
+	return FormatDrawIO
 }
 
 func (d *drawioRenderer) Render(ctx context.Context, doc *Document) ([]byte, error) {
@@ -532,14 +559,18 @@ func (d *drawioRenderer) renderGraphAsDrawIO(buf *bytes.Buffer, graph *GraphCont
 	header := DefaultDrawIOHeader()
 	header.Label = "%Name%"
 	header.Connections = []DrawIOConnection{
-		{From: "From", To: "To", Label: "Label", Style: DrawIODefaultConnectionStyle},
+		{
+			From:  drawioCSVColumnNames[1],
+			To:    drawioCSVColumnNames[2],
+			Label: drawioCSVColumnNames[3],
+			Style: DrawIODefaultConnectionStyle,
+		},
 	}
 
 	d.writeDrawIOHeader(buf, header)
 
 	// Convert graph edges to CSV records
-	columnNames := []string{"Name", "From", "To", "Label"}
-	d.writeCSVRow(buf, columnNames)
+	d.writeCSVRow(buf, drawioCSVColumnNames)
 
 	// Write nodes first
 	nodes := graph.GetNodes()
@@ -720,9 +751,9 @@ func (d *drawioRenderer) extractColumnNames(records []Record) []string {
 
 // detectConnectionColumns tries to find from/to columns in table schema
 func (d *drawioRenderer) detectConnectionColumns(table *TableContent) (string, string, string) {
-	fromColumns := []string{"from", "From", "source", "Source", "start", "Start", "parent", "Parent"}
-	toColumns := []string{"to", "To", "target", "Target", "end", "End", "dest", "Dest", "name", "Name"}
-	labelColumns := []string{"label", "Label", "description", "Description", "title", "Title"}
+	fromColumns := drawioFromColumns
+	toColumns := drawioToColumns
+	labelColumns := drawioLabelColumns
 
 	var fromCol, toCol, labelCol string
 

--- a/v2/html_css.go
+++ b/v2/html_css.go
@@ -323,24 +323,24 @@ details[open] > *:not(summary) {
 	DefaultHTMLTemplate = &HTMLTemplate{
 		Title:    "Output Report",
 		Language: "en",
-		Charset:  "UTF-8",
-		Viewport: "width=device-width, initial-scale=1.0",
+		Charset:  htmlCharsetUTF8,
+		Viewport: htmlViewport,
 		CSS:      defaultResponsiveCSS,
 	}
 
 	MinimalHTMLTemplate = &HTMLTemplate{
 		Title:    "Output Report",
 		Language: "en",
-		Charset:  "UTF-8",
-		Viewport: "width=device-width, initial-scale=1.0",
+		Charset:  htmlCharsetUTF8,
+		Viewport: htmlViewport,
 		CSS:      "",
 	}
 
 	MermaidHTMLTemplate = &HTMLTemplate{
 		Title:    "Diagram Output",
 		Language: "en",
-		Charset:  "UTF-8",
-		Viewport: "width=device-width, initial-scale=1.0",
+		Charset:  htmlCharsetUTF8,
+		Viewport: htmlViewport,
 		CSS:      mermaidOptimizedCSS,
 	}
 }

--- a/v2/json_yaml_renderer.go
+++ b/v2/json_yaml_renderer.go
@@ -75,18 +75,18 @@ func renderDocumentGeneric(
 // buildTextContentData creates a generic representation of text content
 func buildTextContentData(text *TextContent) map[string]any {
 	result := map[string]any{
-		"type":    FormatText,
-		"content": text.Text(),
+		keyType:    FormatText,
+		keyContent: text.Text(),
 	}
 
 	style := text.Style()
 	if style.Bold || style.Italic || style.Color != "" || style.Size > 0 || style.Header {
 		result["style"] = map[string]any{
-			"bold":   style.Bold,
-			"italic": style.Italic,
-			"color":  style.Color,
-			"size":   style.Size,
-			"header": style.Header,
+			keyBold:   style.Bold,
+			keyItalic: style.Italic,
+			keyColor:  style.Color,
+			keySize:   style.Size,
+			keyHeader: style.Header,
 		}
 	}
 
@@ -96,9 +96,9 @@ func buildTextContentData(text *TextContent) map[string]any {
 // buildRawContentData creates a generic representation of raw content
 func buildRawContentData(raw *RawContent) map[string]any {
 	return map[string]any{
-		"type":   "raw",
-		"format": raw.Format(),
-		"data":   string(raw.Data()),
+		keyType:   contentTypeNameRaw,
+		keyFormat: raw.Format(),
+		keyData:   string(raw.Data()),
 	}
 }
 
@@ -199,7 +199,7 @@ func (j *jsonRenderer) renderTableContentJSON(table *TableContent) ([]byte, erro
 	result := make(map[string]any)
 
 	if table.Title() != "" {
-		result["title"] = table.Title()
+		result[keyTitle] = table.Title()
 	}
 
 	// Convert records to ordered map preserving key order
@@ -224,10 +224,10 @@ func (j *jsonRenderer) renderTableContentJSON(table *TableContent) ([]byte, erro
 		tableData = append(tableData, orderedRecord)
 	}
 
-	result["data"] = tableData
+	result[keyData] = tableData
 	result["schema"] = map[string]any{
-		"keys":   keyOrder,
-		"fields": j.convertFieldsToJSON(table.Schema()),
+		keyKeys:   keyOrder,
+		keyFields: j.convertFieldsToJSON(table.Schema()),
 	}
 
 	return json.MarshalIndent(result, "", "  ")
@@ -241,10 +241,10 @@ func (j *jsonRenderer) formatValueForJSON(val any, field *Field) any {
 	// Check if result is CollapsibleValue (Requirement 4.1)
 	if cv, ok := processed.(CollapsibleValue); ok {
 		result := map[string]any{
-			"type":     "collapsible",   // Requirement 4.1: type indication
-			"summary":  cv.Summary(),    // Requirement 4.2: include summary
-			"details":  cv.Details(),    // Requirement 4.2: include details
-			"expanded": cv.IsExpanded(), // Requirement 4.2: include expanded
+			keyType:     "collapsible",   // Requirement 4.1: type indication
+			keySummary:  cv.Summary(),    // Requirement 4.2: include summary
+			keyDetails:  cv.Details(),    // Requirement 4.2: include details
+			keyExpanded: cv.IsExpanded(), // Requirement 4.2: include expanded
 		}
 
 		// Add format-specific hints (Requirement 4.3)
@@ -273,9 +273,9 @@ func (j *jsonRenderer) renderRawContentJSON(raw *RawContent) ([]byte, error) {
 // renderSectionContentJSON renders section content as JSON with nested content
 func (j *jsonRenderer) renderSectionContentJSON(section *SectionContent) ([]byte, error) {
 	result := map[string]any{
-		"type":  "section",
-		"title": section.Title(),
-		"level": section.Level(),
+		keyType:  contentTypeNameSection,
+		keyTitle: section.Title(),
+		keyLevel: section.Level(),
 	}
 
 	var contents []any
@@ -309,9 +309,9 @@ func (j *jsonRenderer) convertFieldsToJSON(schema *Schema) []map[string]any {
 
 	for _, field := range schema.Fields {
 		fieldMap := map[string]any{
-			"name":   field.Name,
-			"type":   field.Type,
-			"hidden": field.Hidden,
+			keyName:   field.Name,
+			keyType:   field.Type,
+			keyHidden: field.Hidden,
 		}
 		fields = append(fields, fieldMap)
 	}
@@ -330,14 +330,14 @@ func (j *jsonRenderer) renderTableContentJSONStream(table *TableContent, w io.Wr
 	result := make(map[string]any)
 
 	if table.Title() != "" {
-		result["title"] = table.Title()
+		result[keyTitle] = table.Title()
 	}
 
 	// Add schema information
 	keyOrder := table.Schema().GetKeyOrder()
 	result["schema"] = map[string]any{
-		"keys":   keyOrder,
-		"fields": j.convertFieldsToJSON(table.Schema()),
+		keyKeys:   keyOrder,
+		keyFields: j.convertFieldsToJSON(table.Schema()),
 	}
 
 	// For streaming, we need to handle data differently
@@ -455,18 +455,18 @@ func (j *jsonRenderer) renderTextContentJSONStream(text *TextContent, w io.Write
 	encoder.SetIndent("", "  ")
 
 	result := map[string]any{
-		"type":    FormatText,
-		"content": text.Text(),
+		keyType:    FormatText,
+		keyContent: text.Text(),
 	}
 
 	style := text.Style()
 	if style.Bold || style.Italic || style.Color != "" || style.Size > 0 || style.Header {
 		result["style"] = map[string]any{
-			"bold":   style.Bold,
-			"italic": style.Italic,
-			"color":  style.Color,
-			"size":   style.Size,
-			"header": style.Header,
+			keyBold:   style.Bold,
+			keyItalic: style.Italic,
+			keyColor:  style.Color,
+			keySize:   style.Size,
+			keyHeader: style.Header,
 		}
 	}
 
@@ -479,9 +479,9 @@ func (j *jsonRenderer) renderRawContentJSONStream(raw *RawContent, w io.Writer) 
 	encoder.SetIndent("", "  ")
 
 	result := map[string]any{
-		"type":   "raw",
-		"format": raw.Format(),
-		"data":   string(raw.Data()),
+		keyType:   contentTypeNameRaw,
+		keyFormat: raw.Format(),
+		keyData:   string(raw.Data()),
 	}
 
 	return encoder.Encode(result)
@@ -558,10 +558,10 @@ func (j *jsonRenderer) renderSectionContentJSONStream(section *SectionContent, w
 // renderChartContentJSON renders ChartContent as JSON
 func (j *jsonRenderer) renderChartContentJSON(content *ChartContent) ([]byte, error) {
 	chartData := map[string]any{
-		"type":       content.Type(),
-		"title":      content.GetTitle(),
+		keyType:      content.Type(),
+		keyTitle:     content.GetTitle(),
 		"chart_type": content.GetChartType(),
-		"data":       content.GetData(),
+		keyData:      content.GetData(),
 	}
 	return json.MarshalIndent(chartData, "", "  ")
 }
@@ -569,10 +569,10 @@ func (j *jsonRenderer) renderChartContentJSON(content *ChartContent) ([]byte, er
 // renderGraphContentJSON renders GraphContent as JSON
 func (j *jsonRenderer) renderGraphContentJSON(content *GraphContent) ([]byte, error) {
 	graphData := map[string]any{
-		"type":  content.Type(),
-		"title": content.GetTitle(),
-		"nodes": content.GetNodes(),
-		"edges": content.GetEdges(),
+		keyType:  content.Type(),
+		keyTitle: content.GetTitle(),
+		"nodes":  content.GetNodes(),
+		"edges":  content.GetEdges(),
 	}
 	return json.MarshalIndent(graphData, "", "  ")
 }
@@ -580,10 +580,10 @@ func (j *jsonRenderer) renderGraphContentJSON(content *GraphContent) ([]byte, er
 // renderDrawIOContentJSON renders DrawIOContent as JSON
 func (j *jsonRenderer) renderDrawIOContentJSON(content *DrawIOContent) ([]byte, error) {
 	drawioData := map[string]any{
-		"type":    content.Type(),
-		"title":   content.GetTitle(),
+		keyType:   content.Type(),
+		keyTitle:  content.GetTitle(),
 		"records": content.GetRecords(),
-		"header":  content.GetHeader(),
+		keyHeader: content.GetHeader(),
 	}
 	return json.MarshalIndent(drawioData, "", "  ")
 }
@@ -687,7 +687,7 @@ func (y *yamlRenderer) renderTableContentYAML(table *TableContent) ([]byte, erro
 	// Add title if present
 	if table.Title() != "" {
 		result.Content = append(result.Content,
-			&yaml.Node{Kind: yaml.ScalarNode, Value: "title"},
+			&yaml.Node{Kind: yaml.ScalarNode, Value: keyTitle},
 			&yaml.Node{Kind: yaml.ScalarNode, Value: table.Title()},
 		)
 	}
@@ -705,7 +705,7 @@ func (y *yamlRenderer) renderTableContentYAML(table *TableContent) ([]byte, erro
 	}
 
 	schemaNode.Content = append(schemaNode.Content,
-		&yaml.Node{Kind: yaml.ScalarNode, Value: "keys"},
+		&yaml.Node{Kind: yaml.ScalarNode, Value: keyKeys},
 		keysArrayNode,
 	)
 
@@ -714,18 +714,18 @@ func (y *yamlRenderer) renderTableContentYAML(table *TableContent) ([]byte, erro
 	for _, field := range table.Schema().Fields {
 		fieldNode := &yaml.Node{Kind: yaml.MappingNode}
 		fieldNode.Content = append(fieldNode.Content,
-			&yaml.Node{Kind: yaml.ScalarNode, Value: "name"},
+			&yaml.Node{Kind: yaml.ScalarNode, Value: keyName},
 			&yaml.Node{Kind: yaml.ScalarNode, Value: field.Name},
-			&yaml.Node{Kind: yaml.ScalarNode, Value: "type"},
+			&yaml.Node{Kind: yaml.ScalarNode, Value: keyType},
 			&yaml.Node{Kind: yaml.ScalarNode, Value: field.Type},
-			&yaml.Node{Kind: yaml.ScalarNode, Value: "hidden"},
+			&yaml.Node{Kind: yaml.ScalarNode, Value: keyHidden},
 			y.createYAMLValueNode(field.Hidden),
 		)
 		fieldsArrayNode.Content = append(fieldsArrayNode.Content, fieldNode)
 	}
 
 	schemaNode.Content = append(schemaNode.Content,
-		&yaml.Node{Kind: yaml.ScalarNode, Value: "fields"},
+		&yaml.Node{Kind: yaml.ScalarNode, Value: keyFields},
 		fieldsArrayNode,
 	)
 
@@ -757,7 +757,7 @@ func (y *yamlRenderer) renderTableContentYAML(table *TableContent) ([]byte, erro
 	}
 
 	result.Content = append(result.Content,
-		&yaml.Node{Kind: yaml.ScalarNode, Value: "data"},
+		&yaml.Node{Kind: yaml.ScalarNode, Value: keyData},
 		dataArrayNode,
 	)
 
@@ -779,9 +779,9 @@ func (y *yamlRenderer) renderRawContentYAML(raw *RawContent) ([]byte, error) {
 // renderSectionContentYAML renders section content as YAML with nested content
 func (y *yamlRenderer) renderSectionContentYAML(section *SectionContent) ([]byte, error) {
 	result := map[string]any{
-		"type":  "section",
-		"title": section.Title(),
-		"level": section.Level(),
+		keyType:  contentTypeNameSection,
+		keyTitle: section.Title(),
+		keyLevel: section.Level(),
 	}
 
 	var contents []any
@@ -863,9 +863,9 @@ func (y *yamlRenderer) formatValueForYAML(val any, field *Field) any {
 	// Check if result is CollapsibleValue (Requirement 5.1)
 	if cv, ok := processed.(CollapsibleValue); ok {
 		result := map[string]any{
-			"summary":  cv.Summary(), // Requirement 5.1: YAML mapping
-			"details":  cv.Details(), // Requirement 5.1: with these fields
-			"expanded": cv.IsExpanded(),
+			keySummary:  cv.Summary(), // Requirement 5.1: YAML mapping
+			keyDetails:  cv.Details(), // Requirement 5.1: with these fields
+			keyExpanded: cv.IsExpanded(),
 		}
 
 		// YAML-specific formatting hints (Requirement 5.2)
@@ -892,7 +892,7 @@ func (y *yamlRenderer) renderTableContentYAMLStream(table *TableContent, w io.Wr
 	result := make(map[string]any)
 
 	if table.Title() != "" {
-		result["title"] = table.Title()
+		result[keyTitle] = table.Title()
 	}
 
 	// Add schema information
@@ -900,16 +900,16 @@ func (y *yamlRenderer) renderTableContentYAMLStream(table *TableContent, w io.Wr
 	fields := make([]map[string]any, 0, len(table.Schema().Fields))
 	for _, field := range table.Schema().Fields {
 		fieldMap := map[string]any{
-			"name":   field.Name,
-			"type":   field.Type,
-			"hidden": field.Hidden,
+			keyName:   field.Name,
+			keyType:   field.Type,
+			keyHidden: field.Hidden,
 		}
 		fields = append(fields, fieldMap)
 	}
 
 	result["schema"] = map[string]any{
-		"keys":   keyOrder,
-		"fields": fields,
+		keyKeys:   keyOrder,
+		keyFields: fields,
 	}
 
 	// Convert records to ordered maps preserving key order
@@ -931,7 +931,7 @@ func (y *yamlRenderer) renderTableContentYAMLStream(table *TableContent, w io.Wr
 		tableData = append(tableData, orderedRecord)
 	}
 
-	result["data"] = tableData
+	result[keyData] = tableData
 
 	return encoder.Encode(result)
 }
@@ -944,18 +944,18 @@ func (y *yamlRenderer) renderTextContentYAMLStream(text *TextContent, w io.Write
 	}()
 
 	result := map[string]any{
-		"type":    FormatText,
-		"content": text.Text(),
+		keyType:    FormatText,
+		keyContent: text.Text(),
 	}
 
 	style := text.Style()
 	if style.Bold || style.Italic || style.Color != "" || style.Size > 0 || style.Header {
 		result["style"] = map[string]any{
-			"bold":   style.Bold,
-			"italic": style.Italic,
-			"color":  style.Color,
-			"size":   style.Size,
-			"header": style.Header,
+			keyBold:   style.Bold,
+			keyItalic: style.Italic,
+			keyColor:  style.Color,
+			keySize:   style.Size,
+			keyHeader: style.Header,
 		}
 	}
 
@@ -970,9 +970,9 @@ func (y *yamlRenderer) renderRawContentYAMLStream(raw *RawContent, w io.Writer) 
 	}()
 
 	result := map[string]any{
-		"type":   "raw",
-		"format": raw.Format(),
-		"data":   string(raw.Data()),
+		keyType:   contentTypeNameRaw,
+		keyFormat: raw.Format(),
+		keyData:   string(raw.Data()),
 	}
 
 	return encoder.Encode(result)
@@ -986,9 +986,9 @@ func (y *yamlRenderer) renderSectionContentYAMLStream(section *SectionContent, w
 	}()
 
 	result := map[string]any{
-		"type":  "section",
-		"title": section.Title(),
-		"level": section.Level(),
+		keyType:  contentTypeNameSection,
+		keyTitle: section.Title(),
+		keyLevel: section.Level(),
 	}
 
 	var contents []any
@@ -1019,10 +1019,10 @@ func (y *yamlRenderer) renderSectionContentYAMLStream(section *SectionContent, w
 // renderChartContentYAML renders ChartContent as YAML
 func (y *yamlRenderer) renderChartContentYAML(content *ChartContent) ([]byte, error) {
 	chartData := map[string]any{
-		"type":       content.Type(),
-		"title":      content.GetTitle(),
+		keyType:      content.Type(),
+		keyTitle:     content.GetTitle(),
 		"chart_type": content.GetChartType(),
-		"data":       content.GetData(),
+		keyData:      content.GetData(),
 	}
 	return yaml.Marshal(chartData)
 }
@@ -1030,10 +1030,10 @@ func (y *yamlRenderer) renderChartContentYAML(content *ChartContent) ([]byte, er
 // renderGraphContentYAML renders GraphContent as YAML
 func (y *yamlRenderer) renderGraphContentYAML(content *GraphContent) ([]byte, error) {
 	graphData := map[string]any{
-		"type":  content.Type(),
-		"title": content.GetTitle(),
-		"nodes": content.GetNodes(),
-		"edges": content.GetEdges(),
+		keyType:  content.Type(),
+		keyTitle: content.GetTitle(),
+		"nodes":  content.GetNodes(),
+		"edges":  content.GetEdges(),
 	}
 	return yaml.Marshal(graphData)
 }
@@ -1041,10 +1041,10 @@ func (y *yamlRenderer) renderGraphContentYAML(content *GraphContent) ([]byte, er
 // renderDrawIOContentYAML renders DrawIOContent as YAML
 func (y *yamlRenderer) renderDrawIOContentYAML(content *DrawIOContent) ([]byte, error) {
 	drawioData := map[string]any{
-		"type":    content.Type(),
-		"title":   content.GetTitle(),
+		keyType:   content.Type(),
+		keyTitle:  content.GetTitle(),
 		"records": content.GetRecords(),
-		"header":  content.GetHeader(),
+		keyHeader: content.GetHeader(),
 	}
 	return yaml.Marshal(drawioData)
 }
@@ -1052,10 +1052,10 @@ func (y *yamlRenderer) renderDrawIOContentYAML(content *DrawIOContent) ([]byte, 
 // renderCollapsibleSectionJSON renders a CollapsibleSection as structured JSON (Requirement 15.5)
 func (j *jsonRenderer) renderCollapsibleSectionJSON(section *DefaultCollapsibleSection) ([]byte, error) {
 	result := map[string]any{
-		"type":     "collapsible_section", // Requirement 15.5: type indication
-		"title":    section.Title(),       // Requirement 15.5: section metadata
-		"level":    section.Level(),       // Requirement 15.5: section metadata
-		"expanded": section.IsExpanded(),  // Requirement 15.5: section metadata
+		keyType:     "collapsible_section", // Requirement 15.5: type indication
+		keyTitle:    section.Title(),       // Requirement 15.5: section metadata
+		keyLevel:    section.Level(),       // Requirement 15.5: section metadata
+		keyExpanded: section.IsExpanded(),  // Requirement 15.5: section metadata
 	}
 
 	// Render nested content (Requirement 15.5: nested content)
@@ -1073,7 +1073,7 @@ func (j *jsonRenderer) renderCollapsibleSectionJSON(section *DefaultCollapsibleS
 		contentArray = append(contentArray, contentData)
 	}
 
-	result["content"] = contentArray // Requirement 15.5: nested content array
+	result[keyContent] = contentArray // Requirement 15.5: nested content array
 
 	// Add format-specific hints (Requirement 15.5)
 	if hints := section.FormatHint(FormatJSON); hints != nil {
@@ -1086,10 +1086,10 @@ func (j *jsonRenderer) renderCollapsibleSectionJSON(section *DefaultCollapsibleS
 // renderCollapsibleSectionYAML renders a CollapsibleSection as structured YAML (Requirement 15.5)
 func (y *yamlRenderer) renderCollapsibleSectionYAML(section *DefaultCollapsibleSection) ([]byte, error) {
 	result := map[string]any{
-		"type":     "collapsible_section", // Requirement 15.5: type indication
-		"title":    section.Title(),       // Requirement 15.5: section metadata
-		"level":    section.Level(),       // Requirement 15.5: section metadata
-		"expanded": section.IsExpanded(),  // Requirement 15.5: section metadata
+		keyType:     "collapsible_section", // Requirement 15.5: type indication
+		keyTitle:    section.Title(),       // Requirement 15.5: section metadata
+		keyLevel:    section.Level(),       // Requirement 15.5: section metadata
+		keyExpanded: section.IsExpanded(),  // Requirement 15.5: section metadata
 	}
 
 	// Render nested content as YAML structures (Requirement 15.5: nested content)
@@ -1107,7 +1107,7 @@ func (y *yamlRenderer) renderCollapsibleSectionYAML(section *DefaultCollapsibleS
 		contentArray = append(contentArray, contentData)
 	}
 
-	result["content"] = contentArray // Requirement 15.5: nested content array
+	result[keyContent] = contentArray // Requirement 15.5: nested content array
 
 	// Add format-specific hints for YAML structure (Requirement 15.5)
 	if hints := section.FormatHint(FormatYAML); hints != nil {

--- a/v2/s3_writer.go
+++ b/v2/s3_writer.go
@@ -347,16 +347,16 @@ func (sw *S3Writer) getContentType(format string) string {
 // defaultContentTypes returns default format to content-type mappings
 func defaultContentTypes() map[string]string {
 	return map[string]string{
-		"json":     "application/json",
-		"yaml":     "application/x-yaml",
-		"yml":      "application/x-yaml",
-		"csv":      "text/csv",
-		"html":     "text/html",
-		"table":    "text/plain",
-		"markdown": "text/markdown",
-		"dot":      "text/vnd.graphviz",
-		"mermaid":  "text/plain",
-		"drawio":   "text/csv",
+		FormatJSON:     "application/json",
+		FormatYAML:     "application/x-yaml",
+		extYML:         "application/x-yaml",
+		FormatCSV:      "text/csv",
+		FormatHTML:     "text/html",
+		FormatTable:    "text/plain",
+		FormatMarkdown: "text/markdown",
+		FormatDOT:      "text/vnd.graphviz",
+		FormatMermaid:  "text/plain",
+		FormatDrawIO:   "text/csv",
 	}
 }
 

--- a/v2/transformer.go
+++ b/v2/transformer.go
@@ -164,7 +164,7 @@ func (tp *TransformPipeline) Info() []TransformInfo {
 	for _, t := range tp.transformers {
 		// Test common formats to see which ones this transformer supports
 		formats := make([]string, 0)
-		testFormats := []string{"json", "yaml", "csv", "html", "table", "markdown", "dot", "mermaid", "drawio"}
+		testFormats := []string{FormatJSON, FormatYAML, FormatCSV, FormatHTML, FormatTable, FormatMarkdown, FormatDOT, FormatMermaid, FormatDrawIO}
 		for _, format := range testFormats {
 			if t.CanTransform(format) {
 				formats = append(formats, format)

--- a/v2/transformers.go
+++ b/v2/transformers.go
@@ -95,7 +95,7 @@ func NewColorTransformerWithScheme(scheme ColorScheme) *ColorTransformer {
 
 // Name returns the transformer name
 func (c *ColorTransformer) Name() string {
-	return "color"
+	return transformerNameColor
 }
 
 // Priority returns the transformer priority (lower = earlier)


### PR DESCRIPTION
## Problem

CI (`.github/workflows/push.yaml`) pins `golangci-lint` to `version: latest`. A newer golangci-lint release now flags **70 pre-existing `goconst` issues** in v2 (concentrated in `s3_writer.go`, `transformer.go`, `transformers.go`, plus several other files goconst counts package-wide). main's last green CI run predates this; the code was unchanged, so this is purely **golangci-lint version drift**. The result is that `main` fails the lint step, blocking all PR merges.

The `v2/.golangci.yml` enables `goconst` with `max-issues-per-linter: 0` and `max-same-issues: 0`, so every occurrence is reported.

## Fix

Pure literal -> constant substitution, behavior-preserving (no logic changes):

- Replaced repeated format-name string literals (`"json"`, `"yaml"`, `"csv"`, `"html"`, `"table"`, `"markdown"`, `"dot"`, `"mermaid"`, `"drawio"`) with the existing `FormatJSON`/`FormatYAML`/... constants. These are untyped string constants, so they drop straight into `map[string]string` and `[]string` without conversion.
- Reused `DrawIOLayoutAuto` for the Draw.io layout value.
- Added new constants in a new `v2/constants.go` for literals that had none: the `"yml"` extension, the `"color"` transformer name, the collapsible truncate indicator, HTML charset/viewport defaults, and the JSON/YAML field-key strings (`type`, `content`, `format`, `data`, `keys`, `fields`, `summary`, `details`, `expanded`, `title`, `level`, `name`, `hidden`, `bold`, `italic`, `color`, `size`, `header`) plus content-type names (`raw`, `section`).
- Refactored the duplicated graph column-matching slices in `graph_renderers.go` into shared package-level `var` slices (DOT/Mermaid share one set; Draw.io extends it), eliminating the repeated column-name literals at the source rather than scattering single-use constants.

The string values are unchanged, so JSON/YAML/CSV output and all detection logic are byte-identical.

## Verification

- `golangci-lint run` in `v2/`: **0 issues** (was 70 goconst).
- `go build ./...`: clean.
- `go test ./...` (full v2 unit suite): pass.
- `gofmt -l .`: clean.