### PR TITLE
Fix T-1293: HTML Chart Rendering Writes Raw Mermaid Text Into Pre Tags

### DIFF
--- a/v2/html_renderer.go
+++ b/v2/html_renderer.go
@@ -313,10 +313,16 @@ func (h *htmlRenderer) renderChartContentHTML(chart *ChartContent) ([]byte, erro
 		return nil, fmt.Errorf("failed to render chart as mermaid: %w", err)
 	}
 
-	// Wrap in <pre class="mermaid">
+	// Wrap in <pre class="mermaid">. The Mermaid renderer emits user-controlled
+	// fields (chart titles, task/section names, pie labels) as raw text, so HTML
+	// metacharacters must be escaped before embedding in the HTML document.
+	// Without escaping, values containing "<", "</pre>", or "<script>" could
+	// break out of the pre block and inject HTML/script (XSS). Escaping is safe
+	// for Mermaid.js: it reads the text content of the pre block, which the
+	// browser un-escapes before Mermaid parses it.
 	var result strings.Builder
 	result.WriteString("<pre class=\"mermaid\">\n")
-	result.Write(mermaidData)
+	result.WriteString(html.EscapeString(string(mermaidData)))
 	result.WriteString("</pre>\n")
 
 	return []byte(result.String()), nil

--- a/v2/mermaid_html_markdown_test.go
+++ b/v2/mermaid_html_markdown_test.go
@@ -41,8 +41,9 @@ func TestHTMLRenderer_ChartContent(t *testing.T) {
 				`<pre class="mermaid">`,
 				"pie showData",
 				"title Distribution",
-				`"A" : 60.00`,
-				`"B" : 40.00`,
+				// Double quotes around pie labels are HTML-escaped (T-1293).
+				`&#34;A&#34; : 60.00`,
+				`&#34;B&#34; : 40.00`,
 				"</pre>",
 			},
 		},

--- a/v2/mermaid_html_markdown_test.go
+++ b/v2/mermaid_html_markdown_test.go
@@ -69,6 +69,109 @@ func TestHTMLRenderer_ChartContent(t *testing.T) {
 	}
 }
 
