### PR TITLE
Fix T-1184: Output Render Accepts Nil Configuration Entries

### DIFF
--- a/specs/bugfixes/output-render-nil-config/report.md
+++ b/specs/bugfixes/output-render-nil-config/report.md
@@ -1,0 +1,123 @@
+# Bugfix Report: Output Render Accepts Nil Configuration Entries
+
+**Date:** 2026-05-25
+**Status:** Fixed
+**Ticket:** T-1184
+
+## Description of the Issue
+
+`Output.Render` validated only that the `formats` and `writers` slices were
+non-empty. It did not validate the individual entries. As a result, a `Format`
+with a nil `Renderer`, a nil transformer, or a nil writer was carried through to
+the rendering path and dereferenced, where it triggered a nil pointer panic.
+The panic was caught by the `SafeExecuteWithTracer` recovery wrapper and
+surfaced as a recovered `PanicError` instead of a normal up-front validation
+error.
+
+**Reproduction steps:**
+1. Build an `Output` with one of the following misconfigurations:
+   - `WithFormat(Format{Name: "json"})` (nil `Renderer` field)
+   - `WithTransformer(nil)`
+   - `WithWriter(nil)`
+2. Call `output.Render(ctx, doc)`.
+3. Observe that the returned error is a recovered `PanicError`
+   (`panic in operation "render-json": runtime error: invalid memory address or
+   nil pointer dereference`) rather than a `ValidationError`.
+
+**Impact:** Low/medium severity. Misconfiguration produced confusing panic
+errors with stack traces instead of clear validation messages. No data
+corruption, but poor caller ergonomics and harder debugging.
+
+## Investigation Summary
+
+- **Symptoms examined:** Recovered `PanicError` returned from `Render` for nil
+  configuration entries.
+- **Code inspected:** `v2/output.go` `Render` (validation block) and the
+  rendering path: `f.Renderer.Render`, `transformer.CanTransform`, and
+  `writer.Write`. Validation helpers in `v2/errors.go` (`ValidateNonNil`,
+  `ValidateSliceNonEmpty`, `FailFast`, `NewValidationError`).
+- **Hypotheses tested:** Confirmed the existing validation block only checks
+  slice non-emptiness, never entry validity. Ruled out the `TransformPipeline`
+  (T-1131) and `MultiWriter` (T-1168) paths — those are separate APIs in other
+  files; this defect is in the top-level `Output` configuration path.
+
+## Discovered Root Cause
+
+The `Render` validation block checked slice length but never inspected slice
+entries, so nil renderers/transformers/writers passed validation and were
+dereferenced during rendering.
+
+**Defect type:** Missing input validation.
+
+**Why it occurred:** `ValidateSliceNonEmpty` only guards against empty slices.
+There was no per-entry nil check, and the panic-recovery wrapper masked the
+underlying nil dereference as a generic `PanicError`, hiding the real cause.
+
+**Contributing factors:** Interface-typed slice entries (`Renderer` field,
+`Transformer`, `Writer`) are nilable, and the functional-options API
+(`WithFormat`, `WithTransformer`, `WithWriter`) accepts any value without
+validation.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `v2/output.go` (`Render`) - After the existing non-empty slice checks, call a
+  new `validateConfigEntries` helper and return its error before rendering.
+- `v2/output.go` (`validateConfigEntries`) - New helper that iterates formats,
+  transformers, and writers and returns a `ValidationError` ("cannot be nil")
+  for the first nil entry (nil `Format.Renderer`, nil transformer, nil writer).
+
+**Approach rationale:** Fail-fast validation at the top of `Render` matches the
+existing pattern (the empty-slice checks live there) and keeps the fix contained
+to `output.go`. Reusing `NewValidationError` produces errors consistent with the
+rest of the API and the existing empty-slice errors.
+
+**Alternatives considered:**
+- Validate at configuration time in the `WithX` option functions - Rejected
+  because options are applied without an error channel, and `Render` is the
+  natural validation boundary where the config snapshot is taken.
+- Return the panic-recovered error as-is - Rejected because a `PanicError` with a
+  stack trace is poor ergonomics for a simple misconfiguration.
+
+## Regression Test
+
+**Test file:** `v2/output_test.go`
+**Test name:** `TestOutput_Render_NilConfigurationEntries`
+
+**What it verifies:** For each of nil renderer, nil transformer, and nil writer,
+`Render` returns a `*ValidationError` mentioning the relevant field and "cannot
+be nil", and does NOT return a `*PanicError`.
+
+**Run command:** `go test -run TestOutput_Render_NilConfigurationEntries ./...`
+(from `v2/`)
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `v2/output.go` | Added `validateConfigEntries` helper and a call to it in `Render` after the non-empty slice checks |
+| `v2/output_test.go` | Added `TestOutput_Render_NilConfigurationEntries` regression test |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes (`make test`)
+- [x] Linters/validators pass (`make lint`, 0 issues)
+
+**Manual verification:**
+- Confirmed the regression test fails before the fix (recovered `PanicError`)
+  and passes after.
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Validate the contents of nilable interface slices, not just their length,
+  before dereferencing entries.
+- Be aware that panic-recovery wrappers can mask missing validation; prefer
+  explicit up-front checks for configuration that is known at call time.
+
+## Related
+
+- Separate but related nil-entry tickets in other files: T-1131
+  (`TransformPipeline`) and T-1168 (`MultiWriter`). Out of scope here.

