### PR TITLE
Fix T-1295: Graph and Draw.io Content Expose Mutable Caller-Owned Data

### DIFF
--- a/v2/graph_content.go
+++ b/v2/graph_content.go
@@ -3,6 +3,7 @@ package output
 import (
 	"fmt"
 	"maps"
+	"slices"
 	"strings"
 )
 
@@ -20,12 +21,36 @@ type Edge struct {
 	Label string
 }
 
+// cloneEdges returns a copy of the edges slice. Edge is a value struct with no
+// reference-typed fields, so a shallow element copy is sufficient.
+func cloneEdges(edges []Edge) []Edge {
+	if edges == nil {
+		return nil
+	}
+	return slices.Clone(edges)
+}
+
+// cloneRecords returns a deep copy of a records slice, copying both the slice
+// and each inner Record map so callers cannot mutate stored content.
+func cloneRecords(records []Record) []Record {
+	if records == nil {
+		return nil
+	}
+	out := make([]Record, len(records))
+	for i, record := range records {
+		newRecord := make(Record, len(record))
+		maps.Copy(newRecord, record)
+		out[i] = newRecord
+	}
+	return out
+}
+
 // NewGraphContent creates a new graph content
 func NewGraphContent(title string, edges []Edge) *GraphContent {
 	return &GraphContent{
 		id:    GenerateID(),
 		title: title,
-		edges: edges,
+		edges: cloneEdges(edges),
 	}
 }
 
@@ -112,9 +137,10 @@ func (g *GraphContent) AppendBinary(b []byte) ([]byte, error) {
 	return g.AppendText(b)
 }
 
-// GetEdges returns the graph edges
+// GetEdges returns a copy of the graph edges so callers cannot mutate
+// the content's internal state.
 func (g *GraphContent) GetEdges() []Edge {
-	return g.edges
+	return cloneEdges(g.edges)
 }
 
 // GetTitle returns the graph title
@@ -139,14 +165,10 @@ func (g *GraphContent) GetNodes() []string {
 
 // Clone creates a deep copy of the GraphContent
 func (g *GraphContent) Clone() Content {
-	// Deep copy edges
-	newEdges := make([]Edge, len(g.edges))
-	copy(newEdges, g.edges)
-
 	return &GraphContent{
 		id:    g.id,
 		title: g.title,
-		edges: newEdges,
+		edges: cloneEdges(g.edges),
 	}
 }
 
@@ -361,7 +383,7 @@ func NewDrawIOContent(title string, records []Record, header DrawIOHeader) *Draw
 		id:      GenerateID(),
 		title:   title,
 		header:  header,
-		records: records,
+		records: cloneRecords(records),
 	}
 }
 
@@ -371,7 +393,7 @@ func NewDrawIOContentFromTable(table *TableContent, header DrawIOHeader) *DrawIO
 		id:      GenerateID(),
 		title:   table.title,
 		header:  header,
-		records: table.records,
+		records: cloneRecords(table.records),
 	}
 }
 
@@ -395,9 +417,10 @@ func (d *DrawIOContent) GetHeader() DrawIOHeader {
 	return d.header
 }
 
-// GetRecords returns the data records
+// GetRecords returns a deep copy of the data records so callers cannot
+// mutate the content's internal state.
 func (d *DrawIOContent) GetRecords() []Record {
-	return d.records
+	return cloneRecords(d.records)
 }
 
 // AppendText implements encoding.TextAppender
