### PR TITLE
Fix T-1091: Graph Renderers Skip Table Transformations

### DIFF
--- a/v2/graph_renderers.go
+++ b/v2/graph_renderers.go
@@ -61,8 +61,15 @@ func (d *dotRenderer) Render(ctx context.Context, doc *Document) ([]byte, error)
 		default:
 		}
 
+		// Apply per-content transformations (filter/sort/limit) before
+		// extracting graph data, so DOT output matches the other formats (T-1091).
+		transformed, err := applyContentTransformations(ctx, content)
+		if err != nil {
+			return nil, err
+		}
+
 		// Handle different content types
-		switch c := content.(type) {
+		switch c := transformed.(type) {
 		case *GraphContent:
 			d.renderGraphContent(&buf, c)
 		case *TableContent:
@@ -170,8 +177,19 @@ func (m *mermaidRenderer) Format() string {
 func (m *mermaidRenderer) Render(ctx context.Context, doc *Document) ([]byte, error) {
 	var buf bytes.Buffer
 
-	// Process each content item
-	contents := doc.GetContents()
+	// Process each content item. Apply per-content transformations
+	// (filter/sort/limit) up front so both the detection pass and the render
+	// pass operate on the transformed content, matching the other formats (T-1091).
+	rawContents := doc.GetContents()
+	contents := make([]Content, len(rawContents))
+	for i, content := range rawContents {
+		transformed, err := applyContentTransformations(ctx, content)
+		if err != nil {
+			return nil, err
+		}
+		contents[i] = transformed
+	}
+
 	hasFlowchart := false
 	specializedCharts := []Content{}
 	hasGraphContent := false
@@ -473,8 +491,20 @@ func (d *drawioRenderer) Format() string {
 func (d *drawioRenderer) Render(ctx context.Context, doc *Document) ([]byte, error) {
 	var buf bytes.Buffer
 
-	// Process each content item
-	contents := doc.GetContents()
+	// Process each content item. Apply per-content transformations
+	// (filter/sort/limit) up front so both the compatibility-detection pass and
+	// the render pass operate on the transformed content, matching the other
+	// formats (T-1091).
+	rawContents := doc.GetContents()
+	contents := make([]Content, len(rawContents))
+	for i, content := range rawContents {
+		transformed, err := applyContentTransformations(ctx, content)
+		if err != nil {
+			return nil, err
+		}
+		contents[i] = transformed
+	}
+
 	hasDrawIOContent := false
 
 	// Check if we have any Draw.io-compatible content

--- a/v2/graph_renderers_test.go
+++ b/v2/graph_renderers_test.go
@@ -443,3 +443,118 @@ func TestDrawioRenderer_Render(t *testing.T) {
 		})
 	}
 }
+
+// graphTransformationDoc builds a document with a single edge table that has
+// from/to/label columns and a filter + limit transformation attached.
+//
+// Source rows (in order):
+//   - keep1 -> keep1b   (keep = true)
+//   - drop1 -> drop1b   (keep = false, filtered out)
+//   - keep2 -> keep2b   (keep = true)
+//   - keep3 -> keep3b   (keep = true, removed by limit 2)
+//
+// After the filter (keep == true) and limit (2), only the first two kept rows
+// survive: keep1 -> keep1b and keep2 -> keep2b.
+func graphTransformationDoc() *Document {
+	return New().
+		Table("Edges", []map[string]any{
+			{"from": "keep1", "to": "keep1b", "label": "L1", "keep": true},
+			{"from": "drop1", "to": "drop1b", "label": "L2", "keep": false},
+			{"from": "keep2", "to": "keep2b", "label": "L3", "keep": true},
+			{"from": "keep3", "to": "keep3b", "label": "L4", "keep": true},
+		},
+			WithKeys("from", "to", "label", "keep"),
+			WithTransformations(
+				NewFilterOp(func(r Record) bool {
+					kept, _ := r["keep"].(bool)
+					return kept
+				}),
+				NewLimitOp(2),
+			),
+		).
+		Build()
+}
+
+// TestDOTRenderer_AppliesTableTransformations is a regression test for T-1091:
+// the DOT renderer must apply per-content transformations (filter/limit) before
+// extracting graph data from a table, so filtered/limited rows do not appear.
+func TestDOTRenderer_AppliesTableTransformations(t *testing.T) {
+	ctx := context.Background()
+	renderer := &dotRenderer{}
+
+	got, err := renderer.Render(ctx, graphTransformationDoc())
+	if err != nil {
+		t.Fatalf("DOTRenderer.Render() error = %v", err)
+	}
+	gotStr := string(got)
+
+	wantPresent := []string{"keep1 -> keep1b", "keep2 -> keep2b"}
+	for _, want := range wantPresent {
+		if !strings.Contains(gotStr, want) {
+			t.Errorf("DOTRenderer.Render() missing expected edge %q\nGot:\n%s", want, gotStr)
+		}
+	}
+
+	wantAbsent := []string{"drop1", "keep3"}
+	for _, absent := range wantAbsent {
+		if strings.Contains(gotStr, absent) {
+			t.Errorf("DOTRenderer.Render() included transformed-out row %q\nGot:\n%s", absent, gotStr)
+		}
+	}
+}
+
+// TestMermaidRenderer_AppliesTableTransformations is a regression test for
+// T-1091: the Mermaid renderer must apply per-content transformations before
+// extracting graph data from a table.
+func TestMermaidRenderer_AppliesTableTransformations(t *testing.T) {
+	ctx := context.Background()
+	renderer := &mermaidRenderer{}
+
+	got, err := renderer.Render(ctx, graphTransformationDoc())
+	if err != nil {
+		t.Fatalf("MermaidRenderer.Render() error = %v", err)
+	}
+	gotStr := string(got)
+
+	wantPresent := []string{"keep1 -->|L1| keep1b", "keep2 -->|L3| keep2b"}
+	for _, want := range wantPresent {
+		if !strings.Contains(gotStr, want) {
+			t.Errorf("MermaidRenderer.Render() missing expected edge %q\nGot:\n%s", want, gotStr)
+		}
+	}
+
+	wantAbsent := []string{"drop1", "keep3"}
+	for _, absent := range wantAbsent {
+		if strings.Contains(gotStr, absent) {
+			t.Errorf("MermaidRenderer.Render() included transformed-out row %q\nGot:\n%s", absent, gotStr)
+		}
+	}
+}
+
+// TestDrawioRenderer_AppliesTableTransformations is a regression test for
+// T-1091: the Draw.io renderer must apply per-content transformations before
+// emitting table rows as CSV.
+func TestDrawioRenderer_AppliesTableTransformations(t *testing.T) {
+	ctx := context.Background()
+	renderer := &drawioRenderer{}
+
+	got, err := renderer.Render(ctx, graphTransformationDoc())
+	if err != nil {
+		t.Fatalf("DrawioRenderer.Render() error = %v", err)
+	}
+	gotStr := string(got)
+
+	wantPresent := []string{"keep1", "keep2"}
+	for _, want := range wantPresent {
+		if !strings.Contains(gotStr, want) {
+			t.Errorf("DrawioRenderer.Render() missing expected row %q\nGot:\n%s", want, gotStr)
+		}
+	}
+
+	wantAbsent := []string{"drop1", "keep3"}
+	for _, absent := range wantAbsent {
+		if strings.Contains(gotStr, absent) {
+			t.Errorf("DrawioRenderer.Render() included transformed-out row %q\nGot:\n%s", absent, gotStr)
+		}
+	}
+}

--- a/v2/specs/bugfixes/graph-renderers-skip-transformations/report.md
+++ b/v2/specs/bugfixes/graph-renderers-skip-transformations/report.md
@@ -1,0 +1,123 @@
+# Bugfix Report: Graph Renderers Skip Table Transformations
+
+**Date:** 2026-05-25
+**Status:** Fixed
+
+## Description of the Issue
+
+The DOT, Mermaid, and Draw.io renderers bypassed per-content transformations
+(filter/sort/limit) on their graph/table-specific render paths. As a result,
+a table built with `WithTransformations(...)` rendered transformed rows through
+JSON/CSV/HTML/Table/Markdown (which go through `baseRenderer.renderTransformedDocument`),
+but rendered the original, untransformed rows through DOT/Mermaid/Draw.io.
+
+**Reproduction steps:**
+1. Build a document with a `Table` that has from/to columns and attach
+   `WithTransformations(NewFilterOp(...), NewLimitOp(2))`.
+2. Render the document with the DOT, Mermaid, or Draw.io renderer.
+3. Observe that rows which should have been filtered out or removed by the limit
+   still appear in the diagram/CSV output.
+
+**Impact:** Medium. Diagrams and Draw.io CSV exports produced from the same
+document as other formats could contain incorrect (extra, unsorted, or unlimited)
+data, silently disagreeing with every other output format.
+
+## Investigation Summary
+
+- **Symptoms examined:** Graph outputs included rows that the attached filter and
+  limit operations should have removed.
+- **Code inspected:** `v2/base_renderer.go` (where ordinary renderers apply
+  `applyContentTransformations`), `v2/renderer.go` (`applyContentTransformations`
+  helper), `v2/graph_renderers.go` (the three custom renderers), `v2/operations.go`
+  (filter/sort/limit `Apply`).
+- **Hypotheses tested:** Confirmed that `applyContentTransformations` is only
+  invoked inside `baseRenderer.renderTransformedDocument` / `renderDocumentTo`.
+  The graph renderers implement their own `Render` loops that iterate
+  `doc.GetContents()` and type-switch on the raw content without ever calling
+  `applyContentTransformations`.
+
+## Discovered Root Cause
+
+The DOT, Mermaid, and Draw.io renderers each have bespoke `Render` methods that
+read `*TableContent.records`/`schema` (or `*GraphContent`/`*ChartContent`) directly
+from `doc.GetContents()`. Per-content transformations live only in
+`applyContentTransformations`, which these custom paths never call, so the
+transformations attached to the content are ignored.
+
+**Defect type:** Missing call to existing transformation step on alternate code paths.
+
+**Why it occurred:** Per-content transformations were centralised in
+`baseRenderer.renderTransformedDocument`. The graph renderers build a single
+combined output (one digraph / one mermaid graph / one CSV) instead of
+concatenating per-content output, so they did not reuse that base path and
+therefore skipped the transformation step.
+
+**Contributing factors:** The transformation logic is not enforced by the
+`Content` interface; it is the renderer's responsibility to call it, making it
+easy to omit on a custom path.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `v2/graph_renderers.go` — DOT `Render`: apply `applyContentTransformations(ctx, content)`
+  at the top of the content loop and switch on the transformed content.
+- `v2/graph_renderers.go` — Mermaid `Render`: transform each content once up front
+  into a transformed slice; use the transformed slice for both the detection pass
+  and the flowchart render pass.
+- `v2/graph_renderers.go` — Draw.io `Render`: transform each content once up front
+  into a transformed slice; use it for both the compatibility-detection pass and
+  the render pass.
+
+**Approach rationale:** Reuse the existing `applyContentTransformations` helper
+(the same one the base renderer uses) so graph output matches every other format.
+For Mermaid and Draw.io, which scan content twice (once to decide headers/compatibility,
+once to render), the content is transformed a single time into a reused slice to keep
+the two passes consistent and avoid transforming twice.
+
+**Alternatives considered:**
+- Route graph renderers through `baseRenderer.renderTransformedDocument` — rejected
+  because those renderers intentionally produce a single combined document
+  (one digraph/graph/CSV) rather than per-content concatenation, so the base loop
+  does not fit.
+
+## Regression Test
+
+**Test file:** `v2/graph_renderers_test.go`
+**Test names:** `TestDOTRenderer_AppliesTableTransformations`,
+`TestMermaidRenderer_AppliesTableTransformations`,
+`TestDrawioRenderer_AppliesTableTransformations`
+
+**What it verifies:** A table with from/to/label columns and a filter (`keep == true`)
+plus a limit (2) renders only the two surviving rows (`keep1`, `keep2`) through each
+renderer, and the filtered-out (`drop1`) and limited-off (`keep3`) rows are absent.
+
+**Run command:** `go test -run 'AppliesTableTransformations' ./v2/`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `v2/graph_renderers.go` | Apply `applyContentTransformations` before graph detection/render in DOT, Mermaid, Draw.io |
+| `v2/graph_renderers_test.go` | Added three regression tests |
+
+## Verification
+
+**Automated:**
+- [x] Regression tests pass
+- [x] Full test suite passes
+- [x] Linters/validators pass
+
+**Manual verification:**
+- Confirmed red state before the fix (all rows present) and green after.
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Any renderer with a custom `Render` path that reads content data directly must
+  call `applyContentTransformations` first, matching `baseRenderer`.
+- Consider a shared helper that yields transformed contents so custom renderers
+  cannot forget the transformation step.
+
+## Related
+
+- Transit ticket T-1091


### PR DESCRIPTION
## Bug

The DOT, Mermaid, and Draw.io renderers bypassed per-content transformations
(filter/sort/limit) on their graph/table-specific render paths. A table built
with `WithTransformations(...)` rendered transformed rows through
JSON/CSV/HTML/Table/Markdown, but rendered the original, untransformed rows
through DOT/Mermaid/Draw.io — producing diagrams and Draw.io CSV exports that
silently disagreed with every other output format.

## Root cause

Per-content transformations live only in `applyContentTransformations`, which
`baseRenderer.renderTransformedDocument` calls for ordinary formats. The DOT,
Mermaid, and Draw.io renderers have bespoke `Render` methods that iterate
`doc.GetContents()` and read `*TableContent`/`*GraphContent`/`*ChartContent`
data directly, never calling `applyContentTransformations`.

## Fix

Apply `applyContentTransformations(ctx, content)` before graph compatibility
detection/rendering in all three renderers, in `v2/graph_renderers.go`:

- **DOT**: transform each content at the top of the render loop and switch on
  the transformed content.
- **Mermaid** and **Draw.io**: these scan content twice (a detection pass then a
  render pass), so each content is transformed once into a reused slice shared by
  both passes, keeping them consistent.

The non-graph fallback paths still pass the original document to
`renderDocumentWithFormat`, which applies transformations itself.

## Tests

Added regression tests in `v2/graph_renderers_test.go`
(`TestDOTRenderer_AppliesTableTransformations`,
`TestMermaidRenderer_AppliesTableTransformations`,
`TestDrawioRenderer_AppliesTableTransformations`): a table with from/to/label
columns plus a filter (`keep == true`) and a limit (2) must render only the two
surviving rows; filtered-out and limited-off rows must be absent. Confirmed red
before the fix and green after.

`make test` and `make lint` both pass.

Bugfix report: `v2/specs/bugfixes/graph-renderers-skip-transformations/report.md`

Closes T-1091.