### PR TITLE
Fix T-1267: Emoji Transformer Corrupts Words Containing Indicators

### DIFF
--- a/v2/specs/bugfixes/emoji-transformer-corrupts-words/report.md
+++ b/v2/specs/bugfixes/emoji-transformer-corrupts-words/report.md
@@ -1,0 +1,114 @@
+# Bugfix Report: Emoji Transformer Corrupts Words Containing Indicators
+
+**Date:** 2026-05-25
+**Status:** Fixed
+
+## Description of the Issue
+
+`EmojiTransformer.Transform` converts text-based status indicators (`OK`, `Yes`,
+`No`, `!!`) into emoji. It runs on table, markdown, HTML, and CSV output, so it
+processes ordinary cell text in addition to standalone status values. The string
+indicators were applied with `strings.ReplaceAll`, which performs unanchored
+substring replacement. Any cell text that merely contained one of the indicators
+as a substring was corrupted.
+
+**Reproduction steps:**
+1. Render a table/markdown/HTML/CSV document containing the cell value "Notes"
+   (or "Nobody", "Nope", "Yesterday", etc.).
+2. Run the output through the emoji transformer.
+3. Observe the corrupted output: "Notes" -> "❌tes", "Nobody" -> "❌body",
+   "Yesterday" -> "✅terday".
+
+**Impact:** Medium. Any consumer using the emoji transformer on tabular output
+silently corrupts cell text containing the substrings "No" or "Yes" (and "OK" in
+upper-case forms). Data integrity in rendered output is compromised.
+
+## Investigation Summary
+
+- **Symptoms examined:** Cell text containing "No"/"Yes"/"OK" substrings being
+  partially replaced by emoji.
+- **Code inspected:** `v2/transformers.go`, `EmojiTransformer.Transform`.
+- **Hypotheses tested:** Confirmed the boolean replacements (`true`/`false`)
+  already use word-boundary regexes (`\btrue\b`, `\bfalse\b`) and are unaffected,
+  while the string indicators use unanchored `strings.ReplaceAll`. This
+  inconsistency is the defect.
+
+## Discovered Root Cause
+
+The string indicator replacements used `strings.ReplaceAll`, which replaces every
+substring occurrence regardless of word boundaries. The boolean replacements in
+the same function already used word-boundary regexes, but the string indicators
+did not follow the same pattern.
+
+**Defect type:** Logic error — unanchored substring replacement where
+word-boundary matching was required.
+
+**Why it occurred:** The replacements were stored in a map and applied with
+`strings.ReplaceAll` in a loop. The map ordering is also non-deterministic, which
+is unsuitable for ordered/anchored replacement.
+
+**Contributing factors:** Inconsistent replacement strategy within a single
+function (substring vs word-boundary).
+
+## Resolution for the Issue
+
+**Changes made:**
+- `v2/transformers.go` — `EmojiTransformer.Transform` now converts the word-based
+  string indicators (`OK`, `Yes`, `No`) using word-boundary regexes
+  (`\bOK\b`, `\bYes\b`, `\bNo\b`), matching the existing approach for `true`/`false`.
+  The non-word `!!` indicator continues to use `strings.ReplaceAll` because `\b`
+  word boundaries do not apply to punctuation. Replacements are applied in a fixed
+  order rather than via non-deterministic map iteration.
+
+**Approach rationale:** Word-boundary regexes are the same mechanism already used
+for the boolean indicators in this function, keeping the implementation
+consistent and minimal. Only standalone indicators (bounded by non-word
+characters or string edges) are converted; indicators embedded in larger words
+are left untouched.
+
+**Alternatives considered:**
+- Full cell-aware parsing of the tabular structure — Rejected as significantly
+  more complex and risky for what is fundamentally a token-matching problem.
+  Word boundaries solve the reported corruption directly.
+
+## Regression Test
+
+**Test file:** `v2/transformers_test.go`
+**Test name:** `TestEmojiTransformer_Transform_WordBoundaries`
+
+**What it verifies:** Words that merely contain an indicator as a substring
+("Notes", "Nobody", "Nope", "Yesterday", "ABCNoDEF") are left untouched, while
+standalone indicators ("No", "Yes", "OK", and indicators surrounded by
+punctuation/whitespace) are still converted to emoji.
+
+**Run command:** `go test ./v2/ -run TestEmojiTransformer_Transform_WordBoundaries`
+(from the v2 module directory) or `make test` from the repo root.
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `v2/transformers.go` | Use word-boundary regexes for string indicators |
+| `v2/transformers_test.go` | Add `TestEmojiTransformer_Transform_WordBoundaries` regression test |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Linters/validators pass
+
+**Manual verification:**
+- Confirmed the failing tests reproduce the corruption before the fix (red), then
+  pass after the fix (green).
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Use word-boundary matching consistently for word-based token replacement.
+- Avoid `strings.ReplaceAll` for replacing whole words/tokens in free text.
+- Prefer deterministic, ordered replacement over map iteration when order matters.
+
+## Related
+
+- Transit ticket T-1267

