### PR TITLE
Fix T-1105: GroupBy Accepts Nil Aggregate Functions

### DIFF
--- a/v2/operations.go
+++ b/v2/operations.go
@@ -625,10 +625,14 @@ func (o *GroupByOp) Validate() error {
 		return NewValidationError("aggregates", o.aggregates, "groupBy operation requires at least one aggregate function")
 	}
 
-	// Validate aggregate function names
-	for aggName := range o.aggregates {
+	// Validate aggregate function names and functions
+	for aggName, aggFunc := range o.aggregates {
 		if aggName == "" {
 			return NewValidationError("aggregate_name", aggName, "aggregate function name cannot be empty")
+		}
+		if aggFunc == nil {
+			return NewValidationError("aggregate_function", aggName,
+				fmt.Sprintf("aggregate function for '%s' is required and cannot be nil", aggName))
 		}
 	}
 

--- a/v2/operations_aggregate_test.go
+++ b/v2/operations_aggregate_test.go
@@ -651,3 +651,77 @@ func TestGroupByCompositeKeyCollision(t *testing.T) {
 		}
 	})
 }
+
+// TestGroupByNilAggregateFunc is a regression test for T-1105.
+//
+// The bug: GroupByOp.Validate checked that aggregate names were non-empty but
+// did not reject nil AggregateFunc values. A GroupByOp such as
+//
+//	NewGroupByOp([]string{"department"}, map[string]AggregateFunc{"count": nil})
+//
+// passed validation, then Apply panicked when it called aggFunc(groupRecords, field).
+//
+// Expected: Validate returns a normal validation error, and the render-time
+// per-content transformation path reports that error instead of panicking.
+func TestGroupByNilAggregateFunc(t *testing.T) {
+	t.Run("Validate rejects a nil aggregate function", func(t *testing.T) {
+		groupByOp := NewGroupByOp([]string{"department"}, map[string]AggregateFunc{
+			"count": nil,
+		})
+
+		err := groupByOp.Validate()
+		if err == nil {
+			t.Fatal("expected validation error for nil aggregate function, got nil")
+		}
+
+		if !strings.Contains(err.Error(), "count") {
+			t.Errorf("expected error to reference the offending aggregate name 'count', got %q", err.Error())
+		}
+		if !strings.Contains(err.Error(), "cannot be nil") {
+			t.Errorf("expected error to explain the function cannot be nil, got %q", err.Error())
+		}
+	})
+
+	t.Run("Validate rejects a nil function among valid functions", func(t *testing.T) {
+		groupByOp := NewGroupByOp([]string{"department"}, map[string]AggregateFunc{
+			"count":        CountAggregate(),
+			"total_salary": nil,
+		})
+
+		err := groupByOp.Validate()
+		if err == nil {
+			t.Fatal("expected validation error for nil aggregate function, got nil")
+		}
+		if !strings.Contains(err.Error(), "total_salary") {
+			t.Errorf("expected error to reference the offending aggregate name 'total_salary', got %q", err.Error())
+		}
+	})
+
+	t.Run("render-time transformation reports nil aggregate as an error not a panic", func(t *testing.T) {
+		// Attach a GroupByOp with a nil aggregate function as a per-content
+		// transformation. Rendering must surface a validation error rather
+		// than panicking inside Apply.
+		doc := New().
+			Table("test", []Record{
+				{"department": "eng", "salary": 100},
+				{"department": "eng", "salary": 120},
+			},
+				WithKeys("department", "salary"),
+				WithTransformations(
+					NewGroupByOp([]string{"department"}, map[string]AggregateFunc{
+						"count": nil,
+					}),
+				),
+			).
+			Build()
+
+		renderer := &tableRenderer{styleName: "Default"}
+		_, err := renderer.Render(context.Background(), doc)
+		if err == nil {
+			t.Fatal("expected render error for nil aggregate function, got nil")
+		}
+		if !strings.Contains(err.Error(), "cannot be nil") {
+			t.Errorf("expected render error to explain the function cannot be nil, got %q", err.Error())
+		}
+	})
+}


### PR DESCRIPTION
## Bug

`GroupByOp.Validate` (`v2/operations.go`) checked that aggregate names were non-empty but did not reject nil `AggregateFunc` values. A group-by such as:

```go
NewGroupByOp([]string{"department"}, map[string]AggregateFunc{"count": nil})
```

passed validation, then `Apply` panicked with a nil pointer dereference when it called `aggFunc(groupRecords, field)` (operations.go:498). The panic is reachable through the render path because `applyContentTransformations` validates then applies each per-content transformation.

## Root cause

Missing validation. The aggregate validation loop guarded only the aggregate *name* (`aggName == ""`) and never the function value, unlike `AddColumnOp.Validate`, which already rejects a nil calculation function.

## Fix

Extend the aggregate validation loop in `GroupByOp.Validate` to also range over the function value and return a `NewValidationError` naming the offending aggregate when its `AggregateFunc` is nil. Because the render-time path validates before applying, the failure is now surfaced as a recoverable error instead of a panic.

## Tests

Added `TestGroupByNilAggregateFunc` in `v2/operations_aggregate_test.go`:
- `Validate` rejects a sole nil aggregate function (error names the aggregate, states it cannot be nil).
- `Validate` rejects a nil function mixed in with valid functions.
- Render-time per-content transformation (via `WithTransformations`) returns an error rather than panicking.

These tests fail against the unfixed code (nil pointer panic at operations.go:498) and pass after the fix.

## Verification

- `make test` — full unit suite passes
- `make lint` — 0 issues

Ticket: T-1105