@@ -429,17 +452,8 @@ func (d *DrawIOContent) AppendBinary(b []byte) ([]byte, error) {
 
 // Clone creates a deep copy of the DrawIOContent
 func (d *DrawIOContent) Clone() Content {
-	// Deep copy records
-	newRecords := make([]Record, len(d.records))
-	for i, record := range d.records {
-		newRecord := make(Record)
-		maps.Copy(newRecord, record)
-		newRecords[i] = newRecord
-	}
-
 	// Deep copy connections
-	newConnections := make([]DrawIOConnection, len(d.header.Connections))
-	copy(newConnections, d.header.Connections)
+	newConnections := slices.Clone(d.header.Connections)
 
 	newHeader := d.header
 	newHeader.Connections = newConnections
@@ -448,7 +462,7 @@ func (d *DrawIOContent) Clone() Content {
 		id:      d.id,
 		title:   d.title,
 		header:  newHeader,
-		records: newRecords,
+		records: cloneRecords(d.records),
 	}
 }
 

--- a/v2/graph_content_mutation_test.go
+++ b/v2/graph_content_mutation_test.go
@@ -1,0 +1,114 @@
+package output
+
+import "testing"
+
+// Regression tests for T-1295: Graph and Draw.io content expose mutable
+// caller-owned data. Constructors and getters must defensively copy slices
+// and record maps so that mutating caller-owned data after creation, or
+// mutating data returned by a getter, cannot change later render output.
+
+// TestGraphContent_MutateInputEdgesAfterCreate verifies that mutating the
+// caller's edge slice after NewGraphContent does not affect the stored edges.
+func TestGraphContent_MutateInputEdgesAfterCreate(t *testing.T) {
+	edges := []Edge{
+		{From: "A", To: "B", Label: "edge1"},
+		{From: "B", To: "C", Label: "edge2"},
+	}
+
+	g := NewGraphContent("graph", edges)
+
+	// Mutate the caller-owned slice after construction.
+	edges[0] = Edge{From: "X", To: "Y", Label: "mutated"}
+
+	got := g.GetEdges()
+	if got[0].From != "A" || got[0].To != "B" || got[0].Label != "edge1" {
+		t.Errorf("mutating input slice changed stored edge: got %+v, want {From:A To:B Label:edge1}", got[0])
+	}
+}
+
+// TestGraphContent_MutateEdgesThroughGetter verifies that mutating the slice
+// returned by GetEdges does not affect the content's internal state.
+func TestGraphContent_MutateEdgesThroughGetter(t *testing.T) {
+	edges := []Edge{
+		{From: "A", To: "B", Label: "edge1"},
+	}
+
+	g := NewGraphContent("graph", edges)
+
+	// Mutate the slice returned by the getter.
+	returned := g.GetEdges()
+	returned[0] = Edge{From: "X", To: "Y", Label: "mutated"}
+
+	got := g.GetEdges()
+	if got[0].From != "A" || got[0].To != "B" || got[0].Label != "edge1" {
+		t.Errorf("mutating getter result changed stored edge: got %+v, want {From:A To:B Label:edge1}", got[0])
+	}
+}
+
+// TestDrawIOContent_MutateInputRecordsAfterCreate verifies that mutating the
+// caller's records slice (and the maps within it) after NewDrawIOContent does
+// not affect the stored records.
+func TestDrawIOContent_MutateInputRecordsAfterCreate(t *testing.T) {
+	records := []Record{
+		{"Name": "Server1", "Type": "Web"},
+		{"Name": "Server2", "Type": "DB"},
+	}
+
+	d := NewDrawIOContent("infra", records, DefaultDrawIOHeader())
+
+	// Mutate both the slice element and a map value the caller still owns.
+	records[0] = Record{"Name": "replaced"}
+	records[1]["Type"] = "mutated"
+
+	got := d.GetRecords()
+	if got[0]["Name"] != "Server1" {
+		t.Errorf("mutating input slice element changed stored record: got %v, want Server1", got[0]["Name"])
+	}
+	if got[1]["Type"] != "DB" {
+		t.Errorf("mutating input record map changed stored record: got %v, want DB", got[1]["Type"])
+	}
+}
+
+// TestDrawIOContent_MutateRecordsThroughGetter verifies that mutating the
+// records slice and inner maps returned by GetRecords does not affect the
+// content's internal state.
+func TestDrawIOContent_MutateRecordsThroughGetter(t *testing.T) {
+	records := []Record{
+		{"Name": "Server1", "Type": "Web"},
+	}
+
+	d := NewDrawIOContent("infra", records, DefaultDrawIOHeader())
+
+	// Mutate the slice and inner map returned by the getter.
+	returned := d.GetRecords()
+	returned[0]["Type"] = "mutated"
+
+	got := d.GetRecords()
+	if got[0]["Type"] != "Web" {
+		t.Errorf("mutating getter result changed stored record: got %v, want Web", got[0]["Type"])
+	}
+}
+
+// TestDrawIOContentFromTable_MutateSourceTableRecords verifies that mutating
+// the source table's records after NewDrawIOContentFromTable does not affect
+// the Draw.io content (the from-table constructor must not alias table data).
+func TestDrawIOContentFromTable_MutateSourceTableRecords(t *testing.T) {
+	records := []Record{
+		{"Name": "Server1", "Type": "Web"},
+	}
+	table, err := NewTableContent("table", records, WithKeys("Name", "Type"))
+	if err != nil {
+		t.Fatalf("NewTableContent failed: %v", err)
+	}
+
+	d := NewDrawIOContentFromTable(table, DefaultDrawIOHeader())
+
+	// Mutate the table's record map through the table's accessor.
+	tableRecords := table.records
+	tableRecords[0]["Type"] = "mutated"
+
+	got := d.GetRecords()
+	if got[0]["Type"] != "Web" {
+		t.Errorf("mutating source table record changed Draw.io content: got %v, want Web", got[0]["Type"])
+	}
+}

--- a/v2/specs/bugfixes/graph-drawio-mutable-data/report.md
+++ b/v2/specs/bugfixes/graph-drawio-mutable-data/report.md
@@ -1,0 +1,134 @@
+# Bugfix Report: Graph and Draw.io Content Expose Mutable Caller-Owned Data
+
+**Date:** 2026-05-25
+**Status:** Fixed
+
+## Description of the Issue
+
+Several v2 graph/Draw.io content constructors and accessors kept or returned
+caller-owned mutable data instead of defensive copies. This violated the
+document/content immutability model: a caller could change later render output
+by mutating data it had passed in, or by mutating data returned from a getter,
+long after the content had been created.
+
+**Reproduction steps:**
+1. Create graph content with `NewGraphContent(title, edges)` (or Draw.io content
+   with `NewDrawIOContent(title, records, header)` /
+   `NewDrawIOContentFromTable(table, header)`).
+2. Mutate the slice/maps that were passed in, the source table's records, or the
+   slice/maps returned by `GetEdges()` / `GetRecords()`.
+3. Observe that the content's stored data (and therefore its rendered output)
+   reflects the mutation.
+
+**Impact:** Medium. Any caller that retains a reference to an input slice/map,
+the source table, or a getter result could silently corrupt graph/Draw.io
+content after construction. The corruption is non-obvious because it happens
+through aliasing rather than an explicit API call.
+
+## Investigation Summary
+
+- **Symptoms examined:** Aliasing of caller-owned slices and `Record` maps into
+  `GraphContent`/`DrawIOContent` internals, and exposure of those internals to
+  callers through getters.
+- **Code inspected:** `v2/graph_content.go` (`NewGraphContent`, `GetEdges`,
+  `NewDrawIOContent`, `NewDrawIOContentFromTable`, `GetRecords`, and the existing
+  `Clone` methods which already performed correct deep copies).
+- **Hypotheses tested:** Confirmed each leak point individually with targeted unit
+  tests that mutate caller-owned data and assert the content's internal state is
+  unaffected. Confirmed the in-package precedent (T-1086 schema fix and the
+  existing `Clone` methods) establishes defensive copying as the convention.
+
+## Discovered Root Cause
+
+Slices and maps in Go are reference types. The constructors assigned the input
+slices directly, and the getters returned the internal slices directly, so the
+underlying backing array - and, for Draw.io, the inner `Record` maps - was shared
+with the caller. `NewDrawIOContentFromTable` additionally aliased the source
+table's `records` slice and maps.
+
+**Defect type:** Missing defensive copy / reference aliasing (immutability
+violation).
+
+**Why it occurred:** The constructors and accessors were written to assign and
+return slices/maps directly without copying. The existing `Clone` methods already
+contained the correct copying logic, but that logic was not applied at the
+construction and accessor boundaries.
+
+**Contributing factors:** `Edge` is a value struct with no reference-typed fields,
+so a shallow slice copy is sufficient for graph edges. `Record` is a map, so the
+Draw.io path requires copying both the slice and each inner map - making the
+Draw.io leak more impactful and easier to overlook.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `v2/graph_content.go` `NewGraphContent` - clones the input `edges` slice.
+- `v2/graph_content.go` `GetEdges` - returns a copy of the internal `edges` slice.
+- `v2/graph_content.go` `NewDrawIOContent` - deep-copies the input `records`
+  (slice and inner maps).
+- `v2/graph_content.go` `NewDrawIOContentFromTable` - deep-copies the source
+  table's `records` (slice and inner maps) instead of aliasing them.
+- `v2/graph_content.go` `GetRecords` - returns a deep copy of the internal
+  `records` (slice and inner maps).
+- Added private helpers `cloneEdges` and `cloneRecords` and reused them from the
+  constructors, getters, and the existing `Clone` methods to keep the copy logic
+  in one place.
+
+**Approach rationale:** Defensive copying on both input and output is the minimal,
+localized fix that restores the documented immutability without changing any
+public signatures. Reusing shared helpers removes the duplicated copy logic that
+already lived in the `Clone` methods.
+
+**Alternatives considered:**
+- Documenting the slices/maps as "do not mutate" instead of copying - Rejected
+  because it does not enforce immutability and contradicts the existing `Clone`
+  behaviour and the T-1086 precedent.
+- Copying only on construction (not in getters) - Rejected because getters still
+  leaked internal state, allowing post-construction mutation.
+
+## Regression Test
+
+**Test file:** `v2/graph_content_mutation_test.go`
+**Test names:**
+- `TestGraphContent_MutateInputEdgesAfterCreate`
+- `TestGraphContent_MutateEdgesThroughGetter`
+- `TestDrawIOContent_MutateInputRecordsAfterCreate`
+- `TestDrawIOContent_MutateRecordsThroughGetter`
+- `TestDrawIOContentFromTable_MutateSourceTableRecords`
+
+**What it verifies:** Mutating caller-owned data after construction, mutating the
+source table's records, and mutating data returned by `GetEdges`/`GetRecords` do
+not change the content's stored data.
+
+**Run command:**
+`go test ./v2/ -run 'TestGraphContent_Mutate|TestDrawIOContent_Mutate|TestDrawIOContentFromTable_Mutate' -v`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `v2/graph_content.go` | Defensive copies in constructors/getters; shared clone helpers |
+| `v2/graph_content_mutation_test.go` | New regression tests (added) |
+
+## Verification
+
+**Automated:**
+- [x] Regression tests pass
+- [x] Full test suite passes
+- [x] Linters/validators pass
+
+**Manual verification:**
+- Confirmed tests fail before the fix and pass after it.
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Treat slices and maps crossing a content/value boundary as requiring a
+  defensive copy on both store and return.
+- Reuse a single clone helper per reference-typed field so constructors,
+  getters, and `Clone` cannot diverge.
+
+## Related
+
+- T-1086 (Schema Key Order Leaks Mutable Slices) - same defect class, schema layer.
+- T-1304 (Draw.io from-table nil-guard) - separate ticket, out of scope here.


### PR DESCRIPTION
## Bug

`GraphContent` and `DrawIOContent` constructors and getters in `v2/graph_content.go` aliased caller-owned mutable data instead of copying it. A caller could change a content's stored data - and therefore its later render output - by mutating an input slice/map, the source table's records, or the slice/maps returned by `GetEdges()` / `GetRecords()`, violating the content immutability model.

## Root cause

Slices and maps are reference types in Go. The constructors assigned input slices directly and the getters returned the internal slices directly, sharing the backing array (and, for Draw.io, the inner `Record` maps) with the caller. `NewDrawIOContentFromTable` additionally aliased the source table's records. The correct deep-copy logic already existed in the `Clone` methods but was not applied at the construction/accessor boundaries.

## Fix

- `NewGraphContent` / `GetEdges` - copy the `edges` slice.
- `NewDrawIOContent` / `NewDrawIOContentFromTable` / `GetRecords` - deep-copy the `records` slice and each inner `Record` map.
- Added shared `cloneEdges` / `cloneRecords` helpers, reused by the constructors, getters, and the existing `Clone` methods so the copy logic lives in one place.

No public signatures changed. Scope limited to `GraphContent` and `DrawIOContent` (ChartContent untouched; the `NewDrawIOContentFromTable` nil-guard is out of scope per T-1304).

## Tests

Added `v2/graph_content_mutation_test.go` with 5 regression tests covering mutation-after-create and mutation-through-getter for both graph and Draw.io content (including the from-table source aliasing). Tests fail before the fix and pass after. Full suite and `make lint` pass.

Bugfix report: `v2/specs/bugfixes/graph-drawio-mutable-data/report.md`