--- a/v2/transformers.go
+++ b/v2/transformers.go
@@ -29,29 +29,34 @@ func (e *EmojiTransformer) CanTransform(format string) bool {
 	return format == FormatTable || format == FormatMarkdown || format == FormatHTML || format == FormatCSV
 }
 
+// Word-based status indicators are matched with word boundaries so that only
+// standalone indicators are converted. Without boundaries, ordinary cell text
+// such as "Notes" or "Nobody" would be corrupted into "❌tes"/"❌body" (see
+// T-1267). Compiled once at package load since the patterns are constant.
+var emojiIndicatorReplacements = []struct {
+	pattern *regexp.Regexp
+	emoji   string
+}{
+	{regexp.MustCompile(`\bOK\b`), "✅"},
+	{regexp.MustCompile(`\bYes\b`), "✅"},
+	{regexp.MustCompile(`\bNo\b`), "❌"},
+	{regexp.MustCompile(`\btrue\b`), "✅"},
+	{regexp.MustCompile(`\bfalse\b`), "❌"},
+}
+
 // Transform converts text indicators to emoji
 func (e *EmojiTransformer) Transform(_ context.Context, input []byte, _ string) ([]byte, error) {
 	output := string(input)
 
-	// Common emoji substitutions based on v1 patterns
-	replacements := map[string]string{
-		"!!":  "🚨",
-		"OK":  "✅",
-		"Yes": "✅",
-		"No":  "❌",
-		"":    "ℹ️", // For info contexts
-	}
+	// The "!!" indicator is punctuation, so word boundaries (\b) do not apply;
+	// it is replaced as a plain substring.
+	output = strings.ReplaceAll(output, "!!", "🚨")
 
-	// Apply replacements
-	for text, emoji := range replacements {
-		if text != "" { // Skip empty string for now
-			output = strings.ReplaceAll(output, text, emoji)
-		}
+	// Word-based indicators use word boundaries so embedded substrings in normal
+	// cell text are left untouched and only standalone indicators are converted.
+	for _, r := range emojiIndicatorReplacements {
+		output = r.pattern.ReplaceAllString(output, r.emoji)
 	}
-
-	// Handle boolean-like patterns
-	output = regexp.MustCompile(`\btrue\b`).ReplaceAllString(output, "✅")
-	output = regexp.MustCompile(`\bfalse\b`).ReplaceAllString(output, "❌")
 
 	return []byte(output), nil
 }

--- a/v2/transformers_test.go
+++ b/v2/transformers_test.go
@@ -93,6 +93,97 @@ func TestEmojiTransformer_Transform(t *testing.T) {
 	}
 }
 
