### PR TITLE
Fix T-1305: Chart Content Exposes Mutable Caller-Owned Data

### DIFF
--- a/v2/graph_content.go
+++ b/v2/graph_content.go
@@ -210,6 +210,54 @@ type PieSlice struct {
 	Value float64
 }
 
+// cloneGanttTasks returns a deep copy of a Gantt task slice. Each task's
+// Dependencies slice is also copied so callers cannot mutate stored content.
+func cloneGanttTasks(tasks []GanttTask) []GanttTask {
+	if tasks == nil {
+		return nil
+	}
+	out := make([]GanttTask, len(tasks))
+	for i, task := range tasks {
+		task.Dependencies = slices.Clone(task.Dependencies)
+		out[i] = task
+	}
+	return out
+}
+
+// clonePieSlices returns a copy of a pie slice slice. PieSlice is a value
+// struct with no reference-typed fields, so a shallow element copy suffices.
+func clonePieSlices(pieSlices []PieSlice) []PieSlice {
+	if pieSlices == nil {
+		return nil
+	}
+	return slices.Clone(pieSlices)
+}
+
+// cloneChartData returns a deep copy of chart-specific data so callers cannot
+// mutate the content's internal state. Known chart types (*GanttData and
+// *PieData) are copied along with their slices; any other payload is returned
+// unchanged since its type is not known to this package.
+func cloneChartData(data any) any {
+	switch d := data.(type) {
+	case *GanttData:
+		if d == nil {
+			return d
+		}
+		clone := *d
+		clone.Tasks = cloneGanttTasks(d.Tasks)
+		return &clone
+	case *PieData:
+		if d == nil {
+			return d
+		}
+		clone := *d
+		clone.Slices = clonePieSlices(d.Slices)
+		return &clone
+	default:
+		return data
+	}
+}
+
 // GanttData represents data for a Gantt chart
 type GanttData struct {
 	DateFormat string
@@ -238,7 +286,7 @@ func NewGanttChart(title string, tasks []GanttTask) *ChartContent {
 	data := &GanttData{
 		DateFormat: "YYYY-MM-DD",
 		AxisFormat: "%Y-%m-%d",
-		Tasks:      tasks,
+		Tasks:      cloneGanttTasks(tasks),
 	}
 	return NewChartContent(title, ChartTypeGantt, data)
 }
@@ -247,7 +295,7 @@ func NewGanttChart(title string, tasks []GanttTask) *ChartContent {
 func NewPieChart(title string, slices []PieSlice, showData bool) *ChartContent {
 	data := &PieData{
 		ShowData: showData,
-		Slices:   slices,
+		Slices:   clonePieSlices(slices),
 	}
 	return NewChartContent(title, ChartTypePie, data)
 }
@@ -272,9 +320,11 @@ func (c *ChartContent) GetTitle() string {
 	return c.title
 }
 
-// GetData returns the chart data
+// GetData returns a copy of the chart data so callers cannot mutate the
+// content's internal state. For known chart types (*GanttData, *PieData) the
+// returned value is an independent deep copy.
 func (c *ChartContent) GetData() any {
-	return c.data
+	return cloneChartData(c.data)
 }
 
 // AppendText implements encoding.TextAppender
@@ -329,7 +379,7 @@ func (c *ChartContent) Clone() Content {
 		id:        c.id,
 		title:     c.title,
 		chartType: c.chartType,
-		data:      c.data, // Shallow copy of data - deep copy would require type-specific logic
+		data:      cloneChartData(c.data),
 	}
 }
 

--- a/v2/graph_content_mutation_test.go
+++ b/v2/graph_content_mutation_test.go
@@ -112,3 +112,153 @@ func TestDrawIOContentFromTable_MutateSourceTableRecords(t *testing.T) {
 		t.Errorf("mutating source table record changed Draw.io content: got %v, want Web", got[0]["Type"])
 	}
 }
