### PR TITLE
Fix T-1304: NewDrawIOContentFromTable Panics On Nil Table

### DIFF
--- a/v2/graph_content.go
+++ b/v2/graph_content.go
@@ -437,8 +437,17 @@ func NewDrawIOContent(title string, records []Record, header DrawIOHeader) *Draw
 	}
 }
 
-// NewDrawIOContentFromTable creates Draw.io content from table data
+// NewDrawIOContentFromTable creates Draw.io content from table data.
+// A nil table yields safe, empty content rather than a panic, since this
+// constructor returns no error to report the invalid input.
 func NewDrawIOContentFromTable(table *TableContent, header DrawIOHeader) *DrawIOContent {
+	if table == nil {
+		return &DrawIOContent{
+			id:     GenerateID(),
+			header: header,
+		}
+	}
+
 	return &DrawIOContent{
 		id:      GenerateID(),
 		title:   table.title,

--- a/v2/graph_content_mutation_test.go
+++ b/v2/graph_content_mutation_test.go
@@ -113,6 +113,28 @@ func TestDrawIOContentFromTable_MutateSourceTableRecords(t *testing.T) {
 	}
 }
 
+// Regression test for T-1304: NewDrawIOContentFromTable panics on nil table.
+// Passing a nil *TableContent must not panic; the constructor must return
+// safe, empty content instead of dereferencing the nil table.
+func TestDrawIOContentFromTable_NilTable(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("NewDrawIOContentFromTable panicked on nil table: %v", r)
+		}
+	}()
+
+	d := NewDrawIOContentFromTable(nil, DefaultDrawIOHeader())
+	if d == nil {
+		t.Fatal("NewDrawIOContentFromTable(nil, ...) returned nil, want non-nil empty content")
+	}
+	if got := d.GetRecords(); len(got) != 0 {
+		t.Errorf("nil table produced %d records, want 0", len(got))
+	}
+	if got := d.GetTitle(); got != "" {
+		t.Errorf("nil table produced title %q, want empty", got)
+	}
+}
+
 // Regression tests for T-1305: ChartContent/GanttData/PieData expose mutable
 // caller-owned data. NewGanttChart and NewPieChart must defensively copy their
 // input slices (including each Gantt task's Dependencies slice), GetData must


### PR DESCRIPTION
## Bug

`NewDrawIOContentFromTable(table *TableContent, header DrawIOHeader)` (in `v2/graph_content.go`) read `table.title` and `cloneRecords(table.records)` with no nil check. Calling it with a nil `*TableContent` panicked with a nil pointer dereference instead of returning usable content.

## Root cause

Missing nil-input validation. The constructor assumed a valid table was always passed. Unlike the sibling `NewGraphContentFromTable` (which guards nil and returns an error), this constructor returns only `*DrawIOContent` with no error channel, so a nil could not be reported as an error without a breaking signature change.

## Fix

Add a `if table == nil` guard at the start of `NewDrawIOContentFromTable` that returns safe, empty content (generated ID + supplied header, no records or title). This removes the panic while preserving the public API. The existing T-1295 defensive deep-copy logic (`cloneRecords`) is unchanged.

## Tests

Added regression test `TestDrawIOContentFromTable_NilTable` in `v2/graph_content_mutation_test.go` that fails (panics) before the fix and passes after, asserting the nil case returns non-nil content with zero records and an empty title.

`make test` and `make lint` both pass.