+// TestEmojiTransformer_Transform_WordBoundaries is a regression test for T-1267.
+//
+// The string indicators ("OK", "Yes", "No") were replaced with strings.ReplaceAll,
+// which has no word-boundary awareness. As a result, normal cell text containing
+// those substrings was corrupted: "Notes" became "❌tes", "Nobody" became "❌body",
+// and words containing "OK" (e.g. "Booking", "Looking") were mangled. Standalone
+// indicators must still convert, but indicators that are part of a larger word
+// must be left untouched.
+func TestEmojiTransformer_Transform_WordBoundaries(t *testing.T) {
+	transformer := &EmojiTransformer{}
+	ctx := context.Background()
+
+	tests := map[string]struct {
+		input    string
+		expected string
+	}{
+		// Words that merely contain an indicator must be left untouched.
+		"word containing No (Notes)": {
+			input:    "Notes",
+			expected: "Notes",
+		},
+		"word containing No (Nobody)": {
+			input:    "Nobody",
+			expected: "Nobody",
+		},
+		"word containing No (Nope)": {
+			input:    "Nope",
+			expected: "Nope",
+		},
+		"word containing OK (Booking)": {
+			input:    "Booking",
+			expected: "Booking",
+		},
+		"word containing OK (Looking)": {
+			input:    "Looking",
+			expected: "Looking",
+		},
+		"word containing Yes (Yesterday)": {
+			input:    "Yesterday",
+			expected: "Yesterday",
+		},
+		"indicator as suffix (NoOK)": {
+			input:    "ABCNoDEF",
+			expected: "ABCNoDEF",
+		},
+		"mixed cell text with embedded indicators": {
+			input:    "Notes about Booking Yesterday",
+			expected: "Notes about Booking Yesterday",
+		},
+		// Standalone indicators must still be converted.
+		"standalone No": {
+			input:    "No",
+			expected: "❌",
+		},
+		"standalone Yes": {
+			input:    "Yes",
+			expected: "✅",
+		},
+		"standalone OK": {
+			input:    "OK",
+			expected: "✅",
+		},
+		"standalone indicators in a sentence": {
+			input:    "Active: Yes, Enabled: No, Status: OK",
+			expected: "Active: ✅, Enabled: ❌, Status: ✅",
+		},
+		"standalone No surrounded by punctuation": {
+			input:    "(No)",
+			expected: "(❌)",
+		},
+		// Embedded and standalone indicators together.
+		"standalone and embedded together": {
+			input:    "No Notes",
+			expected: "❌ Notes",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			result, err := transformer.Transform(ctx, []byte(test.input), "table")
+			if err != nil {
+				t.Fatalf("EmojiTransformer.Transform() error = %v", err)
+			}
+
+			if string(result) != test.expected {
+				t.Errorf("EmojiTransformer.Transform(%q) = %q, want %q", test.input, string(result), test.expected)
+			}
+		})
+	}
+}
+
 // Test ColorTransformer
 
 func TestColorTransformer_Name(t *testing.T) {


### PR DESCRIPTION
## Bug

`EmojiTransformer.Transform` (in `v2/transformers.go`) runs on table, markdown, HTML and CSV output. It converted the string status indicators `OK`, `Yes` and `No` using `strings.ReplaceAll`, which matches substrings anywhere with no word-boundary awareness. As a result, ordinary cell text containing those substrings was corrupted:

- `Notes` -> `❌tes`
- `Nobody` -> `❌body`
- `Yesterday` -> `✅terday`

## Root cause

The boolean indicators (`true`/`false`) already used word-boundary regexes (`\btrue\b`, `\bfalse\b`), but the word-based string indicators (`OK`, `Yes`, `No`) used unanchored `strings.ReplaceAll`. This inconsistency meant any embedded occurrence was replaced. The replacements were also stored in a map and applied via non-deterministic iteration.

## Fix

Match the word-based indicators (`OK`, `Yes`, `No`) with word-boundary regexes, consistent with the existing `true`/`false` handling, so only standalone indicators are converted. The punctuation indicator `!!` keeps substring replacement because `\b` word boundaries do not apply to non-word characters. Replacements are now applied in a fixed order via package-level compiled regexes.

## Tests

Added `TestEmojiTransformer_Transform_WordBoundaries` in `v2/transformers_test.go` covering:
- Words containing indicators left untouched: `Notes`, `Nobody`, `Nope`, `Yesterday`, `Booking`, `Looking`, `ABCNoDEF`.
- Standalone indicators still converted: `No`, `Yes`, `OK`, indicators in sentences, and indicators surrounded by punctuation.

The new tests fail before the fix and pass after. Full `make test` and `make lint` pass.

See bugfix report: `v2/specs/bugfixes/emoji-transformer-corrupts-words/report.md`.

Closes T-1267.