+
+// Regression tests for T-1305: ChartContent/GanttData/PieData expose mutable
+// caller-owned data. NewGanttChart and NewPieChart must defensively copy their
+// input slices (including each Gantt task's Dependencies slice), GetData must
+// return an independent copy of the chart data, and Clone must produce a deep
+// copy so the clone is independent of the original.
+
+// TestNewGanttChart_MutateInputTasksAfterCreate verifies that mutating the
+// caller's task slice after NewGanttChart does not affect the stored tasks.
+func TestNewGanttChart_MutateInputTasksAfterCreate(t *testing.T) {
+	tasks := []GanttTask{
+		{ID: "1", Title: "Design", StartDate: "2026-01-01"},
+		{ID: "2", Title: "Build", StartDate: "2026-01-02"},
+	}
+
+	c := NewGanttChart("project", tasks)
+
+	// Mutate the caller-owned slice element after construction.
+	tasks[0] = GanttTask{ID: "X", Title: "mutated"}
+
+	data, ok := c.GetData().(*GanttData)
+	if !ok {
+		t.Fatalf("GetData did not return *GanttData, got %T", c.GetData())
+	}
+	if data.Tasks[0].Title != "Design" {
+		t.Errorf("mutating input slice changed stored task: got %q, want Design", data.Tasks[0].Title)
+	}
+}
+
+// TestNewGanttChart_MutateInputTaskDependencies verifies that mutating a task's
+// Dependencies slice the caller still owns does not affect the stored task.
+func TestNewGanttChart_MutateInputTaskDependencies(t *testing.T) {
+	tasks := []GanttTask{
+		{ID: "1", Title: "Build", Dependencies: []string{"design"}},
+	}
+
+	c := NewGanttChart("project", tasks)
+
+	// Mutate the nested Dependencies slice the caller still owns.
+	tasks[0].Dependencies[0] = "mutated"
+
+	data := c.GetData().(*GanttData)
+	if data.Tasks[0].Dependencies[0] != "design" {
+		t.Errorf("mutating input task dependency changed stored task: got %q, want design", data.Tasks[0].Dependencies[0])
+	}
+}
+
+// TestNewGanttChart_MutateTasksThroughGetData verifies that mutating the tasks
+// reachable through GetData does not affect the chart's internal state.
+func TestNewGanttChart_MutateTasksThroughGetData(t *testing.T) {
+	tasks := []GanttTask{
+		{ID: "1", Title: "Design"},
+	}
+
+	c := NewGanttChart("project", tasks)
+
+	// Mutate the data returned by the getter.
+	returned := c.GetData().(*GanttData)
+	returned.Tasks[0].Title = "mutated"
+
+	again := c.GetData().(*GanttData)
+	if again.Tasks[0].Title != "Design" {
+		t.Errorf("mutating GetData result changed stored task: got %q, want Design", again.Tasks[0].Title)
+	}
+}
+
+// TestNewPieChart_MutateInputSlicesAfterCreate verifies that mutating the
+// caller's slice after NewPieChart does not affect the stored slices.
+func TestNewPieChart_MutateInputSlicesAfterCreate(t *testing.T) {
+	slices := []PieSlice{
+		{Label: "A", Value: 1},
+		{Label: "B", Value: 2},
+	}
+
+	c := NewPieChart("dist", slices, true)
+
+	// Mutate the caller-owned slice element after construction.
+	slices[0] = PieSlice{Label: "mutated", Value: 99}
+
+	data, ok := c.GetData().(*PieData)
+	if !ok {
+		t.Fatalf("GetData did not return *PieData, got %T", c.GetData())
+	}
+	if data.Slices[0].Label != "A" || data.Slices[0].Value != 1 {
+		t.Errorf("mutating input slice changed stored slice: got %+v, want {Label:A Value:1}", data.Slices[0])
+	}
+}
+
+// TestNewPieChart_MutateSlicesThroughGetData verifies that mutating the slices
+// reachable through GetData does not affect the chart's internal state.
+func TestNewPieChart_MutateSlicesThroughGetData(t *testing.T) {
+	slices := []PieSlice{
+		{Label: "A", Value: 1},
+	}
+
+	c := NewPieChart("dist", slices, true)
+
+	// Mutate the data returned by the getter.
+	returned := c.GetData().(*PieData)
+	returned.Slices[0].Label = "mutated"
+
+	again := c.GetData().(*PieData)
+	if again.Slices[0].Label != "A" {
+		t.Errorf("mutating GetData result changed stored slice: got %q, want A", again.Slices[0].Label)
+	}
+}
+
+// TestChartContent_CloneIndependentGantt verifies that mutating a cloned Gantt
+// chart's data does not affect the original chart.
+func TestChartContent_CloneIndependentGantt(t *testing.T) {
+	tasks := []GanttTask{
+		{ID: "1", Title: "Design", Dependencies: []string{"spec"}},
+	}
+
+	c := NewGanttChart("project", tasks)
+	clone := c.Clone().(*ChartContent)
+
+	// Mutate the clone's data.
+	cloneData := clone.GetData().(*GanttData)
+	cloneData.Tasks[0].Title = "mutated"
+	cloneData.Tasks[0].Dependencies[0] = "mutated"
+
+	origData := c.GetData().(*GanttData)
+	if origData.Tasks[0].Title != "Design" {
+		t.Errorf("mutating clone changed original task title: got %q, want Design", origData.Tasks[0].Title)
+	}
+	if origData.Tasks[0].Dependencies[0] != "spec" {
+		t.Errorf("mutating clone changed original task dependency: got %q, want spec", origData.Tasks[0].Dependencies[0])
+	}
+}
+
+// TestChartContent_CloneIndependentPie verifies that mutating a cloned pie
+// chart's data does not affect the original chart.
+func TestChartContent_CloneIndependentPie(t *testing.T) {
+	slices := []PieSlice{
+		{Label: "A", Value: 1},
+	}
+
+	c := NewPieChart("dist", slices, true)
+	clone := c.Clone().(*ChartContent)
+
+	// Mutate the clone's data.
+	cloneData := clone.GetData().(*PieData)
+	cloneData.Slices[0].Label = "mutated"
+
+	origData := c.GetData().(*PieData)
+	if origData.Slices[0].Label != "A" {
+		t.Errorf("mutating clone changed original slice: got %q, want A", origData.Slices[0].Label)
+	}
+}