+// TestHTMLRenderer_ChartContent_EscapesUserText is a regression test for T-1293.
+//
+// renderChartContentHTML wrote the raw Mermaid bytes directly inside
+// <pre class="mermaid"> without HTML escaping. Chart titles, task names,
+// section names, and pie labels are user-controlled and the Mermaid renderer
+// emits them as raw text, so values containing "<", "</pre>", or "<script>"
+// could break out of the pre block or be interpreted as HTML/script (an XSS
+// injection path).
+//
+// Expected behaviour: HTML metacharacters in user-controlled chart fields are
+// HTML-escaped in the output. The browser un-escapes the text content of the
+// pre block before Mermaid.js parses it, so this preserves valid Mermaid syntax.
+func TestHTMLRenderer_ChartContent_EscapesUserText(t *testing.T) {
+	tests := map[string]struct {
+		chart        *ChartContent
+		mustContain  []string
+		mustNotMatch []string
+	}{
+		"pie chart with injection in title and labels": {
+			chart: NewPieChart(`<script>alert('xss')</script>`, []PieSlice{
+				{Label: `</pre><script>alert(1)</script>`, Value: 60},
+				{Label: "Safe", Value: 40},
+			}, true),
+			mustContain: []string{
+				`<pre class="mermaid">`,
+				"</pre>",
+				// The injected markup must be escaped, not emitted verbatim.
+				"&lt;script&gt;alert(&#39;xss&#39;)&lt;/script&gt;",
+				"&lt;/pre&gt;&lt;script&gt;alert(1)&lt;/script&gt;",
+			},
+			mustNotMatch: []string{
+				// A literal opening script tag would execute in the browser.
+				"<script>alert('xss')</script>",
+				"<script>alert(1)</script>",
+				// A literal closing pre breaks out of the mermaid block.
+				"</pre><script>",
+			},
+		},
+		"gantt chart with injection in title, section and task name": {
+			chart: NewGanttChart(`<script>evil()</script>`, []GanttTask{
+				{
+					ID:        "task1",
+					Title:     `</pre><img src=x onerror=alert(1)>`,
+					StartDate: "2024-01-01",
+					Duration:  "5d",
+					Status:    "done",
+					Section:   `<script>section()</script>`,
+				},
+			}),
+			mustContain: []string{
+				`<pre class="mermaid">`,
+				"</pre>",
+				"&lt;script&gt;evil()&lt;/script&gt;",
+				"&lt;script&gt;section()&lt;/script&gt;",
+				"&lt;/pre&gt;&lt;img src=x onerror=alert(1)&gt;",
+			},
+			mustNotMatch: []string{
+				"<script>evil()</script>",
+				"<script>section()</script>",
+				"</pre><img src=x onerror=alert(1)>",
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			doc := New().AddContent(tc.chart).Build()
+			renderer := &htmlRenderer{}
+
+			result, err := renderer.Render(context.Background(), doc)
+			if err != nil {
+				t.Fatalf("Render() error = %v", err)
+			}
+
+			output := string(result)
+
+			for _, expected := range tc.mustContain {
+				if !strings.Contains(output, expected) {
+					t.Errorf("Output should contain %q, got:\n%s", expected, output)
+				}
+			}
+
+			// Isolate the chart block so the mermaid script (which legitimately
+			// contains a <script> tag) does not produce false positives.
+			start := strings.Index(output, `<pre class="mermaid">`)
+			if start < 0 {
+				t.Fatalf("Output missing mermaid pre block, got:\n%s", output)
+			}
+			end := strings.Index(output[start:], "</pre>")
+			if end < 0 {
+				t.Fatalf("Output missing closing </pre>, got:\n%s", output)
+			}
+			chartBlock := output[start : start+end]
+
+			for _, forbidden := range tc.mustNotMatch {
+				if strings.Contains(chartBlock, forbidden) {
+					t.Errorf("Chart block should not contain unescaped %q, got:\n%s", forbidden, chartBlock)
+				}
+			}
+		})
+	}
+}
+
 func TestMarkdownRenderer_ChartContent(t *testing.T) {
 	tests := map[string]struct {
 		chart       *ChartContent

--- a/v2/specs/bugfixes/html-chart-raw-mermaid/report.md
+++ b/v2/specs/bugfixes/html-chart-raw-mermaid/report.md
@@ -1,0 +1,124 @@
+# Bugfix Report: HTML Chart Rendering Writes Raw Mermaid Text Into Pre Tags
+
+**Date:** 2026-05-25
+**Status:** Fixed
+**Ticket:** T-1293
+
+## Description of the Issue
+
+When rendering a document to HTML, chart content (`ChartContent`) is converted
+to Mermaid syntax and embedded inside a `<pre class="mermaid">` block so
+Mermaid.js can draw it client-side. The Mermaid renderer emits user-controlled
+fields — chart titles, gantt task names, gantt section names, and pie slice
+labels — as raw text. `htmlRenderer.renderChartContentHTML` wrote those raw
+Mermaid bytes directly into the `<pre>` block without HTML escaping.
+
+If any of those fields contained HTML metacharacters (`<`, `>`, `&`), the output
+was malformed. Worse, a value such as `</pre><script>...</script>` could break
+out of the pre block and inject arbitrary HTML/script into the page — a stored
+XSS injection path.
+
+**Reproduction steps:**
+1. Build a document with a pie or gantt chart whose title/label/task/section
+   contains `<script>alert(1)</script>` or `</pre><script>...`.
+2. Render it with the HTML renderer.
+3. Observe the literal `<script>`/`</pre>` tags inside the `<pre class="mermaid">`
+   block, unescaped.
+
+**Impact:** Security-relevant (XSS). Any caller embedding untrusted text in chart
+fields and serving the resulting HTML is exposed to script injection and
+malformed output. Affects all chart types rendered via the HTML renderer.
+
+## Investigation Summary
+
+- **Symptoms examined:** Raw HTML chart output containing unescaped user text.
+- **Code inspected:**
+  - `v2/html_renderer.go` `renderChartContentHTML` (~lines 301-323) — the
+    embedding point.
+  - `v2/graph_renderers.go` `mermaidRenderer` (`renderGanttChart`,
+    `renderPieChart`, `renderFlowchartContent`, `renderGraphContent`) — confirmed
+    titles, task titles, section names, and pie labels are written verbatim.
+- **Hypotheses tested:**
+  - Could escaping happen in the Mermaid renderer instead? Rejected — the Mermaid
+    renderer also feeds Markdown output (code fences) and standalone `.mmd`
+    files, where HTML escaping would corrupt the syntax. Escaping belongs at the
+    HTML embedding boundary.
+
+## Discovered Root Cause
+
+`renderChartContentHTML` wrote `mermaidData` straight into the HTML stream with
+`result.Write(mermaidData)`, with no HTML escaping, even though every other text
+path in `html_renderer.go` routes user data through `html.EscapeString`.
+
+**Defect type:** Missing output encoding / missing validation (XSS).
+
+**Why it occurred:** The Mermaid bytes were treated as already-safe markup rather
+than as text that needs encoding for the HTML context it is placed in. The
+Mermaid renderer's job is Mermaid syntax, not HTML safety.
+
+**Contributing factors:** Mermaid.js reads the *text content* of the pre block,
+so HTML-escaping is invisible to it (the browser un-escapes text content before
+Mermaid parses it). This made the missing escape easy to overlook because the
+chart still renders correctly for benign input.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `v2/html_renderer.go:renderChartContentHTML` — escape the Mermaid output with
+  `html.EscapeString` before writing it inside `<pre class="mermaid">`.
+
+**Approach rationale:** Escaping at the HTML embedding boundary is the correct
+layer: it is the point where Mermaid text crosses into an HTML context. It
+matches how the rest of `html_renderer.go` handles user data, is a one-line
+change, and preserves valid Mermaid syntax because Mermaid.js reads the
+DOM text content (which the browser has already un-escaped).
+
+**Alternatives considered:**
+- **Escape inside the Mermaid renderer** — rejected; it would corrupt Markdown
+  code-fence and standalone Mermaid output, which must not be HTML-escaped.
+- **Sanitize/strip the user fields** — rejected; lossy and changes the rendered
+  diagram text. Escaping preserves the intended content.
+
+## Regression Test
+
+**Test file:** `v2/mermaid_html_markdown_test.go`
+**Test name:** `TestHTMLRenderer_ChartContent_EscapesUserText`
+
+**What it verifies:** Pie and gantt charts whose title, labels, task names, and
+section names contain `<script>` and `</pre>` payloads produce HTML where those
+metacharacters are escaped (`&lt;`, `&gt;`, `&#39;`) and no literal `<script>` or
+`</pre><...>` markup appears inside the mermaid `<pre>` block.
+
+**Run command:** `cd v2 && go test . -run TestHTMLRenderer_ChartContent_EscapesUserText -v`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `v2/html_renderer.go` | Escape Mermaid output before embedding in `<pre class="mermaid">` |
+| `v2/mermaid_html_markdown_test.go` | Add XSS/escaping regression tests |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Linters/validators pass
+
+**Manual verification:**
+- Inspected rendered HTML for both pie and gantt charts to confirm escaped
+  entities appear and Mermaid syntax (titles, labels, task lines) is otherwise
+  intact.
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Treat any bytes written into an HTML context as text that needs encoding,
+  unless they are known-trusted markup produced by the renderer itself.
+- When a renderer's output is reused across formats (HTML, Markdown, raw files),
+  apply context-specific encoding at each embedding boundary rather than in the
+  shared producer.
+
+## Related
+
+- Transit ticket T-1293


### PR DESCRIPTION
## Bug

`htmlRenderer.renderChartContentHTML` rendered chart content through the Mermaid renderer and wrote the resulting bytes directly inside `<pre class="mermaid">` **without HTML escaping** (`v2/html_renderer.go`).

Chart titles, gantt task names, gantt section names, and pie slice labels are user-controlled, and the Mermaid renderer emits them as raw text. Values containing `<`, `</pre>`, or `<script>` could break out of the pre block or be interpreted as HTML/script by the browser — malformed output and a stored **XSS** injection path.

## Root cause

`renderChartContentHTML` wrote `mermaidData` straight into the HTML stream (`result.Write(mermaidData)`) with no output encoding, even though every other text path in `html_renderer.go` routes user data through `html.EscapeString`. The Mermaid bytes were treated as trusted markup rather than text that needs encoding for the HTML context they are placed in.

## Fix

Escape the Mermaid output with `html.EscapeString` before embedding it in the `<pre class="mermaid">` block.

This is safe for Mermaid.js: it reads the **text content** of the pre block, which the browser un-escapes before Mermaid parses it. So `<`, `>`, `&` are escaped for HTML safety while valid Mermaid syntax is preserved at parse time.

Escaping is applied at the HTML embedding boundary (not in the Mermaid renderer) because the Mermaid renderer also feeds Markdown code fences and standalone `.mmd` output, which must not be HTML-escaped.

## Tests

- Added `TestHTMLRenderer_ChartContent_EscapesUserText` — pie and gantt charts with `<script>` and `</pre>` payloads in titles, labels, task names, and section names. Asserts the payloads are escaped (`&lt;`, `&gt;`, `&#39;`) and that no literal `<script>` or `</pre><...>` markup appears inside the mermaid block.
- Updated the existing pie-chart HTML expectation: label quotes are now escaped (`&#34;`).
- `make test`, `make test-integration`, and `make lint` all pass.

See `v2/specs/bugfixes/html-chart-raw-mermaid/report.md` for the full investigation report.