### PR TITLE
Fix T-1281: AddColumn Duplicates Existing Schema Keys

### DIFF
--- a/v2/docs/API.md
+++ b/v2/docs/API.md
@@ -1606,6 +1606,9 @@ doc.Pipeline().
 - **Parameter**: `Record` - Full record with all existing fields
 - **Returns**: `any` - Calculated value for new column
 - **Position**: Use `AddColumnAt()` to specify column position
+- **Duplicate names**: The column name must not already exist in the table
+  schema. Adding a column whose name matches an existing field returns a
+  `ValidationError`; the operation never overwrites existing fields.
 
 #### Pipeline Options
 

--- a/v2/operations.go
+++ b/v2/operations.go
@@ -840,6 +840,15 @@ func (o *AddColumnOp) Apply(ctx context.Context, content Content) (Content, erro
 	// Clone the content to preserve immutability
 	cloned := tableContent.Clone().(*TableContent)
 
+	// Reject column names that already exist in the schema. Without this guard
+	// Apply would overwrite the existing record value and evolveSchema would
+	// append a duplicate entry to the key order, causing renderers to emit
+	// duplicate headers/columns for the same field (T-1281).
+	if cloned.schema != nil && cloned.schema.HasField(o.name) {
+		return nil, NewValidationError("column_name", o.name,
+			fmt.Sprintf("addColumn cannot add column %q because it already exists in the table schema", o.name))
+	}
+
 	// Add the new column to each record
 	for i, record := range cloned.records {
 		// Check context cancellation

--- a/v2/operations_transform_test.go
+++ b/v2/operations_transform_test.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -490,6 +491,102 @@ func TestAddColumnOpApply(t *testing.T) {
 		if len(tableContent.records[0]) != originalRecordFieldCount {
 			t.Errorf("original record was modified: had %d fields, now has %d",
 				originalRecordFieldCount, len(tableContent.records[0]))
+		}
+	})
+}
+
+// TestAddColumnOpDuplicateColumn is a regression test for T-1281.
+//
+// AddColumnOp previously did not reject a column name that already existed in
+// the schema. Apply overwrote the existing record value, and evolveSchema
+// unconditionally appended the name to the key order, producing a duplicate
+// entry. Renderers iterate the key order directly, so the output gained
+// duplicate headers/columns for the same field.
+//
+// Expected behaviour: reject a duplicate column name with a ValidationError and
+// leave the original content untouched.
+func TestAddColumnOpDuplicateColumn(t *testing.T) {
+	t.Run("rejects column name that already exists in schema", func(t *testing.T) {
+		addColumnOp := &AddColumnOp{
+			name: "name",
+			fn:   func(r Record) any { return "overwritten" },
+		}
+
+		doc := New().
+			Table("test", []Record{
+				{"id": 1, "name": "Alice"},
+				{"id": 2, "name": "Bob"},
+			}).
+			Build()
+
+		tableContent := doc.GetContents()[0].(*TableContent)
+
+		result, err := addColumnOp.Apply(context.Background(), tableContent)
+		if err == nil {
+			t.Fatalf("expected error for duplicate column, got nil (result: %v)", result)
+		}
+
+		var valErr *ValidationError
+		if !errors.As(err, &valErr) {
+			t.Fatalf("expected *ValidationError, got %T: %v", err, err)
+		}
+		if valErr.Field != "column_name" {
+			t.Errorf("expected error field 'column_name', got %q", valErr.Field)
+		}
+	})
+
+	t.Run("does not duplicate schema keys for existing column", func(t *testing.T) {
+		addColumnOp := &AddColumnOp{
+			name: "name",
+			fn:   func(r Record) any { return "overwritten" },
+		}
+
+		doc := New().
+			Table("test", []Record{
+				{"id": 1, "name": "Alice"},
+			}).
+			Build()
+
+		tableContent := doc.GetContents()[0].(*TableContent)
+
+		_, err := addColumnOp.Apply(context.Background(), tableContent)
+		if err == nil {
+			t.Fatal("expected error for duplicate column, got nil")
+		}
+
+		// Original schema key order must remain free of duplicates.
+		keyOrder := tableContent.schema.GetKeyOrder()
+		seen := make(map[string]bool, len(keyOrder))
+		for _, key := range keyOrder {
+			if seen[key] {
+				t.Errorf("duplicate key %q in key order %v", key, keyOrder)
+			}
+			seen[key] = true
+		}
+	})
+
+	t.Run("leaves original content unchanged when rejecting", func(t *testing.T) {
+		addColumnOp := &AddColumnOp{
+			name: "name",
+			fn:   func(r Record) any { return "overwritten" },
+		}
+
+		doc := New().
+			Table("test", []Record{
+				{"id": 1, "name": "Alice"},
+			}).
+			Build()
+
+		tableContent := doc.GetContents()[0].(*TableContent)
+
+		_, err := addColumnOp.Apply(context.Background(), tableContent)
+		if err == nil {
+			t.Fatal("expected error for duplicate column, got nil")
+		}
+
+		// The existing value must not be overwritten.
+		if got := tableContent.records[0]["name"]; got != "Alice" {
+			t.Errorf("original record value was modified: expected 'Alice', got %v", got)
 		}
 	})
 }


### PR DESCRIPTION
## Bug

`AddColumnOp` did not reject or handle a column name that already existed in a table's schema (Transit T-1281).

When the requested column name matched an existing field:

1. `Apply` wrote `cloned.records[i][o.name] = value`, silently overwriting the existing record value.
2. `evolveSchema` unconditionally allocated `len(originalKeyOrder)+1` and appended/inserted `o.name`, producing a duplicate entry in the schema key order.

Renderers such as `TableContent.AppendText` iterate the schema key order directly, so the duplicated key produced duplicate headers/columns for the same field in the rendered output. The data overwrite was silent — no error was returned.

## Root cause

`AddColumnOp` was designed only for the "add a brand-new column" case and never validated `o.name` against the existing schema. `Validate()` cannot perform this check because it has no access to the content/schema, so the guard must live in `Apply`. `evolveSchema` building the key order from `len(originalKeyOrder)+1` with no de-duplication turned the missing validation into a structurally invalid schema.

## Fix

`AddColumnOp.Apply` now checks `cloned.schema.HasField(o.name)` (when a schema is present) immediately after cloning, before mutating any records or schema, and returns a `ValidationError` on the `column_name` field if the column already exists. On rejection the original content is untouched — no overwrite, no duplicate keys.

A documented "replace" mode was deliberately not added: there is no existing API surface or caller demand to opt into it, and silently overwriting data is surprising. Rejecting with a `ValidationError` is the simplest, safest option and matches the operation's existing error-handling style. A replace mode could be added later as an explicit opt-in option if needed.

## Tests

Added `TestAddColumnOpDuplicateColumn` in `v2/operations_transform_test.go` covering:
- AddColumn with an existing field name returns a `*ValidationError` on the `column_name` field.
- The schema key order contains no duplicate keys after a rejected AddColumn.
- The original record value for the colliding field is not overwritten.

Verified red (fail before fix) then green (pass after fix). `make check` (fmt + lint + full test suite) passes with 0 lint issues.

Also documented the duplicate-name behaviour in `v2/docs/API.md`.