### PR TITLE
Fix T-1186: CSV RenderTo Drops Flush Errors

### DIFF
--- a/v2/csv_renderer.go
+++ b/v2/csv_renderer.go
@@ -58,7 +58,14 @@ func (c *csvRenderer) renderDocumentCSVTo(ctx context.Context, doc *Document, w 
 
 	contents := doc.GetContents()
 	csvWriter := csv.NewWriter(w)
-	defer csvWriter.Flush()
+
+	// flushCSV flushes any buffered rows and reports a write error surfaced by
+	// the underlying io.Writer. csv.Writer.Write buffers data, so an underlying
+	// failure may only be reported here via csvWriter.Error() (T-1186).
+	flushCSV := func() error {
+		csvWriter.Flush()
+		return csvWriter.Error()
+	}
 
 	// Track the last written header schema to detect schema changes
 	var lastKeyOrder []string
@@ -67,6 +74,11 @@ func (c *csvRenderer) renderDocumentCSVTo(ctx context.Context, doc *Document, w 
 		// Check for context cancellation
 		select {
 		case <-ctx.Done():
+			// Flush already-buffered rows; prefer a write error over the
+			// context error so a failed destination is not masked.
+			if flushErr := flushCSV(); flushErr != nil {
+				return flushErr
+			}
 			return ctx.Err()
 		default:
 		}
@@ -74,6 +86,11 @@ func (c *csvRenderer) renderDocumentCSVTo(ctx context.Context, doc *Document, w 
 		// Apply per-content transformations before rendering
 		transformed, err := applyContentTransformations(ctx, content)
 		if err != nil {
+			// Flush already-buffered rows; prefer a write error over the
+			// transformation error so a failed destination is not masked.
+			if flushErr := flushCSV(); flushErr != nil {
+				return flushErr
+			}
 			return err
 		}
 
@@ -105,6 +122,9 @@ func (c *csvRenderer) renderDocumentCSVTo(ctx context.Context, doc *Document, w 
 				// Apply transformations to nested content
 				nestedTransformed, err := applyContentTransformations(ctx, nestedContent)
 				if err != nil {
+					if flushErr := flushCSV(); flushErr != nil {
+						return flushErr
+					}
 					return err
 				}
 
@@ -126,6 +146,9 @@ func (c *csvRenderer) renderDocumentCSVTo(ctx context.Context, doc *Document, w 
 					for _, deepContent := range nestedSection.Contents() {
 						deepTransformed, err := applyContentTransformations(ctx, deepContent)
 						if err != nil {
+							if flushErr := flushCSV(); flushErr != nil {
+								return flushErr
+							}
 							return err
 						}
 						if deepTable, ok := deepTransformed.(*TableContent); ok {
@@ -173,7 +196,9 @@ func (c *csvRenderer) renderDocumentCSVTo(ctx context.Context, doc *Document, w 
 		}
 	}
 
-	return nil
+	// Flush buffered rows and report any error from the underlying writer
+	// that was deferred until flush time (T-1186).
+	return flushCSV()
 }
 
 // renderTableContentCSV renders table content to CSV with key order preservation

--- a/v2/renderer_csv_test.go
+++ b/v2/renderer_csv_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/csv"
+	"errors"
 	"strings"
 	"testing"
 )
@@ -282,5 +283,58 @@ func TestCSVRenderer_TransformationIntegration(t *testing.T) {
 	// Should have header + 2 filtered records
 	if len(records) != 3 {
 		t.Errorf("Expected 3 rows (header + 2 data), got %d", len(records))
+	}
+}
+
+// csvFailWriter is an io.Writer that always fails. Because encoding/csv buffers
+// data through a bufio.Writer, the failure typically surfaces only when the
+// buffer is flushed rather than on the individual Write call.
+type csvFailWriter struct{}
+
+func (csvFailWriter) Write(p []byte) (int, error) {
+	return 0, errors.New("forced write failure")
+}
+
+// TestCSVRenderer_RenderToFlushError verifies that RenderTo reports the error
+// from an underlying writer that fails during flush (T-1186). csv.Writer.Write
+// buffers data, so a writer failure may only be reported by csvWriter.Error()
+// after Flush. Before the fix RenderTo returned nil for a failing writer.
+func TestCSVRenderer_RenderToFlushError(t *testing.T) {
+	doc := New().
+		Table("users", []map[string]any{
+			{"id": 1, "name": "Alice"},
+			{"id": 2, "name": "Bob"},
+		}, WithKeys("id", "name")).
+		Build()
+
+	renderer := &csvRenderer{}
+	err := renderer.RenderTo(context.Background(), doc, csvFailWriter{})
+	if err == nil {
+		t.Fatal("expected RenderTo to return an error when the underlying writer fails on flush, got nil")
+	}
+	if !strings.Contains(err.Error(), "forced write failure") {
+		t.Errorf("error = %v, want it to wrap the underlying %q failure", err, "forced write failure")
+	}
+}
+
+// TestCSVRenderer_RenderToFlushErrorWithSection verifies the same flush-error
+// detection for a document whose content comes from a section (a separate
+// rendering path through renderDocumentCSVTo).
+func TestCSVRenderer_RenderToFlushErrorWithSection(t *testing.T) {
+	doc := New().
+		Section("group", func(b *Builder) {
+			b.Table("users", []map[string]any{
+				{"id": 1, "name": "Alice"},
+			}, WithKeys("id", "name"))
+		}).
+		Build()
+
+	renderer := &csvRenderer{}
+	err := renderer.RenderTo(context.Background(), doc, csvFailWriter{})
+	if err == nil {
+		t.Fatal("expected RenderTo to return an error for a failing writer with section content, got nil")
+	}
+	if !strings.Contains(err.Error(), "forced write failure") {
+		t.Errorf("error = %v, want it to wrap the underlying %q failure", err, "forced write failure")
 	}
 }


### PR DESCRIPTION
## Bug

`csvRenderer.RenderTo` (via `renderDocumentCSVTo` in `v2/csv_renderer.go`) returned `nil` even when the destination `io.Writer` failed. Callers believed the CSV was written successfully when it was not — silent data loss for streaming CSV output (failed file handle, broken network/S3 stream, full disk).

## Root cause

The function wrapped the output writer in an `encoding/csv.Writer` and only flushed via `defer csvWriter.Flush()`, never checking `csvWriter.Error()`. Because `csv.Writer` buffers through an internal `bufio.Writer`, an underlying write failure is commonly reported only at flush time, and only via `Error()`. A deferred `Flush()` discards its (void) result, so the error was never observed and the success path returned `nil`.

## Fix

- Replace `defer csvWriter.Flush()` with an explicit `flushCSV` helper that calls `Flush()` then returns `csvWriter.Error()`.
- Flush and check the error on every return path that may have buffered rows:
  - the success path (final return),
  - the context-cancellation path,
  - the transformation-error paths (top-level and nested sections).
- On the early-return paths a surfaced write error is preferred over the original (context / transformation) error so a failed destination is not masked.

## Tests

Added regression tests in `v2/renderer_csv_test.go`:
- `TestCSVRenderer_RenderToFlushError` — failing writer with a top-level table.
- `TestCSVRenderer_RenderToFlushErrorWithSection` — failing writer with table content nested in a section.

Both tests fail (return nil) before the fix and pass after it. `make test` and `make lint` pass.

Fixes T-1186.