### PR TITLE
Fix T-1292: Escape Graph Labels in DOT and Mermaid Renderers

### DIFF
--- a/v2/graph_renderers.go
+++ b/v2/graph_renderers.go
@@ -103,8 +103,9 @@ func (d *dotRenderer) SupportsStreaming() bool {
 func (d *dotRenderer) renderGraphContent(buf *bytes.Buffer, graph *GraphContent) {
 	// Add title as graph label if present
 	if title := graph.GetTitle(); title != "" {
-		// Always quote labels in DOT format
-		fmt.Fprintf(buf, "  label=\"%s\";\n", title)
+		// Always quote labels in DOT format, escaping special characters so the
+		// title cannot break out of the quoted string (T-1292).
+		fmt.Fprintf(buf, "  label=\"%s\";\n", escapeDOTLabel(title))
 	}
 
 	// Render edges
@@ -115,8 +116,8 @@ func (d *dotRenderer) renderGraphContent(buf *bytes.Buffer, graph *GraphContent)
 		buf.WriteString(sanitizeDOTID(edge.To))
 
 		if edge.Label != "" {
-			// Always quote edge labels
-			fmt.Fprintf(buf, " [label=\"%s\"]", edge.Label)
+			// Always quote edge labels, escaping special characters (T-1292).
+			fmt.Fprintf(buf, " [label=\"%s\"]", escapeDOTLabel(edge.Label))
 		}
 
 		buf.WriteString(";\n")
@@ -294,7 +295,13 @@ func (m *mermaidRenderer) renderGraphContent(buf *bytes.Buffer, graph *GraphCont
 		buf.WriteString(sanitizeMermaidID(edge.From))
 
 		if edge.Label != "" {
-			fmt.Fprintf(buf, " -->|%s| ", edge.Label)
+			if mermaidLabelNeedsQuoting(edge.Label) {
+				// Wrap the edge label in quotes and escape special characters so
+				// pipes, quotes, and newlines cannot break the edge syntax (T-1292).
+				fmt.Fprintf(buf, " -->|\"%s\"| ", escapeMermaidLabel(edge.Label))
+			} else {
+				fmt.Fprintf(buf, " -->|%s| ", edge.Label)
+			}
 		} else {
 			buf.WriteString(" --> ")
 		}
@@ -457,11 +464,53 @@ func (m *mermaidRenderer) extractGraphFromTable(table *TableContent) *GraphConte
 
 // sanitizeMermaidID makes a string safe for use as a Mermaid identifier
 func sanitizeMermaidID(s string) string {
-	// Mermaid uses brackets for node text with special characters
+	// Mermaid uses brackets for node text with special characters.
 	if containsSpecialChars(s) {
+		// Characters that would otherwise break out of the [..] node syntax are
+		// escaped and the text is wrapped in double quotes (T-1292). Plain
+		// special characters such as spaces or dashes keep the simpler [text]
+		// form for readability and backwards compatibility.
+		if mermaidLabelNeedsQuoting(s) {
+			return `["` + escapeMermaidLabel(s) + `"]`
+		}
 		return fmt.Sprintf("[%s]", s)
 	}
 	return s
+}
+
+// escapeDOTLabel escapes a string for safe inclusion inside a quoted DOT label.
+// DOT string rules require escaping the backslash and double-quote characters;
+// literal newlines are converted to the "\n" escape sequence understood by
+// Graphviz so labels cannot break out of the label="..." syntax (T-1292).
+func escapeDOTLabel(s string) string {
+	replacer := strings.NewReplacer(
+		`\`, `\\`,
+		`"`, `\"`,
+		"\n", `\n`,
+		"\r", `\r`,
+	)
+	return replacer.Replace(s)
+}
+
+// mermaidLabelNeedsQuoting reports whether a label contains characters that
+// would break out of Mermaid's node ([..]) or edge (|..|) label syntax and
+// therefore require the quoted, escaped form (T-1292).
+func mermaidLabelNeedsQuoting(s string) bool {
+	return strings.ContainsAny(s, "\"[]|<>\n\r")
+}
+
+// escapeMermaidLabel escapes a string for safe inclusion inside a quoted Mermaid
+// label. Mermaid recommends wrapping label text in double quotes and encoding
+// embedded quotes as the &quot; HTML entity; newlines become <br/> so the label
+// cannot break out of its delimiter (T-1292). Callers are responsible for
+// wrapping the result in the surrounding quotes.
+func escapeMermaidLabel(s string) string {
+	replacer := strings.NewReplacer(
+		`"`, "&quot;",
+		"\n", "<br/>",
+		"\r", "",
+	)
+	return replacer.Replace(s)
 }
 
 // containsSpecialChars checks if a string contains characters that need escaping in Mermaid

--- a/v2/graph_renderers_test.go
+++ b/v2/graph_renderers_test.go
@@ -325,7 +325,7 @@ func TestSanitizeMermaidID(t *testing.T) {
 		{"with-dash", "[with-dash]"},
 		{"with:colon", "[with:colon]"},
 		{"with/slash", "[with/slash]"},
-		{"with\"quote", "[with\"quote]"},
+		{"with\"quote", "[\"with&quot;quote\"]"},
 		{"a.b.c", "[a.b.c]"},
 		{"normal_underscore", "normal_underscore"},
 		{"CamelCase", "CamelCase"},
@@ -337,6 +337,155 @@ func TestSanitizeMermaidID(t *testing.T) {
 			got := sanitizeMermaidID(tt.input)
 			if got != tt.want {
 				t.Errorf("sanitizeMermaidID(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestDOTRenderer_EscapesLabels is a regression test for T-1292.
+//
+// Bug: the DOT renderer wrote user-controlled title and edge label text
+// directly into label="%s" via Fprintf without escaping. Labels containing
+// double quotes, backslashes, or newlines broke the generated DOT syntax
+// (e.g. a label of `say "hi"` produced label="say "hi"" which is invalid).
+//
+// Expected: special characters are escaped per DOT string rules — `"` becomes
+// `\"`, `\` becomes `\\`, and newlines become the literal `\n` sequence.
+func TestDOTRenderer_EscapesLabels(t *testing.T) {
+	tests := map[string]struct {
+		doc  *Document
+		want string
+	}{
+		"title with quotes": {
+			doc: New().
+				Graph(`say "hi"`, []Edge{
+					{From: "A", To: "B"},
+				}).
+				Build(),
+			want: `digraph {
+  label="say \"hi\"";
+  A -> B;
+}
+`,
+		},
+		"edge label with quotes": {
+			doc: New().
+				Graph("", []Edge{
+					{From: "A", To: "B", Label: `weight "5"`},
+				}).
+				Build(),
+			want: `digraph {
+  A -> B [label="weight \"5\""];
+}
+`,
+		},
+		"edge label with backslash": {
+			doc: New().
+				Graph("", []Edge{
+					{From: "A", To: "B", Label: `path\to`},
+				}).
+				Build(),
+			want: `digraph {
+  A -> B [label="path\\to"];
+}
+`,
+		},
+		"edge label with newline": {
+			doc: New().
+				Graph("", []Edge{
+					{From: "A", To: "B", Label: "line1\nline2"},
+				}).
+				Build(),
+			want: `digraph {
+  A -> B [label="line1\nline2"];
+}
+`,
+		},
+	}
+
+	ctx := context.Background()
+	renderer := &dotRenderer{}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := renderer.Render(ctx, tt.doc)
+			if err != nil {
+				t.Fatalf("DOTRenderer.Render() error = %v", err)
+			}
+			if string(got) != tt.want {
+				t.Errorf("DOTRenderer.Render() = %q, want %q", string(got), tt.want)
+			}
+		})
+	}
+}
+
+// TestMermaidRenderer_EscapesLabels is a regression test for T-1292.
+//
+// Bug: the Mermaid renderer wrote user-controlled edge label text directly into
+// -->|%s| and node text into [%s] without escaping. Labels containing double
+// quotes, pipes, or newlines broke the generated Mermaid syntax (e.g. a label
+// containing `|` prematurely closed the edge-label delimiter).
+//
+// Expected: label text is wrapped in double quotes and quote characters are
+// HTML-entity-encoded (&quot;) so Mermaid renders the literal text safely.
+func TestMermaidRenderer_EscapesLabels(t *testing.T) {
+	tests := map[string]struct {
+		doc  *Document
+		want string
+	}{
+		"edge label with quotes": {
+			doc: New().
+				Graph("", []Edge{
+					{From: "A", To: "B", Label: `weight "5"`},
+				}).
+				Build(),
+			want: `graph TD
+  A -->|"weight &quot;5&quot;"| B
+`,
+		},
+		"edge label with pipe": {
+			doc: New().
+				Graph("", []Edge{
+					{From: "A", To: "B", Label: "a|b"},
+				}).
+				Build(),
+			want: `graph TD
+  A -->|"a|b"| B
+`,
+		},
+		"edge label with newline": {
+			doc: New().
+				Graph("", []Edge{
+					{From: "A", To: "B", Label: "line1\nline2"},
+				}).
+				Build(),
+			want: `graph TD
+  A -->|"line1<br/>line2"| B
+`,
+		},
+		"node text with quotes": {
+			doc: New().
+				Graph("", []Edge{
+					{From: `node "x"`, To: "B"},
+				}).
+				Build(),
+			want: `graph TD
+  ["node &quot;x&quot;"] --> B
+`,
+		},
+	}
+
+	ctx := context.Background()
+	renderer := &mermaidRenderer{}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, err := renderer.Render(ctx, tt.doc)
+			if err != nil {
+				t.Fatalf("MermaidRenderer.Render() error = %v", err)
+			}
+			if string(got) != tt.want {
+				t.Errorf("MermaidRenderer.Render() = %q, want %q", string(got), tt.want)
 			}
 		})
 	}

--- a/v2/specs/bugfixes/escape-graph-labels/report.md
+++ b/v2/specs/bugfixes/escape-graph-labels/report.md
@@ -1,0 +1,130 @@
+# Bugfix Report: Escape Graph Labels in DOT and Mermaid Renderers
+
+**Date:** 2026-05-25
+**Status:** Fixed
+**Ticket:** T-1292
+
+## Description of the Issue
+
+The DOT (Graphviz) and Mermaid renderers in `v2/graph_renderers.go` emitted
+user-controlled label text directly into the output without escaping
+format-special characters. Titles, edge labels, and node text containing double
+quotes, backslashes, newlines, or Mermaid delimiter characters broke the
+generated graph syntax or could inject unintended markup.
+
+**Reproduction steps:**
+
+1. Build a graph with an edge whose label contains a double quote, e.g.
+   `Graph("", []Edge{{From: "A", To: "B", Label: `+"`weight \"5\"`"+`}})`.
+2. Render it with the DOT renderer.
+3. Observe the output `A -> B [label="weight "5""];` — the embedded quotes
+   terminate the DOT string early, producing invalid Graphviz.
+
+The same class of failure occurs in Mermaid: an edge label containing `|`
+produced `A -->|a|b| B`, where the embedded pipe prematurely closes the
+edge-label delimiter, and node text with a quote produced `[node "x"]`.
+
+**Impact:** Medium. Any caller rendering graphs from data containing quotes,
+backslashes, pipes, or newlines in labels would get malformed DOT/Mermaid output
+that fails to parse or renders incorrectly. Affects DOT and Mermaid output
+formats only (the Draw.io CSV path already escaped via `writeCSVRow`).
+
+## Investigation Summary
+
+Applied a structured root-cause analysis to the rendering paths.
+
+- **Symptoms examined:** Invalid DOT/Mermaid produced for labels with special
+  characters.
+- **Code inspected:** `v2/graph_renderers.go` —
+  `dotRenderer.renderGraphContent`, `mermaidRenderer.renderGraphContent`,
+  `sanitizeMermaidID`, `sanitizeDOTID`.
+- **Hypotheses tested:** Whether `sanitizeDOTID` (used for node IDs) covered
+  labels — it does not; labels are emitted via raw `fmt.Fprintf`. `sanitizeDOTID`
+  also escapes only `"`, missing `\` and newlines, so it is insufficient even
+  for labels.
+
+## Discovered Root Cause
+
+Label text was written into the output via `fmt.Fprintf` using `label="%s"`
+(DOT title and edge), `-->|%s|` (Mermaid edge), and `[%s]` (Mermaid node via
+`sanitizeMermaidID`) without any escaping. No escaping helper for label strings
+existed; `sanitizeDOTID` handled identifiers only and escaped just the double
+quote.
+
+**Defect type:** Missing output escaping (injection / malformed output).
+
+**Why it occurred:** The renderers were written assuming simple alphanumeric
+labels. The ID-sanitisation helper escaped quotes but was never applied to
+labels, and there was no equivalent for backslashes, newlines, or Mermaid
+delimiters.
+
+**Contributing factors:** DOT and Mermaid have different escaping conventions,
+so a single shared helper would not suffice — each format needs its own.
+
+## Resolution for the Issue
+
+**Changes made:**
+
+- `v2/graph_renderers.go` — added `escapeDOTLabel` (escapes `\`, `"`, newline,
+  carriage-return per DOT string rules) and `escapeMermaidLabel` (encodes `"` as
+  `&quot;`, newline as `<br/>`, strips carriage-return), plus
+  `mermaidLabelNeedsQuoting` to decide when the quoted/escaped form is required.
+- `dotRenderer.renderGraphContent` — title and edge labels now pass through
+  `escapeDOTLabel`.
+- `mermaidRenderer.renderGraphContent` — edge labels containing delimiter-
+  breaking characters are wrapped in quotes and passed through
+  `escapeMermaidLabel`; plain labels keep the bare `|label|` form.
+- `sanitizeMermaidID` — node text containing characters that break the `[..]`
+  syntax (`"[]|<>` or newlines) is wrapped in quotes and escaped; ordinary
+  special characters (spaces, dashes, colons) keep the simpler `[text]` form.
+
+**Approach rationale:** Format-specific escaping is applied at every label
+emission point. Escaping is conditional for Mermaid so that existing valid
+output for ordinary special characters (e.g. `[Node A]`, `|HTTP|`) is unchanged,
+keeping the diff and behavioural change minimal while closing the syntax-breaking
+cases.
+
+**Alternatives considered:**
+
+- **Always quote-wrap every Mermaid label/node** — Rejected: it churns existing
+  valid output and the golden tests for no functional benefit.
+- **Reuse/extend `sanitizeDOTID` for labels** — Rejected: ID sanitisation also
+  decides whether to quote at all, which is the wrong contract for labels (DOT
+  labels are always quoted), and it lacked backslash/newline handling.
+
+## Regression Test
+
+**Test file:** `v2/graph_renderers_test.go`
+**Test names:** `TestDOTRenderer_EscapesLabels`, `TestMermaidRenderer_EscapesLabels`
+(and an updated case in `TestSanitizeMermaidID`).
+
+**What it verifies:** DOT titles/edge labels escape `"`, `\`, and newlines;
+Mermaid edge labels and node text with `"`, `|`, or newlines are quoted and
+escaped (`&quot;`, `<br/>`).
+
+**Run command:**
+`go test -run 'TestDOTRenderer_EscapesLabels|TestMermaidRenderer_EscapesLabels' ./...`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `v2/graph_renderers.go` | Added DOT/Mermaid label escaping helpers and applied them at all label emission points |
+| `v2/graph_renderers_test.go` | Added escaping regression tests; updated one `sanitizeMermaidID` expectation |
+
+## Verification
+
+**Automated:**
+- [x] Regression tests pass
+- [x] Full test suite passes (`make test`)
+- [x] Linter passes (`make lint`, 0 issues)
+
+**Manual verification:**
+- Confirmed the new tests fail against the pre-fix code (the "red" stage) before
+  implementing the fix.
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Route all user-controlled text destined for a structured output format through
+  a format-specific escaping helper rather than raw `fmt.Fprintf`.


### PR DESCRIPTION
## Bug

The DOT (Graphviz) and Mermaid renderers in `v2/graph_renderers.go` wrote user-controlled title, edge, and node label text directly into the output via `fmt.Fprintf` without escaping. Labels containing double quotes, backslashes, newlines, or Mermaid delimiter characters broke the generated graph syntax or could inject unintended markup.

Examples of broken output before the fix:
- DOT edge label `weight "5"` → `A -> B [label="weight "5""];` (invalid Graphviz — quotes terminate the string early)
- Mermaid edge label `a|b` → `A -->|a|b| B` (embedded pipe closes the edge-label delimiter)
- Mermaid node text `node "x"` → `[node "x"]` (unescaped quote inside the node brackets)

## Root cause

Label text was emitted with `label="%s"` (DOT), `-->|%s|` (Mermaid edge), and `[%s]` (Mermaid node via `sanitizeMermaidID`) with no escaping. No label-escaping helper existed; the only sanitiser (`sanitizeDOTID`) applies to node identifiers, escapes just the double quote, and was never applied to labels.

## Fix

Added format-specific escaping helpers and applied them at every label emission point:

- `escapeDOTLabel` — escapes `\`, `"`, and newlines per DOT string rules; used for DOT titles and edge labels.
- `escapeMermaidLabel` — encodes `"` as `&quot;` and newlines as `<br/>`; used for Mermaid edge labels and node text.
- `mermaidLabelNeedsQuoting` — Mermaid labels/nodes are quote-wrapped and escaped only when they contain a delimiter-breaking character (`"[]|<>` or a newline), so existing valid output for ordinary special characters (e.g. `[Node A]`, `|HTTP|`) is unchanged.

## Tests

Added `TestDOTRenderer_EscapesLabels` and `TestMermaidRenderer_EscapesLabels` covering quotes, backslashes, newlines, and pipes for both formats, plus an updated `sanitizeMermaidID` case. The tests fail against the pre-fix code and pass after the fix. `make test` and `make lint` both pass.

See `v2/specs/bugfixes/escape-graph-labels/report.md` for the full investigation report.