### PR TITLE
Fix T-1221: SortTransformer Can Break Markdown Table Separators

### DIFF
--- a/v2/transformers.go
+++ b/v2/transformers.go
@@ -191,6 +191,11 @@ func (s *SortTransformer) Transform(_ context.Context, input []byte, _ string) (
 	var beforeHeader []string
 	var afterData []string
 
+	// separatorRow holds the Markdown alignment row (e.g. "| --- | --- |") so it
+	// can be reinserted directly under the header rather than being sorted as a
+	// data row.
+	var separatorRow string
+
 	headerFound := false
 	for i, line := range lines {
 		line = strings.TrimSpace(line)
@@ -211,6 +216,13 @@ func (s *SortTransformer) Transform(_ context.Context, input []byte, _ string) (
 		}
 
 		if headerFound {
+			// The Markdown separator row immediately follows the header and must
+			// never be sorted; hold it aside for reinsertion after the header.
+			if separatorRow == "" && len(dataLines) == 0 && isMarkdownSeparatorRow(line) {
+				separatorRow = lines[i]
+				continue
+			}
+
 			if strings.Contains(line, "\t") || strings.Contains(line, ",") || strings.Contains(line, "|") {
 				dataLines = append(dataLines, lines[i])
 			} else {
@@ -278,10 +290,32 @@ func (s *SortTransformer) Transform(_ context.Context, input []byte, _ string) (
 	var result []string
 	result = append(result, beforeHeader...)
 	result = append(result, headerLine)
+	if separatorRow != "" {
+		result = append(result, separatorRow)
+	}
 	result = append(result, dataLines...)
 	result = append(result, afterData...)
 
 	return []byte(strings.Join(result, "\n")), nil
+}
+
+// isMarkdownSeparatorRow reports whether a trimmed line is a Markdown table
+// separator/alignment row, such as "| --- | --- |" or "|:---|---:|". Such rows
+// consist solely of pipes, dashes, colons, and spaces, and contain at least one
+// dash so plain data rows are not misidentified.
+func isMarkdownSeparatorRow(line string) bool {
+	if !strings.Contains(line, "|") || !strings.Contains(line, "-") {
+		return false
+	}
+	for _, r := range line {
+		switch r {
+		case '|', '-', ':', ' ', '\t':
+			// allowed separator characters
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // LineSplitTransformer splits cells containing multiple values into separate rows

--- a/v2/transformers_test.go
+++ b/v2/transformers_test.go
@@ -372,6 +372,57 @@ func TestSortTransformer_Transform(t *testing.T) {
 	}
 }
 
+// TestSortTransformer_MarkdownSeparatorRow verifies that the Markdown separator
+// row (e.g. "| --- | --- |") stays directly under the header after sorting.
+//
+// Bug T-1221: SortTransformer treated every pipe-delimited post-header line as a
+// sortable data row, including the required Markdown separator. Descending and
+// string sorts could move the separator below real rows, producing invalid
+// Markdown. Expected: the separator always remains immediately after the header.
+func TestSortTransformer_MarkdownSeparatorRow(t *testing.T) {
+	ctx := context.Background()
+
+	tests := map[string]struct {
+		transformer *SortTransformer
+		input       string
+		expected    string
+	}{
+		"descending numeric sort keeps separator under header": {
+			transformer: NewSortTransformer("Age", false),
+			input:       "| Name | Age |\n| --- | --- |\n| Charlie | 30 |\n| Alice | 25 |\n| Bob | 35 |",
+			expected:    "| Name | Age |\n| --- | --- |\n| Bob | 35 |\n| Charlie | 30 |\n| Alice | 25 |",
+		},
+		"ascending string sort keeps separator under header": {
+			transformer: NewSortTransformerAscending("Name"),
+			input:       "| Name | Age |\n| --- | --- |\n| Charlie | 30 |\n| Alice | 25 |\n| Bob | 35 |",
+			expected:    "| Name | Age |\n| --- | --- |\n| Alice | 25 |\n| Bob | 35 |\n| Charlie | 30 |",
+		},
+		"descending string sort keeps separator under header": {
+			transformer: NewSortTransformer("Name", false),
+			input:       "| Name | Age |\n| --- | --- |\n| Alice | 25 |\n| Bob | 35 |\n| Charlie | 30 |",
+			expected:    "| Name | Age |\n| --- | --- |\n| Charlie | 30 |\n| Bob | 35 |\n| Alice | 25 |",
+		},
+		"aligned separator row with colons is preserved": {
+			transformer: NewSortTransformer("Age", false),
+			input:       "| Name | Age |\n|:---|---:|\n| Charlie | 30 |\n| Alice | 25 |\n| Bob | 35 |",
+			expected:    "| Name | Age |\n|:---|---:|\n| Bob | 35 |\n| Charlie | 30 |\n| Alice | 25 |",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			result, err := test.transformer.Transform(ctx, []byte(test.input), FormatMarkdown)
+			if err != nil {
+				t.Fatalf("SortTransformer.Transform() error = %v", err)
+			}
+
+			if string(result) != test.expected {
+				t.Errorf("SortTransformer.Transform()\n got = %q\nwant = %q", string(result), test.expected)
+			}
+		})
+	}
+}
+
 // Test LineSplitTransformer
 
 func TestLineSplitTransformer_Name(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes T-1221. `SortTransformer` could break Markdown tables by moving the required separator/alignment row out from directly under the header.

## Bug

`SortTransformer.CanTransform` returns true for `FormatMarkdown`, and `Transform` treated every pipe-delimited line after the header as a sortable data row — including the Markdown separator row (`| --- | --- |`). Ascending numeric sorts left it near the top by accident (dashes sort low), but descending and string sorts moved the separator below real data rows, producing invalid Markdown.

## Root cause

`Transform` classifies any non-empty post-header line containing `\t`, `,`, or `|` as a data row. The Markdown separator row contains `|`, so it was appended to `dataLines` and sorted along with the real rows. The transformer had no awareness of Markdown's structural separator row.

## Fix

- Detect the Markdown separator row (the first post-header alignment row) and hold it aside instead of appending it to `dataLines`.
- Reinsert the separator row immediately after the header during output reconstruction, before the sorted data rows.
- Add `isMarkdownSeparatorRow` helper that matches only lines composed of `|`, `-`, `:`, and whitespace and containing at least one `-`, so genuine data rows are never misidentified.

This keeps the advertised Markdown support in `CanTransform` working while guaranteeing valid output. The data-sorting logic is unchanged.

## Tests

Added `TestSortTransformer_MarkdownSeparatorRow` in `v2/transformers_test.go` covering descending numeric, ascending string, descending string, and colon-aligned (`|:---|---:|`) separator cases. Tests fail before the fix and pass after.

`make test` and `make lint` both pass (0 lint issues).

## Scope note

Scoped to `SortTransformer` only; does not touch the `EmojiTransformer` work from T-1267.