### PR TITLE
Fix T-1209: Builder AddContent Accepts Nil Content

### DIFF
--- a/v2/document.go
+++ b/v2/document.go
@@ -101,10 +101,20 @@ func (b *Builder) SetMetadata(key string, value any) *Builder {
 	return b
 }
 
-// AddContent is a helper method to safely add content
+// AddContent is a helper method to safely add content.
+//
+// Nil content is rejected: it is not appended to the document and a builder
+// error is recorded instead (consistent with Table and Raw). This prevents nil
+// entries in the document's contents, which would otherwise cause nil
+// dereferences during rendering and transformation.
 func (b *Builder) AddContent(content Content) *Builder {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+
+	if content == nil {
+		b.addError(fmt.Errorf("AddContent: cannot add nil content"))
+		return b
+	}
 
 	if b.doc != nil {
 		b.doc.contents = append(b.doc.contents, content)

--- a/v2/document_test.go
+++ b/v2/document_test.go
@@ -138,6 +138,62 @@ func TestBuilder_AddContent(t *testing.T) {
 	}
 }
 
+// TestBuilder_AddContent_Nil is a regression test for T-1209.
+//
+// Bug: Builder.AddContent appended a nil Content value to the document
+// without validation. A nil entry in doc.contents causes nil dereferences
+// later during rendering/transformation, where code assumes contents are
+// non-nil.
+//
+// Expected behaviour: AddContent must skip nil content and record an error
+// using the builder's error-accumulation pattern (consistent with Table and
+// Raw), so the resulting document contains no nil entries.
+func TestBuilder_AddContent_Nil(t *testing.T) {
+	builder := New()
+
+	// Add a valid content, then a nil, then another valid content.
+	builder.AddContent(&testContent{id: "before", contentType: ContentTypeText})
+	builder.AddContent(nil)
+	builder.AddContent(&testContent{id: "after", contentType: ContentTypeText})
+
+	// The nil should have been rejected and recorded as an error.
+	if !builder.HasErrors() {
+		t.Error("expected builder to record an error after AddContent(nil)")
+	}
+
+	errors := builder.Errors()
+	if len(errors) != 1 {
+		t.Fatalf("expected 1 error after AddContent(nil), got %d: %v", len(errors), errors)
+	}
+	if !strings.Contains(errors[0].Error(), "nil content") {
+		t.Errorf("expected error message to mention %q, got %q", "nil content", errors[0].Error())
+	}
+
+	// The document must contain only the two valid contents, no nil entries.
+	doc := builder.Build()
+	contents := doc.GetContents()
+	if len(contents) != 2 {
+		t.Fatalf("expected 2 contents (nil skipped), got %d", len(contents))
+	}
+	for i, c := range contents {
+		if c == nil {
+			t.Errorf("content at index %d is nil; nil content should never be stored", i)
+		}
+	}
+	if contents[0].ID() != "before" || contents[1].ID() != "after" {
+		t.Errorf("unexpected content order: got [%s, %s], want [before, after]", contents[0].ID(), contents[1].ID())
+	}
+}
+
+// TestBuilder_AddContent_Nil_Fluent verifies AddContent still returns the
+// builder for chaining when given nil content (regression for T-1209).
+func TestBuilder_AddContent_Nil_Fluent(t *testing.T) {
+	builder := New()
+	if got := builder.AddContent(nil); got != builder {
+		t.Error("AddContent(nil) should return the same builder instance (fluent API)")
+	}
+}
+
 func TestDocument_GetContents(t *testing.T) {
 	builder := New()
 	content := &testContent{id: "test1", contentType: ContentTypeText}


### PR DESCRIPTION
## Bug

`Builder.AddContent` (in `v2/document.go`) appended whatever `Content` value it was given to the document's `contents` slice without validation. Passing `nil` stored a nil entry in `doc.contents`.

## Root cause

`AddContent` is the single funnel every `Add*` method (`Table`, `Text`, `Section`, charts, etc.) routes through, but it only guarded against `b.doc == nil` (post-`Build()`) — never against a nil `content` argument. Downstream rendering and transformation code iterates `doc.contents` and calls interface methods on each element assuming they are non-nil, so a nil entry surfaces as an opaque nil-dereference panic far from the call site, with no error recorded to signal the invalid input.

## Fix

Guard `AddContent` against nil content, following the builder's existing error-accumulation pattern (as used by `Table` and `Raw`):
- When content is nil, record an error via `addError` (`"AddContent: cannot add nil content"`) and skip the append.
- Valid content behaves exactly as before; `AddContent(nil)` still returns the builder for fluent chaining.
- `Build()` still succeeds and returns only valid content.

Guarding the single funnel covers every `Add*` method without touching renderers.

## Tests

Added regression tests in `v2/document_test.go`:
- `TestBuilder_AddContent_Nil` — nil is skipped, exactly one error mentioning "nil content" is recorded, document keeps only the surrounding valid contents in order, and no nil entries are stored.
- `TestBuilder_AddContent_Nil_Fluent` — `AddContent(nil)` still returns the builder.

Both fail before the fix and pass after. Full unit suite (`make test`) and `make lint` pass.

Ticket: T-1209