### PR TITLE
Fix T-1315: CSV Collapsible Sections Skip Headers For Schema Changes

### DIFF
--- a/v2/csv_renderer.go
+++ b/v2/csv_renderer.go
@@ -125,13 +125,13 @@ func (c *csvRenderer) renderDocumentCSVTo(ctx context.Context, doc *Document, w 
 			}
 
 		case *DefaultCollapsibleSection:
-			// Handle CollapsibleSection with metadata comments (Requirement 15.8)
-			hasWritten := lastKeyOrder != nil
-			if err := c.renderCollapsibleSectionCSV(content, csvWriter, &hasWritten); err != nil {
+			// Handle CollapsibleSection with metadata comments (Requirement 15.8).
+			// lastKeyOrder is shared so header re-writes and separators stay
+			// consistent with surrounding top-level tables, and so tables inside
+			// the section get their own headers whenever the schema changes
+			// (T-1315).
+			if err := c.renderCollapsibleSectionCSV(content, csvWriter, &lastKeyOrder); err != nil {
 				return fmt.Errorf("failed to render collapsible section %s: %w", content.ID(), err)
-			}
-			if hasWritten && lastKeyOrder == nil {
-				lastKeyOrder = []string{"_collapsible"}
 			}
 
 		default:
@@ -454,8 +454,14 @@ func (c *csvRenderer) flattenDetails(details any) string {
 	}
 }
 