--- a/v2/output.go
+++ b/v2/output.go
@@ -159,8 +159,51 @@ func (o *Output) Render(ctx context.Context, doc *Document) error {
 			return err
 		}
 
+		// Validate individual configuration entries are non-nil. Without this,
+		// a Format with a nil Renderer, a nil transformer, or a nil writer would
+		// be dereferenced during rendering and surface as a recovered PanicError
+		// instead of a normal validation error.
+		if err := validateConfigEntries(formats, transformers, writers); err != nil {
+			return err
+		}
+
 		return o.renderWithConfig(ctx, doc, formats, writers, transformers, progress)
 	})
+}
+
+// validateConfigEntries checks that each configured format has a non-nil
+// renderer and that no transformer or writer entry is nil. It returns the first
+// validation error encountered, ensuring nil entries are reported as normal
+// validation errors rather than being dereferenced during rendering.
+func validateConfigEntries(formats []Format, transformers []Transformer, writers []Writer) error {
+	for i, f := range formats {
+		if f.Renderer == nil {
+			return NewValidationError(
+				fmt.Sprintf("formats[%d].renderer", i),
+				f.Renderer,
+				"cannot be nil",
+			)
+		}
+	}
+	for i, transformer := range transformers {
+		if transformer == nil {
+			return NewValidationError(
+				fmt.Sprintf("transformers[%d]", i),
+				transformer,
+				"transformer cannot be nil",
+			)
+		}
+	}
+	for i, writer := range writers {
+		if writer == nil {
+			return NewValidationError(
+				fmt.Sprintf("writers[%d]", i),
+				writer,
+				"writer cannot be nil",
+			)
+		}
+	}
+	return nil
 }
 
 // renderWithConfig performs the actual rendering with the given configuration

--- a/v2/output_test.go
+++ b/v2/output_test.go
@@ -338,6 +338,96 @@ func TestOutput_Render_ErrorHandling(t *testing.T) {
 	})
 }
 
