### PR TITLE
Fix T-1142: Table Operations Panic On Nil Content

### DIFF
--- a/v2/operations.go
+++ b/v2/operations.go
@@ -49,6 +49,12 @@ func (o *FilterOp) Name() string {
 
 // Apply filters table records based on the predicate
 func (o *FilterOp) Apply(ctx context.Context, content Content) (Content, error) {
+	// Guard against nil content before dereferencing it for the error message
+	if content == nil {
+		return nil, NewValidationError("content_type", nil,
+			"filter operation requires table content")
+	}
+
 	// Type check
 	tableContent, ok := content.(*TableContent)
 	if !ok {
@@ -102,7 +108,7 @@ func (o *FilterOp) ApplyWithFormat(ctx context.Context, content Content, format 
 // CanTransform checks if filter operation applies to the given content and format
 func (o *FilterOp) CanTransform(content Content, format string) bool {
 	// Filter works with table content in any format
-	return content.Type() == ContentTypeTable
+	return content != nil && content.Type() == ContentTypeTable
 }
 
 // SortOp implements sorting operation using keys or custom comparators
@@ -118,6 +124,12 @@ func (o *SortOp) Name() string {
 
 // Apply sorts table records based on keys or comparator
 func (o *SortOp) Apply(ctx context.Context, content Content) (Content, error) {
+	// Guard against nil content before dereferencing it for the error message
+	if content == nil {
+		return nil, NewValidationError("content_type", nil,
+			"sort operation requires table content")
+	}
+
 	// Type check
 	tableContent, ok := content.(*TableContent)
 	if !ok {
@@ -332,7 +344,7 @@ func (o *SortOp) ApplyWithFormat(ctx context.Context, content Content, format st
 // CanTransform checks if sort operation applies to the given content and format
 func (o *SortOp) CanTransform(content Content, format string) bool {
 	// Sort works with table content in any format
-	return content.Type() == ContentTypeTable
+	return content != nil && content.Type() == ContentTypeTable
 }
 
 // LimitOp implements limit operation to restrict the number of records
@@ -347,6 +359,12 @@ func (o *LimitOp) Name() string {
 
 // Apply limits the number of records in the table
 func (o *LimitOp) Apply(ctx context.Context, content Content) (Content, error) {
+	// Guard against nil content before dereferencing it for the error message
+	if content == nil {
+		return nil, NewValidationError("content_type", nil,
+			"limit operation requires table content")
+	}
+
 	// Type check
 	tableContent, ok := content.(*TableContent)
 	if !ok {
@@ -388,7 +406,7 @@ func (o *LimitOp) ApplyWithFormat(ctx context.Context, content Content, format s
 // CanTransform checks if limit operation applies to the given content and format
 func (o *LimitOp) CanTransform(content Content, format string) bool {
 	// Limit works with table content in any format
-	return content.Type() == ContentTypeTable
+	return content != nil && content.Type() == ContentTypeTable
 }
 
 // NewFilterOp creates a new filter operation with the given predicate
@@ -435,6 +453,12 @@ func (o *GroupByOp) Name() string {
 
 // Apply groups table records and applies aggregate functions
 func (o *GroupByOp) Apply(ctx context.Context, content Content) (Content, error) {
+	// Guard against nil content before dereferencing it for the error message
+	if content == nil {
+		return nil, NewValidationError("content_type", nil,
+			"groupBy operation requires table content")
+	}
+
 	// Type check
 	tableContent, ok := content.(*TableContent)
 	if !ok {
@@ -648,7 +672,7 @@ func (o *GroupByOp) ApplyWithFormat(ctx context.Context, content Content, format
 // CanTransform checks if groupBy operation applies to the given content and format
 func (o *GroupByOp) CanTransform(content Content, format string) bool {
 	// GroupBy works with table content in any format
-	return content.Type() == ContentTypeTable
+	return content != nil && content.Type() == ContentTypeTable
 }
 
 // Built-in aggregate functions
@@ -800,6 +824,12 @@ func (o *AddColumnOp) Name() string {
 
 // Apply adds a calculated column to the table
 func (o *AddColumnOp) Apply(ctx context.Context, content Content) (Content, error) {
+	// Guard against nil content before dereferencing it for the error message
+	if content == nil {
+		return nil, NewValidationError("content_type", nil,
+			"addColumn operation requires table content")
+	}
+
 	// Type check
 	tableContent, ok := content.(*TableContent)
 	if !ok {
@@ -923,7 +953,7 @@ func (o *AddColumnOp) ApplyWithFormat(ctx context.Context, content Content, form
 // CanTransform checks if addColumn operation applies to the given content and format
 func (o *AddColumnOp) CanTransform(content Content, format string) bool {
 	// AddColumn works with table content in any format
-	return content.Type() == ContentTypeTable
+	return content != nil && content.Type() == ContentTypeTable
 }
 
 // NewAddColumnOp creates a new addColumn operation

--- a/v2/operations_nil_content_test.go
+++ b/v2/operations_nil_content_test.go
@@ -1,0 +1,92 @@
+package output
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestOperationsApplyNilContent is a regression test for T-1142.
+//
+// Bug: FilterOp, SortOp, LimitOp, GroupByOp, and AddColumnOp all called
+// content.Type().String() when building the validation error after a failed
+// type assertion. Passing nil content makes the type assertion fail, so the
+// error path then called Type() on a nil Content interface and panicked.
+//
+// Expected: Apply must return a normal validation error (not panic) when
+// content is nil, matching the behaviour for other invalid content.
+func TestOperationsApplyNilContent(t *testing.T) {
+	type opCase struct {
+		op      Operation
+		wantMsg string
+	}
+
+	cases := map[string]opCase{
+		"filter": {
+			op:      &FilterOp{predicate: func(Record) bool { return true }},
+			wantMsg: "filter operation requires table content",
+		},
+		"sort": {
+			op:      &SortOp{keys: []SortKey{{Column: "id", Direction: Ascending}}},
+			wantMsg: "sort operation requires table content",
+		},
+		"limit": {
+			op:      &LimitOp{count: 5},
+			wantMsg: "limit operation requires table content",
+		},
+		"groupBy": {
+			op:      &GroupByOp{groupBy: []string{"id"}, aggregates: map[string]AggregateFunc{"count": CountAggregate()}},
+			wantMsg: "groupBy operation requires table content",
+		},
+		"addColumn": {
+			op:      &AddColumnOp{name: "calc", fn: func(Record) any { return 1 }},
+			wantMsg: "addColumn operation requires table content",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			// Apply must not panic on nil content.
+			_, err := tc.op.Apply(context.Background(), nil)
+			if err == nil {
+				t.Fatalf("expected validation error when applying %s op to nil content, got nil", name)
+			}
+			if !strings.Contains(err.Error(), tc.wantMsg) {
+				t.Errorf("expected error containing %q, got %q", tc.wantMsg, err.Error())
+			}
+		})
+	}
+}
+
+// TestOperationsCanTransformNilContent is a regression test for T-1142.
+//
+// Bug: every operation's CanTransform called content.Type() directly, which
+// panics when content is nil.
+//
+// Expected: CanTransform must return false for nil content instead of
+// panicking.
+func TestOperationsCanTransformNilContent(t *testing.T) {
+	ops := map[string]Operation{
+		"filter":    &FilterOp{predicate: func(Record) bool { return true }},
+		"sort":      &SortOp{keys: []SortKey{{Column: "id", Direction: Ascending}}},
+		"limit":     &LimitOp{count: 5},
+		"groupBy":   &GroupByOp{groupBy: []string{"id"}, aggregates: map[string]AggregateFunc{"count": CountAggregate()}},
+		"addColumn": &AddColumnOp{name: "calc", fn: func(Record) any { return 1 }},
+	}
+
+	for name, op := range ops {
+		t.Run(name, func(t *testing.T) {
+			transformer, ok := op.(interface {
+				CanTransform(content Content, format string) bool
+			})
+			if !ok {
+				t.Fatalf("%s op does not implement CanTransform", name)
+			}
+			// CanTransform must not panic and must report it cannot transform
+			// nil content.
+			if transformer.CanTransform(nil, "json") {
+				t.Errorf("expected CanTransform to return false for nil content on %s op", name)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Bug

The v2 table operations `FilterOp`, `SortOp`, `LimitOp`, `GroupByOp`, and `AddColumnOp` panicked with a nil pointer dereference when called with a nil `Content`. Callers using operations directly, or any pipeline path that accidentally passed nil content, crashed the process instead of receiving a structured validation error.

## Root cause

Each operation's `Apply` performs a type assertion to `*TableContent` and, on failure, builds a validation error using `content.Type().String()`. A nil `Content` interface fails the assertion, so the error path then called `Type()` on nil and panicked. The `CanTransform` methods had the same flaw — they called `content.Type()` directly with no nil guard.

## Fix

Added an explicit `content == nil` guard at the start of each operation's `Apply` (returns a `ValidationError` reporting `requires table content`) and each `CanTransform` (returns `false`). This mirrors the existing validation behaviour for non-table content without dereferencing nil.

## Tests

New `v2/operations_nil_content_test.go` with:
- `TestOperationsApplyNilContent` — each op's `Apply(ctx, nil)` returns a `requires table content` error instead of panicking.
- `TestOperationsCanTransformNilContent` — each op's `CanTransform(nil, ...)` returns `false` instead of panicking.

These tests panicked at `operations.go:806` before the fix (red) and pass after it (green). Full suite (`make test`) and `make lint` pass.

Resolves T-1142.