### PR TITLE
Fix T-1233: DefaultCollapsibleValue Lazy Caches Race During Concurrent Rendering

### DIFF
--- a/v2/collapsible.go
+++ b/v2/collapsible.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"fmt"
+	"sync"
 )
 
 // Constants for repeated strings
@@ -41,10 +42,12 @@ type DefaultCollapsibleValue struct {
 	codeLanguage  string // Language for syntax highlighting (e.g., "json", "yaml", "go")
 	useCodeFences bool   // Whether to wrap details in code fences
 
-	// Performance optimization fields for lazy evaluation (Requirement 10.3, 10.5)
+	// Performance optimization fields for lazy evaluation (Requirement 10.3).
+	// detailsOnce guards the one-time processing of details so that Details() is
+	// safe to call concurrently when a shared value is rendered from multiple
+	// goroutines (T-1233).
+	detailsOnce      sync.Once
 	processedDetails any
-	detailsProcessed bool
-	hintsAccessed    map[string]bool
 	memoryProcessor  *MemoryOptimizedProcessor
 }
 
@@ -60,9 +63,6 @@ func NewCollapsibleValue(summary string, details any, opts ...CollapsibleOption)
 		maxDetailLength:   500, // Default from requirements
 		truncateIndicator: truncateIndicatorText,
 		formatHints:       make(map[string]map[string]any),
