### PR TITLE
Fix T-1168: MultiWriter Panics On Nil Writers

### DIFF
--- a/v2/docs/API.md
+++ b/v2/docs/API.md
@@ -1019,7 +1019,8 @@ func NewFileWriter(rootDir, pattern string) (Writer, error)
 // S3Writer writes to AWS S3 (compatible with AWS SDK v2)
 func NewS3Writer(client S3PutObjectAPI, bucket, keyPattern string) *S3Writer
 
-// MultiWriter writes to multiple destinations
+// MultiWriter writes to multiple destinations.
+// Nil writers passed to NewMultiWriter or AddWriter are ignored.
 func NewMultiWriter(writers ...Writer) Writer
 ```
 

--- a/v2/multi_writer.go
+++ b/v2/multi_writer.go
@@ -13,11 +13,19 @@ type MultiWriter struct {
 	mu      sync.RWMutex // For concurrent access to writers slice
 }
 
-// NewMultiWriter creates a new MultiWriter with the specified writers
+// NewMultiWriter creates a new MultiWriter with the specified writers.
+// Nil writers are ignored: a nil Writer is never a valid destination, and
+// storing one would cause a nil interface method call (panic) during Write.
 func NewMultiWriter(writers ...Writer) *MultiWriter {
+	valid := make([]Writer, 0, len(writers))
+	for _, w := range writers {
+		if w != nil {
+			valid = append(valid, w)
+		}
+	}
 	return &MultiWriter{
 		baseWriter: baseWriter{name: "multi"},
-		writers:    writers,
+		writers:    valid,
 	}
 }
 
@@ -50,6 +58,12 @@ func (mw *MultiWriter) Write(ctx context.Context, format string, data []byte) er
 	errChan := make(chan error, len(writers))
 
 	for _, writer := range writers {
+		// Defence in depth: NewMultiWriter and AddWriter already drop nil
+		// writers, but skip any that slip through so the goroutine never
+		// calls a method on a nil interface (which would panic).
+		if writer == nil {
+			continue
+		}
 		wg.Add(1)
 		go func(w Writer) {
 			defer wg.Done()
@@ -77,8 +91,12 @@ func (mw *MultiWriter) Write(ctx context.Context, format string, data []byte) er
 	return nil
 }
 
-// AddWriter adds a writer to the multi-writer
+// AddWriter adds a writer to the multi-writer. A nil writer is ignored:
+// it is never a valid destination and would panic during Write.
 func (mw *MultiWriter) AddWriter(w Writer) {
+	if w == nil {
+		return
+	}
 	mw.mu.Lock()
 	defer mw.mu.Unlock()
 	mw.writers = append(mw.writers, w)

--- a/v2/multi_writer_test.go
+++ b/v2/multi_writer_test.go
@@ -210,6 +210,73 @@ func TestMultiWriterAddRemove(t *testing.T) {
 	}
 }
 
+// TestMultiWriterNilWriterFromConstructor reproduces T-1168.
+//
+// Bug: NewMultiWriter stored nil Writer values as-is. During Write, each
+// writer was handed to a goroutine that called w.Write directly, so a nil
+// interface caused a nil-method-call panic in a child goroutine, crashing
+// the caller instead of returning a normal error.
+//
+// Expected: nil writers are rejected at construction time so they never
+// reach a Write goroutine, and Write completes without panicking.
+func TestMultiWriterNilWriterFromConstructor(t *testing.T) {
+	w1 := &mockWriter{name: "w1"}
+
+	// A nil Writer mixed in with a valid one must not be stored.
+	mw := NewMultiWriter(w1, nil)
+
+	if got := mw.WriterCount(); got != 1 {
+		t.Fatalf("WriterCount() = %d, want 1 (nil writer should be dropped)", got)
+	}
+
+	// Must not panic when writing.
+	if err := mw.Write(context.Background(), FormatText, []byte("data")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := w1.String(); got != "data" {
+		t.Errorf("w1 got %q, want %q", got, "data")
+	}
+}
+
+// TestMultiWriterNilWriterFromAddWriter reproduces T-1168 for the AddWriter path.
+func TestMultiWriterNilWriterFromAddWriter(t *testing.T) {
+	mw := NewMultiWriter()
+
+	mw.AddWriter(nil)
+	if got := mw.WriterCount(); got != 0 {
+		t.Fatalf("after AddWriter(nil): WriterCount() = %d, want 0", got)
+	}
+
+	w1 := &mockWriter{name: "w1"}
+	mw.AddWriter(w1)
+	mw.AddWriter(nil)
+	if got := mw.WriterCount(); got != 1 {
+		t.Fatalf("WriterCount() = %d, want 1 (nil writer should be dropped)", got)
+	}
+
+	if err := mw.Write(context.Background(), FormatText, []byte("data")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := w1.String(); got != "data" {
+		t.Errorf("w1 got %q, want %q", got, "data")
+	}
+}
+
+// TestMultiWriterOnlyNilWriters ensures a MultiWriter built solely from nil
+// writers behaves like one with no writers (error, no panic).
+func TestMultiWriterOnlyNilWriters(t *testing.T) {
+	mw := NewMultiWriter(nil, nil)
+	if got := mw.WriterCount(); got != 0 {
+		t.Fatalf("WriterCount() = %d, want 0", got)
+	}
+
+	err := mw.Write(context.Background(), FormatText, []byte("data"))
+	if err == nil {
+		t.Fatal("expected error for MultiWriter with no usable writers, got nil")
+	}
+}
+
 func TestMultiWriterConcurrency(t *testing.T) {
 	// Create writers that count writes
 	var count1, count2, count3 int32


### PR DESCRIPTION
## Summary

Fixes T-1168. `MultiWriter` accepted nil `Writer` values via `NewMultiWriter(writers ...Writer)` and `AddWriter(w Writer)` without validation, which could crash callers.

## Bug

`(*MultiWriter).Write` snapshots the writers slice and starts one goroutine per writer that calls `w.Write(ctx, format, data)` directly. If any stored writer is nil, that goroutine panics with a nil interface method call. Because the panic happens in a child goroutine it cannot be recovered by the caller and crashes the process instead of returning a normal `WriteError`/`MultiWriteError`.

## Root Cause

The public API never enforced the non-nil invariant: `NewMultiWriter` stored its variadic argument as-is and `AddWriter` appended unconditionally, so a nil interface could reach the per-writer goroutine and be dereferenced.

## Fix

- `NewMultiWriter` filters out nil writers when building the initial slice.
- `AddWriter` skips appending when the supplied writer is nil.
- `Write` adds a defensive nil-skip guard in the goroutine spawn loop (defence in depth).

Nil writers are silently dropped rather than rejected via a returned error, keeping the existing non-error API signatures (consistent with the other writer constructors) intact. Nil is never a valid destination, so dropping it is safe and keeps `WriterCount` accurate. Scope is limited to `v2/multi_writer.go`; this is distinct from T-1120.

## Tests

Added regression tests in `v2/multi_writer_test.go` (`TestMultiWriterNilWriterFromConstructor`, `TestMultiWriterNilWriterFromAddWriter`, `TestMultiWriterOnlyNilWriters`) that fail before the fix and pass after. Full suite (`make test`) and `make lint` pass.