### PR TITLE
Fix T-1239: CSV Renderer Skips Deeply Nested Section Tables

### DIFF
--- a/v2/csv_renderer.go
+++ b/v2/csv_renderer.go
@@ -116,55 +116,12 @@ func (c *csvRenderer) renderDocumentCSVTo(ctx context.Context, doc *Document, w 
 			lastKeyOrder = content.getSchema().GetKeyOrder()
 
 		case *SectionContent:
-			// Extract and render tables from sections
-			// CSV is a flat format, so we flatten the section hierarchy
-			for _, nestedContent := range content.Contents() {
-				// Apply transformations to nested content
-				nestedTransformed, err := applyContentTransformations(ctx, nestedContent)
-				if err != nil {
-					if flushErr := flushCSV(); flushErr != nil {
-						return flushErr
-					}
-					return err
-				}
-
-				if nestedTable, ok := nestedTransformed.(*TableContent); ok {
-					// Add separator between tables
-					if lastKeyOrder != nil {
-						if err := csvWriter.Write([]string{}); err != nil {
-							return fmt.Errorf("failed to write separator row: %w", err)
-						}
-					}
-
-					writeHeaders := !keyOrdersEqual(lastKeyOrder, nestedTable.getSchema().GetKeyOrder())
-					if err := c.renderTableContentCSV(nestedTable, csvWriter, writeHeaders); err != nil {
-						return fmt.Errorf("failed to render table %s: %w", nestedTable.ID(), err)
-					}
-					lastKeyOrder = nestedTable.getSchema().GetKeyOrder()
-				} else if nestedSection, ok := nestedTransformed.(*SectionContent); ok {
-					// Recursively handle nested sections
-					for _, deepContent := range nestedSection.Contents() {
-						deepTransformed, err := applyContentTransformations(ctx, deepContent)
-						if err != nil {
-							if flushErr := flushCSV(); flushErr != nil {
-								return flushErr
-							}
-							return err
-						}
-						if deepTable, ok := deepTransformed.(*TableContent); ok {
-							if lastKeyOrder != nil {
-								if err := csvWriter.Write([]string{}); err != nil {
-									return fmt.Errorf("failed to write separator row: %w", err)
-								}
-							}
-							writeHeaders := !keyOrdersEqual(lastKeyOrder, deepTable.getSchema().GetKeyOrder())
-							if err := c.renderTableContentCSV(deepTable, csvWriter, writeHeaders); err != nil {
-								return fmt.Errorf("failed to render table %s: %w", deepTable.ID(), err)
-							}
-							lastKeyOrder = deepTable.getSchema().GetKeyOrder()
-						}
-					}
-				}
+			// Extract and render tables from sections. CSV is a flat format,
+			// so we recursively flatten the section hierarchy to any depth
+			// (T-1239). renderSectionTablesCSV applies per-content
+			// transformations at every level and renders each nested table.
+			if err := c.renderSectionTablesCSV(ctx, content, csvWriter, &lastKeyOrder, flushCSV); err != nil {
+				return err
 			}
 
 		case *DefaultCollapsibleSection:
@@ -199,6 +156,56 @@ func (c *csvRenderer) renderDocumentCSVTo(ctx context.Context, doc *Document, w 
 	// Flush buffered rows and report any error from the underlying writer
 	// that was deferred until flush time (T-1186).
 	return flushCSV()
+}
+
+// renderSectionTablesCSV recursively flattens a section hierarchy and renders
+// every nested table to CSV (T-1239). It walks the section's contents,
+// applying per-content transformations at each level, rendering any
+// TableContent it finds, and recursing into any nested SectionContent. This
+// replaces an earlier hand-written loop that only reached tables one section
+// level deep, silently dropping tables nested deeper.
+//
+// lastKeyOrder is shared across the whole document so separators and header
+// re-writes behave consistently with top-level tables. flushCSV is the
+// document-level flush used to surface deferred writer errors before returning
+// a transformation error (T-1186).
+func (c *csvRenderer) renderSectionTablesCSV(ctx context.Context, section *SectionContent, csvWriter *csv.Writer, lastKeyOrder *[]string, flushCSV func() error) error {
+	for _, nestedContent := range section.Contents() {
+		// Apply transformations to nested content at this level.
+		transformed, err := applyContentTransformations(ctx, nestedContent)
+		if err != nil {
+			// Flush already-buffered rows; prefer a write error over the
+			// transformation error so a failed destination is not masked.
+			if flushErr := flushCSV(); flushErr != nil {
+				return flushErr
+			}
+			return err
+		}
+
+		switch nested := transformed.(type) {
+		case *TableContent:
+			// Add separator between tables (matches top-level behaviour).
+			if *lastKeyOrder != nil {
+				if err := csvWriter.Write([]string{}); err != nil {
+					return fmt.Errorf("failed to write separator row: %w", err)
+				}
+			}
+
+			writeHeaders := !keyOrdersEqual(*lastKeyOrder, nested.getSchema().GetKeyOrder())
+			if err := c.renderTableContentCSV(nested, csvWriter, writeHeaders); err != nil {
+				return fmt.Errorf("failed to render table %s: %w", nested.ID(), err)
+			}
+			*lastKeyOrder = nested.getSchema().GetKeyOrder()
+
+		case *SectionContent:
+			// Recurse into deeper sections to any depth.
+			if err := c.renderSectionTablesCSV(ctx, nested, csvWriter, lastKeyOrder, flushCSV); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 // renderTableContentCSV renders table content to CSV with key order preservation

--- a/v2/renderer_csv_test.go
+++ b/v2/renderer_csv_test.go
@@ -338,3 +338,104 @@ func TestCSVRenderer_RenderToFlushErrorWithSection(t *testing.T) {
 		t.Errorf("error = %v, want it to wrap the underlying %q failure", err, "forced write failure")
 	}
 }
+
+// TestCSVRenderer_DeeplyNestedSectionTables is a regression test for T-1239.
+// The CSV renderer flattens tables inside sections, but the original
+// implementation only handled direct table children plus a single nested
+// SectionContent level. Tables nested 3+ levels deep were silently dropped
+// from the output. This test builds tables at several nesting depths and
+// verifies each one's rows reach the CSV output.
+func TestCSVRenderer_DeeplyNestedSectionTables(t *testing.T) {
+	// newTable builds a single-row table whose only value identifies the depth
+	// at which it lives, so we can assert each table reaches the output.
+	newTable := func(t *testing.T, name string) *TableContent {
+		t.Helper()
+		table, err := NewTableContent(name, []map[string]any{{"name": name}}, WithKeys("name"))
+		if err != nil {
+			t.Fatalf("failed to create table %q: %v", name, err)
+		}
+		return table
+	}
+
+	tests := map[string]struct {
+		// depth is the number of nested sections wrapping the table.
+		// depth=1 -> section -> table (already worked before the fix)
+		// depth=2 -> outer -> inner -> table (already worked before the fix)
+		// depth=3 -> outer -> middle -> inner -> table (regression)
+		depth int
+		row   string
+	}{
+		"one level":    {depth: 1, row: "level-1"},
+		"two levels":   {depth: 2, row: "level-2"},
+		"three levels": {depth: 3, row: "deep-row"},
+		"five levels":  {depth: 5, row: "level-5"},
+	}
+
+	for testName, tt := range tests {
+		t.Run(testName, func(t *testing.T) {
+			// Build the innermost section holding the table, then wrap it in
+			// the requested number of outer sections.
+			innermost := NewSectionContent("section-0")
+			innermost.AddContent(newTable(t, tt.row))
+
+			current := innermost
+			for level := 1; level < tt.depth; level++ {
+				outer := NewSectionContent("section")
+				outer.AddContent(current)
+				current = outer
+			}
+
+			doc := New().AddContent(current).Build()
+
+			result, err := (&csvRenderer{}).Render(context.Background(), doc)
+			if err != nil {
+				t.Fatalf("Render failed: %v", err)
+			}
+
+			if !strings.Contains(string(result), tt.row) {
+				t.Errorf("CSV output missing table nested %d level(s) deep: want it to contain %q, got %q",
+					tt.depth, tt.row, string(result))
+			}
+		})
+	}
+}
+
+// TestCSVRenderer_MultipleTablesAcrossNestingLevels verifies that tables at
+// different depths within the same section hierarchy are all rendered, not
+// just the shallowest ones. Regression test for T-1239.
+func TestCSVRenderer_MultipleTablesAcrossNestingLevels(t *testing.T) {
+	makeTable := func(t *testing.T, row string) *TableContent {
+		t.Helper()
+		table, err := NewTableContent(row, []map[string]any{{"name": row}}, WithKeys("name"))
+		if err != nil {
+			t.Fatalf("failed to create table %q: %v", row, err)
+		}
+		return table
+	}
+
+	// Structure: outer{tableA, middle{tableB, inner{tableC}}}
+	inner := NewSectionContent("inner")
+	inner.AddContent(makeTable(t, "row-c"))
+
+	middle := NewSectionContent("middle")
+	middle.AddContent(makeTable(t, "row-b"))
+	middle.AddContent(inner)
+
+	outer := NewSectionContent("outer")
+	outer.AddContent(makeTable(t, "row-a"))
+	outer.AddContent(middle)
+
+	doc := New().AddContent(outer).Build()
+
+	result, err := (&csvRenderer{}).Render(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+
+	out := string(result)
+	for _, want := range []string{"row-a", "row-b", "row-c"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("CSV output missing table row %q across nesting levels, got %q", want, out)
+		}
+	}
+}


### PR DESCRIPTION
## Bug

The CSV renderer flattened tables inside `SectionContent`, but only handled direct table children plus a single nested `SectionContent` level. Tables nested three or more sections deep (`outer -> middle -> inner -> table`) were silently omitted from CSV output — no error, just missing rows.

## Root Cause

The `*SectionContent` branch in `renderDocumentCSVTo` (`v2/csv_renderer.go`) used a hand-written two-level loop. The outer loop rendered a section's direct tables; an inner loop rendered the direct tables of one nested section but never recursed. Any `SectionContent` encountered inside the inner loop was ignored, so tables at depth 3+ were never rendered. A comment claimed "Recursively handle nested sections" despite the code being a fixed-depth manual unroll.

## Fix

Replaced the two-level loop with a recursive helper `renderSectionTablesCSV` that:
- walks a section's contents and applies per-content transformations at every level,
- renders each `TableContent` it finds,
- recurses into nested `SectionContent` to any depth.

The helper shares the document-level `lastKeyOrder` (via pointer) so separator rows and header re-writes match top-level table behaviour, and reuses the document-level `flushCSV` closure so deferred writer errors are still surfaced ahead of a transformation error — preserving the T-1186 flush/`Error()` handling.

## Tests

Added two regression tests in `v2/renderer_csv_test.go`:
- `TestCSVRenderer_DeeplyNestedSectionTables` — a table wrapped in 1, 2, 3, and 5 section levels; asserts the row appears at every depth (depths 3 and 5 failed before the fix).
- `TestCSVRenderer_MultipleTablesAcrossNestingLevels` — `outer{tableA, middle{tableB, inner{tableC}}}`; asserts rows from all three depths reach the output (`row-c` was dropped before the fix).

Both tests fail on the unpatched code and pass after the fix. `make test` and `make lint` (0 issues) pass.