+// TestOutput_Render_NilConfigurationEntries verifies that Render returns a
+// normal validation error when the configuration contains nil entries, rather
+// than dereferencing them and producing a recovered PanicError.
+//
+// Regression test for T-1184: previously Render only checked that the formats
+// and writers slices were non-empty, so a Format with a nil Renderer reached
+// f.Renderer.Render, a nil transformer reached transformer.CanTransform, and a
+// nil writer reached writer.Write — each producing a recovered PanicError
+// instead of an up-front validation error.
+func TestOutput_Render_NilConfigurationEntries(t *testing.T) {
+	doc := New().
+		Table("Test", []map[string]any{
+			{"Name": "Alice", "Age": 30},
+		}, WithKeys("Name", "Age")).
+		Build()
+
+	// assertValidationError checks that err is a *ValidationError mentioning the
+	// expected field and "cannot be nil", and that it is not a PanicError.
+	assertValidationError := func(t *testing.T, err error, field string) {
+		t.Helper()
+		if err == nil {
+			t.Fatalf("Render() should fail for nil %s entry", field)
+		}
+
+		var panicErr *PanicError
+		if AsError(err, &panicErr) {
+			t.Fatalf("Render() should return a validation error, not a PanicError, got: %v", err)
+		}
+
+		var validationErr *ValidationError
+		if !AsError(err, &validationErr) {
+			t.Fatalf("error should be a *ValidationError, got %T: %v", err, err)
+		}
+
+		if !strings.Contains(err.Error(), field) || !strings.Contains(err.Error(), "cannot be nil") {
+			t.Errorf("error should mention %q cannot be nil, got: %v", field, err)
+		}
+	}
+
+	t.Run("nil renderer", func(t *testing.T) {
+		var progressBuf bytes.Buffer
+		progress := NewProgress(WithProgressWriter(&progressBuf))
+
+		output := NewOutput(
+			// Format with a nil Renderer field.
+			WithFormat(Format{Name: "json"}),
+			WithWriter(NewStdoutWriter()),
+			WithProgress(progress),
+		)
+
+		err := output.Render(context.Background(), doc)
+		assertValidationError(t, err, "renderer")
+
+		output.Close()
+	})
+
+	t.Run("nil transformer", func(t *testing.T) {
+		var progressBuf bytes.Buffer
+		progress := NewProgress(WithProgressWriter(&progressBuf))
+
+		output := NewOutput(
+			WithFormat(JSON()),
+			WithTransformer(nil),
+			WithWriter(NewStdoutWriter()),
+			WithProgress(progress),
+		)
+
+		err := output.Render(context.Background(), doc)
+		assertValidationError(t, err, "transformer")
+
+		output.Close()
+	})
+
+	t.Run("nil writer", func(t *testing.T) {
+		var progressBuf bytes.Buffer
+		progress := NewProgress(WithProgressWriter(&progressBuf))
+
+		output := NewOutput(
+			WithFormat(JSON()),
+			WithWriter(nil),
+			WithProgress(progress),
+		)
+
+		err := output.Render(context.Background(), doc)
+		assertValidationError(t, err, "writer")
+
+		output.Close()
+	})
+}
+
 func TestOutput_Render_WithTransformers(t *testing.T) {
 	doc := New().
 		Table("Test", []map[string]any{


### PR DESCRIPTION
## Bug

`Output.Render` validated only that the `formats` and `writers` slices were non-empty, not that their entries were valid. A `Format` with a nil `Renderer`, a nil transformer, or a nil writer was carried into the rendering path and dereferenced (`f.Renderer.Render`, `transformer.CanTransform`, `writer.Write`). The resulting nil pointer panic was caught by the panic-recovery wrapper and returned as a recovered `PanicError` instead of a normal validation error.

## Root cause

Missing per-entry input validation. `ValidateSliceNonEmpty` only guards against empty slices; nilable interface entries were never checked, and the panic-recovery wrapper masked the underlying nil dereference.

## Fix

Add a `validateConfigEntries` helper in `v2/output.go`, called from `Render` after the existing non-empty checks. It returns a `ValidationError` ("cannot be nil") for the first nil entry encountered (nil `Format.Renderer`, nil transformer, nil writer), matching the existing validation-error style.

The change is contained to `output.go`'s `Render` validation path. The separate `TransformPipeline` (T-1131) and `MultiWriter` (T-1168) nil-entry paths in other files are intentionally untouched.

## Tests

Added `TestOutput_Render_NilConfigurationEntries` in `v2/output_test.go` covering nil renderer, nil transformer, and nil writer. Each asserts a `*ValidationError` is returned (not a `*PanicError`). Confirmed red before the fix and green after.

- `make test` passes
- `make lint` passes (0 issues)

See `specs/bugfixes/output-render-nil-config/report.md` for the full bugfix report.