-// renderCollapsibleSectionCSV renders a CollapsibleSection with metadata comments (Requirement 15.8)
-func (c *csvRenderer) renderCollapsibleSectionCSV(section *DefaultCollapsibleSection, csvWriter *csv.Writer, hasWrittenHeaders *bool) error {
+// renderCollapsibleSectionCSV renders a CollapsibleSection with metadata comments (Requirement 15.8).
+//
+// lastKeyOrder is shared with the document-level renderer so that headers are
+// re-written and separators inserted whenever a table's key order changes,
+// mirroring the normal CSV path and renderSectionTablesCSV (T-1315). Tracking a
+// single boolean previously suppressed headers for every table after the first,
+// producing malformed CSV when a section held tables with differing schemas.
+func (c *csvRenderer) renderCollapsibleSectionCSV(section *DefaultCollapsibleSection, csvWriter *csv.Writer, lastKeyOrder *[]string) error {
 	// Add section metadata as CSV comments or special rows (Requirement 15.8)
 
 	// Since CSV doesn't support comments officially, we'll use a special metadata row format
@@ -475,6 +481,14 @@ func (c *csvRenderer) renderCollapsibleSectionCSV(section *DefaultCollapsibleSec
 	for i, content := range section.Content() {
 		switch contentItem := content.(type) {
 		case *TableContent:
+			// Add a blank separator row between tables (matches top-level
+			// behaviour) when a previous table has already been written.
+			if *lastKeyOrder != nil {
+				if err := csvWriter.Write([]string{}); err != nil {
+					return fmt.Errorf("failed to write separator row: %w", err)
+				}
+			}
+
 			// For table content, add section context to CSV (Requirement 15.8)
 			if contentItem.Title() != "" {
 				// Add table title with section context
@@ -484,12 +498,14 @@ func (c *csvRenderer) renderCollapsibleSectionCSV(section *DefaultCollapsibleSec
 				}
 			}
 
-			// Render the table content
-			writeHeaders := !*hasWrittenHeaders
+			// Write headers for the first table or whenever the schema/key
+			// order differs from the previously rendered table (T-1315).
+			keyOrder := contentItem.getSchema().GetKeyOrder()
+			writeHeaders := !keyOrdersEqual(*lastKeyOrder, keyOrder)
 			if err := c.renderTableContentCSV(contentItem, csvWriter, writeHeaders); err != nil {
 				return fmt.Errorf("failed to render section table: %w", err)
 			}
-			*hasWrittenHeaders = true
+			*lastKeyOrder = keyOrder
 
 		default:
 			// For non-table content, add as metadata (Requirement 15.8)

--- a/v2/csv_renderer_collapsible_schema_test.go
+++ b/v2/csv_renderer_collapsible_schema_test.go
@@ -1,0 +1,118 @@
+package output
+
+import (
+	"context"
+	"encoding/csv"
+	"strings"
+	"testing"
+)
+
+// TestCSVRenderer_CollapsibleSectionMultipleSchemas reproduces T-1315.
+//
+// A DefaultCollapsibleSection that contains multiple TableContent entries with
+// different key orders previously wrote headers only for the first table
+// (renderCollapsibleSectionCSV tracked a single boolean hasWrittenHeaders).
+// Later tables then rendered their rows without their own headers, producing
+// malformed CSV where later values appear under the previous table's columns.
+//
+// Expected: like the top-level CSV path, headers are (re)written whenever a
+// table's key order differs from the previously rendered table.
+func TestCSVRenderer_CollapsibleSectionMultipleSchemas(t *testing.T) {
+	employees, err := NewTableContent("employees", []map[string]any{
+		{"Name": "Alice", "Department": "Engineering"},
+		{"Name": "Bob", "Department": "Marketing"},
+	}, WithKeys("Name", "Department"))
+	if err != nil {
+		t.Fatalf("failed to create employees table: %v", err)
+	}
+
+	projects, err := NewTableContent("projects", []map[string]any{
+		{"Project": "Alpha", "Status": "Active", "Budget": 100000},
+		{"Project": "Beta", "Status": "Complete", "Budget": 50000},
+	}, WithKeys("Project", "Status", "Budget"))
+	if err != nil {
+		t.Fatalf("failed to create projects table: %v", err)
+	}
+
+	section := NewCollapsibleSection("Quarterly Report", []Content{employees, projects})
+	doc := New().AddContent(section).Build()
+
+	renderer := &csvRenderer{}
+	result, err := renderer.Render(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+
+	csvReader := csv.NewReader(strings.NewReader(string(result)))
+	csvReader.FieldsPerRecord = -1 // allow variable field counts
+	records, err := csvReader.ReadAll()
+	if err != nil {
+		t.Fatalf("Failed to parse CSV: %v", err)
+	}
+
+	// The second table has a different key order, so its header row must be
+	// present in the output.
+	foundFirstHeader := false
+	foundSecondHeader := false
+	for _, row := range records {
+		if len(row) >= 2 && row[0] == "Name" && row[1] == "Department" {
+			foundFirstHeader = true
+		}
+		if len(row) >= 3 && row[0] == "Project" && row[1] == "Status" && row[2] == "Budget" {
+			foundSecondHeader = true
+		}
+	}
+
+	if !foundFirstHeader {
+		t.Errorf("Expected headers for first table inside collapsible section, got:\n%s", string(result))
+	}
+	if !foundSecondHeader {
+		t.Errorf("Expected headers for second table with different schema inside collapsible section, got:\n%s", string(result))
+	}
+}
+
+// TestCSVRenderer_CollapsibleSectionSameSchema ensures the fix does not cause
+// redundant header rows when consecutive tables share a key order. Headers
+// should be written exactly once for the contiguous run of same-schema tables.
+func TestCSVRenderer_CollapsibleSectionSameSchema(t *testing.T) {
+	team1, err := NewTableContent("team1", []map[string]any{
+		{"Name": "Alice", "Score": 95},
+	}, WithKeys("Name", "Score"))
+	if err != nil {
+		t.Fatalf("failed to create team1 table: %v", err)
+	}
+
+	team2, err := NewTableContent("team2", []map[string]any{
+		{"Name": "Bob", "Score": 87},
+	}, WithKeys("Name", "Score"))
+	if err != nil {
+		t.Fatalf("failed to create team2 table: %v", err)
+	}
+
+	section := NewCollapsibleSection("Scores", []Content{team1, team2})
+	doc := New().AddContent(section).Build()
+
+	renderer := &csvRenderer{}
+	result, err := renderer.Render(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+
+	csvReader := csv.NewReader(strings.NewReader(string(result)))
+	csvReader.FieldsPerRecord = -1
+	records, err := csvReader.ReadAll()
+	if err != nil {
+		t.Fatalf("Failed to parse CSV: %v", err)
+	}
+
+	headerCount := 0
+	for _, row := range records {
+		if len(row) >= 2 && row[0] == "Name" && row[1] == "Score" {
+			headerCount++
+		}
+	}
+
+	if headerCount != 1 {
+		t.Errorf("Expected exactly 1 header row for same-schema tables in collapsible section, got %d.\nOutput:\n%s", headerCount, string(result))
+	}
+}


### PR DESCRIPTION
## Bug

In `v2/csv_renderer.go`, `renderCollapsibleSectionCSV` tracked only a boolean `hasWrittenHeaders`. When a `DefaultCollapsibleSection` contained multiple `TableContent` entries with different key orders, the first table wrote headers and later tables rendered rows without their own headers. This produced malformed CSV where the later table's values appeared under the previous table's column names.

## Root cause

For each table the code computed `writeHeaders := !*hasWrittenHeaders` and then unconditionally set `*hasWrittenHeaders = true`. A boolean cannot represent "the schema changed" — only "something was written" — so headers were never re-emitted after the first table, regardless of key order. The normal top-level CSV path and the recursive `renderSectionTablesCSV` helper (T-1239) already compare `lastKeyOrder` for this purpose; the collapsible path had not adopted that pattern.

## Fix

- `renderCollapsibleSectionCSV` now takes `*[]string lastKeyOrder` instead of `*bool`. For each table it:
  - writes a blank separator row when a previous table has already been written,
  - sets `writeHeaders := !keyOrdersEqual(*lastKeyOrder, keyOrder)`,
  - updates `*lastKeyOrder` to the rendered table's key order.
- The `DefaultCollapsibleSection` call site passes the document-level `&lastKeyOrder` directly, so header/separator decisions stay consistent with surrounding top-level tables. The previous `_collapsible` sentinel workaround is removed.
- T-1186 flush/`Error()` handling is preserved unchanged.

## Tests

New regression tests in `v2/csv_renderer_collapsible_schema_test.go`:
- `TestCSVRenderer_CollapsibleSectionMultipleSchemas` — two differing-schema tables in a collapsible section each emit their own header row.
- `TestCSVRenderer_CollapsibleSectionSameSchema` — two same-schema tables emit exactly one header row (no redundant headers).

`make test` and `make lint` both pass.