### PR TITLE
Fix T-1272: Transformations Example Fails Go Test Vet Checks

### DIFF
--- a/v2/examples/transformations/main.go
+++ b/v2/examples/transformations/main.go
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	fmt.Println("=== Per-Content Transformations Examples ===\n")
+	fmt.Print("=== Per-Content Transformations Examples ===\n\n")
 
 	// Example 1: Basic filter + sort transformations
 	basicFilterAndSort()
@@ -68,7 +68,7 @@ func basicFilterAndSort() {
 		log.Printf("Error rendering: %v\n", err)
 	}
 
-	fmt.Println("\n")
+	fmt.Print("\n\n")
 }
 
 // Example 2: Multiple tables with different transformations
@@ -126,7 +126,7 @@ func multipleTables() {
 		log.Printf("Error rendering: %v\n", err)
 	}
 
-	fmt.Println("\n")
+	fmt.Print("\n\n")
 }
 
 // Example 3: Dynamic transformation construction
@@ -197,7 +197,7 @@ func dynamicTransformations() {
 		log.Printf("Error rendering: %v\n", err)
 	}
 
-	fmt.Println("\n")
+	fmt.Print("\n\n")
 }
 
 // Example 4: Error handling
@@ -231,7 +231,7 @@ func errorHandling() {
 	if err := out.Render(context.Background(), doc); err != nil {
 		fmt.Printf("✓ Expected error caught: %v\n\n", err)
 	} else {
-		fmt.Println("✗ Expected error but got none\n")
+		fmt.Print("✗ Expected error but got none\n\n")
 	}
 
 	// Example 4b: Invalid operation configuration (negative limit)
@@ -240,7 +240,7 @@ func errorHandling() {
 	if err := invalidOp.Validate(); err != nil {
 		fmt.Printf("✓ Validation error caught: %v\n\n", err)
 	} else {
-		fmt.Println("✗ Expected validation error but got none\n")
+		fmt.Print("✗ Expected validation error but got none\n\n")
 	}
 
 	// Example 4c: Successful rendering with proper error checking


### PR DESCRIPTION
## Bug

Running `go test ./...` inside the standalone module `v2/examples/transformations` failed. Because `go test` runs `go vet` by default for package tests, the `printf` analyzer flagged six `fmt.Println` calls whose argument lists already ended with a newline (`main.go` lines 13, 71, 129, 200, 234, 243).

## Root cause

`fmt.Println` appends its own trailing newline, so passing a string that already ends in `\n` (or a lone `"\n"`) produces a redundant newline. `go vet` reports `fmt.Println arg list ends with redundant newline` for each, failing normal validation of the example module.

## Fix

Replaced the six offending `fmt.Println` calls with `fmt.Print` using explicit `\n\n`. This preserves the exact printed output (a line followed by a trailing blank line used for section spacing) while resolving the vet findings.

## Verification

- `go test ./...` and `go vet ./...` are clean in `v2/examples/transformations`
- `make test` passes for the main v2 module

Fixes T-1272.