### PR TITLE
Fix T-1223: Collapsible Renderer Constructors Ignore Transformer Config

### DIFF
--- a/v2/base_renderer.go
+++ b/v2/base_renderer.go
@@ -563,14 +563,22 @@ func (mop *MemoryOptimizedProcessor) processMap(content map[string]any, maxLengt
 // NewMarkdownRendererWithCollapsible creates a markdown renderer with collapsible configuration
 func NewMarkdownRendererWithCollapsible(config RendererConfig) Renderer {
 	return &markdownRenderer{
-		baseRenderer:      baseRenderer{},
+		// RendererConfig is the single renderer config: it must also populate
+		// baseRenderer.config so the embedded renderDocumentWithFormat path
+		// honours the configured DataTransformers/ByteTransformers (T-1223).
+		baseRenderer:      baseRenderer{config: config},
 		includeToC:        false,
 		headingLevel:      1,
 		collapsibleConfig: config,
 	}
 }
 
-// NewTableRendererWithCollapsible creates a table renderer with collapsible configuration
+// NewTableRendererWithCollapsible creates a table renderer with collapsible configuration.
+//
+// Note: tableRenderer does not embed baseRenderer and renders through its own
+// path that never invokes renderDocumentWithFormat, so the config's
+// DataTransformers/ByteTransformers are not applied here. Only the collapsible
+// settings take effect for the table format.
 func NewTableRendererWithCollapsible(styleName string, config RendererConfig) Renderer {
 	return &tableRenderer{
 		styleName:         styleName,
@@ -581,12 +589,21 @@ func NewTableRendererWithCollapsible(styleName string, config RendererConfig) Re
 // NewHTMLRendererWithCollapsible creates an HTML renderer with collapsible configuration
 func NewHTMLRendererWithCollapsible(config RendererConfig) Renderer {
 	return &htmlRenderer{
-		baseRenderer:      baseRenderer{},
+		// RendererConfig is the single renderer config: it must also populate
+		// baseRenderer.config because htmlRenderer.Render routes through
+		// renderDocumentWithFormat, which reads the configured
+		// DataTransformers/ByteTransformers from baseRenderer.config (T-1223).
+		baseRenderer:      baseRenderer{config: config},
 		collapsibleConfig: config,
 	}
 }
 
-// NewCSVRendererWithCollapsible creates a CSV renderer with collapsible configuration
+// NewCSVRendererWithCollapsible creates a CSV renderer with collapsible configuration.
+//
+// Note: csvRenderer does not embed baseRenderer and renders through its own
+// path that never invokes renderDocumentWithFormat, so the config's
+// DataTransformers/ByteTransformers are not applied here. Only the collapsible
+// settings take effect for the CSV format.
 func NewCSVRendererWithCollapsible(config RendererConfig) Renderer {
 	return &csvRenderer{
 		collapsibleConfig: config,

--- a/v2/collapsible_constructor_transformer_test.go
+++ b/v2/collapsible_constructor_transformer_test.go
@@ -1,0 +1,100 @@
+package output
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// Regression tests for T-1223: Collapsible renderer constructors ignore transformer config.
+//
+// RendererConfig carries DataTransformers and ByteTransformers, and
+// baseRenderer.renderDocumentWithFormat reads them from baseRenderer.config.
+// Before the fix, the New*RendererWithCollapsible constructors stored the
+// supplied config only in the renderer's collapsibleConfig field and left
+// baseRenderer.config at its zero value, so transformers passed through the
+// constructor were silently ignored.
+//
+// Only the HTML renderer routes its Render call through
+// renderDocumentWithFormat (the path that reads baseRenderer.config). The
+// expected behaviour after the fix is that transformers supplied via
+// NewHTMLRendererWithCollapsible actually run.
+
+// newConstructorTransformerDoc builds a small table document used by the
+// regression tests below.
+func newConstructorTransformerDoc() *Document {
+	records := []Record{
+		{"name": "Alice", "status": "active"},
+		{"name": "Bob", "status": "inactive"},
+	}
+	return New().
+		Table("users", records, WithKeys("name", "status")).
+		Build()
+}
+
+// TestNewHTMLRendererWithCollapsible_AppliesDataTransformer verifies that a
+// data transformer supplied via the constructor's RendererConfig actually runs.
+func TestNewHTMLRendererWithCollapsible_AppliesDataTransformer(t *testing.T) {
+	dataTransformer := &testDataTransformer{
+		name:     "test-filter",
+		priority: 100,
+		formats:  []string{FormatHTML},
+	}
+
+	config := DefaultRendererConfig
+	config.DataTransformers = []*TransformerAdapter{
+		NewTransformerAdapter(dataTransformer),
+	}
+	config.ByteTransformers = NewTransformPipeline()
+
+	renderer := NewHTMLRendererWithCollapsible(config)
+
+	output, err := renderer.Render(context.Background(), newConstructorTransformerDoc())
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+	out := string(output)
+
+	// Expected: the data transformer filters out the inactive user and
+	// prefixes the active user's name.
+	if dataTransformer.callCount != 1 {
+		t.Errorf("data transformer should have run once, got %d calls", dataTransformer.callCount)
+	}
+	if strings.Contains(out, "Bob") {
+		t.Error("data transformer should have filtered out inactive user Bob")
+	}
+	if !strings.Contains(out, "[FILTERED]Alice") {
+		t.Errorf("data transformer should have prefixed Alice; output: %s", out)
+	}
+}
+
+// TestNewHTMLRendererWithCollapsible_AppliesByteTransformer verifies that a
+// byte transformer supplied via the constructor's RendererConfig actually runs.
+func TestNewHTMLRendererWithCollapsible_AppliesByteTransformer(t *testing.T) {
+	byteTransformer := &testByteTransformer{
+		name:     "test-suffix",
+		priority: 200,
+		formats:  []string{FormatHTML},
+		suffix:   "\n<!-- Processed by byte transformer -->",
+	}
+
+	config := DefaultRendererConfig
+	config.DataTransformers = nil
+	config.ByteTransformers = NewTransformPipeline()
+	config.ByteTransformers.Add(byteTransformer)
+
+	renderer := NewHTMLRendererWithCollapsible(config)
+
+	output, err := renderer.Render(context.Background(), newConstructorTransformerDoc())
+	if err != nil {
+		t.Fatalf("Render failed: %v", err)
+	}
+	out := string(output)
+
+	if byteTransformer.callCount != 1 {
+		t.Errorf("byte transformer should have run once, got %d calls", byteTransformer.callCount)
+	}
+	if !strings.Contains(out, "<!-- Processed by byte transformer -->") {
+		t.Errorf("byte transformer should have appended its suffix; output: %s", out)
+	}
+}


### PR DESCRIPTION
## Bug

`RendererConfig` carries `DataTransformers` and `ByteTransformers`, which `baseRenderer.renderDocumentWithFormat` reads from `baseRenderer.config`. The `New*RendererWithCollapsible` constructors stored the supplied config only in each renderer's `collapsibleConfig` field and left the embedded `baseRenderer.config` at its zero value. Callers passing transformer configuration through `NewHTMLRendererWithCollapsible` (and friends) saw collapsible options apply while data/byte transformers were silently ignored.

## Root cause

`RendererConfig` is dual-purpose (collapsible settings plus the transformer pipeline), but the constructors only propagated it to the collapsible-specific field. For renderers that embed `baseRenderer`, the transformer half never reached `baseRenderer.config` — the field the render path actually reads.

Only the HTML renderer's `Render` routes through `renderDocumentWithFormat`, so HTML is where the bug was observable. Markdown also embeds `baseRenderer` but uses its own render path; Table and CSV do not embed `baseRenderer` at all.

## Fix

- Copy the supplied `RendererConfig` into `baseRenderer.config` in `NewHTMLRendererWithCollapsible` and `NewMarkdownRendererWithCollapsible` (the constructors for renderers that embed `baseRenderer`).
- Document on `NewTableRendererWithCollapsible` and `NewCSVRendererWithCollapsible` that their render paths do not apply the transformer fields (no `baseRenderer` to populate).
- Add regression tests proving data and byte transformers supplied via `NewHTMLRendererWithCollapsible` actually run (call counts go from 0 to 1; output reflects the transformations). Both tests fail before the fix and pass after.

Single-file change to `v2/base_renderer.go` plus a new test file. Full unit suite and `make lint` pass.

Closes T-1223