### PR DESCRIPTION
## Bug

`ChartContent` aliased caller-owned data at every boundary:
- `NewGanttChart` stored the caller's `[]GanttTask` directly in `GanttData.Tasks`.
- `NewPieChart` stored the caller's `[]PieSlice` directly in `PieData.Slices`.
- `GetData()` returned the live mutable backing data.
- `Clone()` shallow-copied the `data` pointer, so clones were not independent.

Mutating the original input slice, the value returned by `GetData()`, or a clone could silently change later chart rendering. For Gantt tasks, the nested `GanttTask.Dependencies []string` slice was also shared.

## Root cause

ChartContent treated its `any` payload as opaque end-to-end and never established ownership of the chart-specific slices. Unlike `GraphContent`/`DrawIOContent` (fixed in T-1295, which added `cloneEdges`/`cloneRecords`), there was no chart-data deep-copy helper, so aliasing leaked at construction, accessor, and clone.

## Fix

- Add `cloneGanttTasks`, `clonePieSlices`, and `cloneChartData` helpers in `v2/graph_content.go`, mirroring the T-1295 defensive-copy pattern.
- `NewGanttChart` / `NewPieChart` now defensively copy their input slices. The Gantt helper also deep-copies each task's `Dependencies` slice.
- `GetData()` returns `cloneChartData(c.data)` — an independent deep copy for known chart types. The `any` return signature is unchanged (no API break).
- `Clone()` deep-copies via `cloneChartData`, removing the previous shallow-copy.
- `cloneChartData` passes through unknown payloads so the generic `NewChartContent` keeps working. All helpers preserve the nil-vs-empty distinction.

Scope is limited to `ChartContent`/`GanttData`/`PieData`; `GraphContent`/`DrawIOContent` (already fixed in T-1295) are untouched.

## Tests

Added regression tests in `v2/graph_content_mutation_test.go` covering caller mutation, accessor mutation, and clone independence for both Gantt and Pie (including the nested `Dependencies` slice). Verified failing before the fix and passing after. Full suite (`make test`) and `make lint` pass.