-		// Initialize performance optimization fields (Requirements 10.3, 10.5)
-		detailsProcessed: false,
-		hintsAccessed:    nil, // Lazy initialized when first accessed
 	}
 
 	for _, opt := range opts {
@@ -141,40 +141,33 @@ func (d *DefaultCollapsibleValue) Details() any {
 		return d.summary // Fallback for nil details
 	}
 
-	// Use cached processed details if available (Requirement 10.3)
-	if d.detailsProcessed {
-		return d.processedDetails
-	}
-
-	// Initialize memory processor if needed for large content processing (Requirement 10.4)
-	if d.memoryProcessor == nil && d.needsMemoryOptimization() {
-		config := RendererConfig{
-			MaxDetailLength:   d.maxDetailLength,
-			TruncateIndicator: d.truncateIndicator,
+	// Process details exactly once and cache the result. sync.Once makes this
+	// safe for concurrent callers (T-1233) while preserving lazy evaluation
+	// (Requirement 10.3).
+	d.detailsOnce.Do(func() {
+		// Initialize memory processor if needed for large content processing (Requirement 10.4)
+		if d.needsMemoryOptimization() {
+			config := RendererConfig{
+				MaxDetailLength:   d.maxDetailLength,
+				TruncateIndicator: d.truncateIndicator,
+			}
+			d.memoryProcessor = NewMemoryOptimizedProcessor(config)
 		}
-		d.memoryProcessor = NewMemoryOptimizedProcessor(config)
-	}
 
-	// Process details once and cache result
-	var result any
-	var err error
-
-	// Use memory-optimized processing for large content (Requirement 10.4)
-	if d.memoryProcessor != nil {
-		result, err = d.memoryProcessor.ProcessLargeDetails(d.details, d.maxDetailLength)
-		if err != nil {
-			// Fallback to simple processing on error
-			result = d.processDetailsSimple()
+		// Use memory-optimized processing for large content (Requirement 10.4)
+		if d.memoryProcessor != nil {
+			result, err := d.memoryProcessor.ProcessLargeDetails(d.details, d.maxDetailLength)
+			if err != nil {
+				// Fallback to simple processing on error
+				result = d.processDetailsSimple()
+			}
+			d.processedDetails = result
+		} else {
+			d.processedDetails = d.processDetailsSimple()
 		}
-	} else {
-		result = d.processDetailsSimple()
-	}
+	})
 
-	// Cache the processed result to avoid redundant processing (Requirement 10.3)
-	d.processedDetails = result
-	d.detailsProcessed = true
-
-	return result
+	return d.processedDetails
 }
 
 // needsMemoryOptimization determines if memory optimization is beneficial
@@ -215,17 +208,10 @@ func (d *DefaultCollapsibleValue) IsExpanded() bool {
 	return d.defaultExpanded
 }
 
-// FormatHint returns renderer-specific hints for the given format
-// Implements lazy evaluation to avoid processing hints when not used (Requirement 10.5)
+// FormatHint returns renderer-specific hints for the given format.
+// It is a pure read of the configured hints, making it safe to call concurrently
+// when a shared value is rendered from multiple goroutines (T-1233).
 func (d *DefaultCollapsibleValue) FormatHint(format string) map[string]any {
-	// Initialize hintsAccessed map if not already done
-	if d.hintsAccessed == nil {
-		d.hintsAccessed = make(map[string]bool)
-	}
-
-	// Mark this format as accessed for performance tracking
-	d.hintsAccessed[format] = true
-
 	if hints, exists := d.formatHints[format]; exists {
 		return hints
 	}

--- a/v2/collapsible_race_test.go
+++ b/v2/collapsible_race_test.go
@@ -1,0 +1,76 @@
+package output
+
+import (
+	"strings"
+	"sync"
+	"testing"
+)
+
+// TestCollapsibleValue_ConcurrentDetails verifies that Details() is safe to call
+// concurrently on a shared value. Regression test for T-1233: Details() lazily
+// wrote memoryProcessor, processedDetails, and detailsProcessed without
+// synchronization, racing when a shared document/value is rendered concurrently.
+func TestCollapsibleValue_ConcurrentDetails(t *testing.T) {
+	// Use details large enough to trigger the memory-optimized processing path
+	// (>1KB string), exercising the memoryProcessor lazy init as well.
+	largeDetails := strings.Repeat("detail-content ", 200)
+	cv := NewCollapsibleValue("summary", largeDetails, WithMaxLength(0))
+
+	const goroutines = 64
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			_ = cv.Details()
+		}()
+	}
+	wg.Wait()
+
+	if got, ok := cv.Details().(string); !ok || got != largeDetails {
+		t.Errorf("Details() = %v, want stable %q", cv.Details(), largeDetails)
+	}
+}
+
+// TestCollapsibleValue_ConcurrentFormatHint verifies that FormatHint() is safe to
+// call concurrently on a shared value. Regression test for T-1233: FormatHint()
+// lazily allocated and wrote hintsAccessed without synchronization.
+func TestCollapsibleValue_ConcurrentFormatHint(t *testing.T) {
+	cv := NewCollapsibleValue("summary", "details",
+		WithFormatHint(FormatJSON, map[string]any{"key": "value"}))
+
+	const goroutines = 64
+	formats := []string{FormatJSON, FormatYAML, FormatTable, FormatHTML, FormatCSV, FormatMarkdown}
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := range goroutines {
+		format := formats[i%len(formats)]
+		go func() {
+			defer wg.Done()
+			_ = cv.FormatHint(format)
+		}()
+	}
+	wg.Wait()
+}
+
+// TestCollapsibleValue_ConcurrentRender verifies a shared value rendered through the
+// render path (Details() + FormatHint()) concurrently does not race. Regression test
+// for T-1233 reproducing the JSON formatValueForJSON access pattern.
+func TestCollapsibleValue_ConcurrentRender(t *testing.T) {
+	cv := NewCollapsibleValue("summary", strings.Repeat("x", 2000),
+		WithFormatHint(FormatJSON, map[string]any{"key": "value"}))
+
+	const goroutines = 64
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			_ = cv.Summary()
+			_ = cv.Details()
+			_ = cv.IsExpanded()
+			_ = cv.FormatHint(FormatJSON)
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## Bug

`DefaultCollapsibleValue` is reached from render paths (JSON via `formatValueForJSON`, plus table/markdown/html/csv renderers) that call `Details()` and `FormatHint()` while rendering. Both methods mutated lazy-cache fields without synchronization, so a value shared across concurrent renders raced — flagged under `go test -race` (and concurrent `hintsAccessed` map writes could panic).

## Root cause

- `Details()` did an unsynchronized check-then-act lazy init of `processedDetails`/`detailsProcessed`/`memoryProcessor`.
- `FormatHint()` lazily allocated and wrote a `hintsAccessed` map.

These mutate a value that v2's thread-safety contract treats as immutable-after-build, with no lock. Investigation confirmed `hintsAccessed` was write-only dead state — never read by any production code or test.

## Fix

- Guard the `Details()` lazy processing with `sync.Once` so it runs exactly once and is safe for concurrent callers, preserving the lazy-evaluation/caching behaviour (Req 10.3/10.4).
- Remove the write-only `hintsAccessed` tracking entirely; `FormatHint()` is now a pure read.

`sync.Once` makes the value non-copyable, but `NewCollapsibleValue` returns a pointer and all methods use pointer receivers; `go vet` (copylocks) is clean and no by-value usage exists.

## Tests

Added `v2/collapsible_race_test.go` with concurrency regression tests (`TestCollapsibleValue_ConcurrentDetails`, `TestCollapsibleValue_ConcurrentFormatHint`, `TestCollapsibleValue_ConcurrentRender`). They reproduced the race before the fix (red) and pass after (green).

## Verification

- `cd v2 && go test -race ./...` — pass (race gone)
- `make test` — pass
- `make lint` — 0 issues
- `go vet ./...` — clean

Note: distinct from T-1317 (DefaultCollapsibleSection aliasing in `collapsible_section.go`).