### PR TITLE
Fix T-1269: Tabular Transformers Misparse Quoted CSV

### DIFF
--- a/specs/bugfixes/tabular-transformers-quoted-csv/report.md
+++ b/specs/bugfixes/tabular-transformers-quoted-csv/report.md
@@ -1,0 +1,121 @@
+# Bugfix Report: Tabular Transformers Misparse Quoted CSV
+
+**Date:** 2026-05-25
+**Status:** Fixed
+
+## Description of the Issue
+
+`SortTransformer` and `LineSplitTransformer` in `v2/transformers.go` advertise CSV
+support (`CanTransform` returns true for `FormatCSV`), but both parse the rendered
+CSV bytes with `strings.Split` and `detectSeparator` instead of `encoding/csv`.
+This naive splitting ignores RFC 4180 quoting:
+
+- A quoted field containing a comma, such as `"Smith, Bob",NY`, is split into three
+  cells (`Smith`, ` Bob"`, `NY`). Sorting by a later column then compares the wrong
+  value, and a re-emitted row has the wrong shape.
+- Quoted fields containing embedded newlines are torn apart because the whole
+  payload is split on `\n`, so one logical record becomes several broken rows.
+
+**Reproduction steps:**
+1. Render a table to CSV that contains a quoted field with a comma (e.g.
+   `"Smith, Bob",NY`) or an embedded newline.
+2. Apply `SortTransformer` (sort by a column after the quoted field) or
+   `LineSplitTransformer`.
+3. Observe rows split into the wrong number of cells, sorted by the wrong value,
+   or multiline records broken across rows.
+
+**Impact:** Medium. Any CSV output that uses quoted fields (commas, separators, or
+embedded newlines inside values) is corrupted when these transformers run.
+
+## Investigation Summary
+
+- **Symptoms examined:** Sorting by a column produced the wrong order when an
+  earlier field was quoted; multiline quoted records were broken into multiple
+  rows.
+- **Code inspected:** `v2/transformers.go` — `SortTransformer.Transform`,
+  `LineSplitTransformer.Transform`, and the shared `detectSeparator` helper.
+- **Hypotheses tested:** Confirmed via failing tests that `strings.Split(content,
+  "\n")` breaks embedded newlines and `strings.Split(line, separator)` breaks
+  quoted commas. Ruled out the table/markdown (tab/pipe) paths as affected — those
+  formats do not use RFC 4180 quoting.
+
+## Discovered Root Cause
+
+Both transformers operate on already-rendered bytes using single-character string
+splitting that assumes a field separator never appears inside a value and that a
+newline always ends a record. CSV (RFC 4180) allows commas, the separator
+character, and newlines inside double-quoted fields, so byte-level splitting
+mis-parses them.
+
+**Defect type:** Logic error — incorrect parsing (ignoring quoting rules).
+
+**Why it occurred:** The transformers were written to handle several text formats
+with one generic separator-splitting routine, which happens to be wrong for CSV.
+
+**Contributing factors:** `CanTransform` returns true for `FormatCSV`, so the
+incorrect path is reached whenever CSV output is transformed.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `v2/transformers.go` — `SortTransformer.Transform`: when the format is
+  `FormatCSV`, parse the input with `encoding/csv` (variable fields per record,
+  embedded newlines allowed), sort the records by the requested column, and
+  re-emit with `encoding/csv`. Non-CSV formats keep the existing string-split
+  logic unchanged.
+- `v2/transformers.go` — `LineSplitTransformer.Transform`: when the format is
+  `FormatCSV`, parse records with `encoding/csv`, split the targeted cell, and
+  re-emit with `encoding/csv`. Non-CSV formats keep the existing logic.
+
+**Approach rationale:** Parsing and re-emitting with `encoding/csv` is the robust
+option recommended by the ticket. It correctly handles quoted commas, embedded
+separators, and embedded newlines, and produces canonical, valid CSV. Scoping the
+change to the `FormatCSV` branch leaves the table/markdown behaviour (validated by
+existing tests, including the T-1221 Markdown separator handling) untouched.
+
+**Alternatives considered:**
+- Removing CSV support from these transformers — rejected because it is a
+  user-facing capability reduction; correct parsing is preferable.
+- Patching the string-split logic to skip quotes — rejected as a fragile
+  reimplementation of a standard-library parser.
+
+## Regression Test
+
+**Test file:** `v2/transformers_test.go`
+**Test names:** `TestSortTransformer_QuotedCSV`, `TestLineSplitTransformer_QuotedCSV`
+
+**What it verifies:** Quoted CSV fields containing commas and embedded newlines are
+parsed as whole values; sorting uses the correct column value; line splitting only
+affects the targeted cell; and the CSV is re-emitted with quoting preserved.
+
+**Run command:** `go test -run 'TestSortTransformer_QuotedCSV|TestLineSplitTransformer_QuotedCSV' ./v2/...`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `v2/transformers.go` | CSV-format paths of `SortTransformer` and `LineSplitTransformer` now parse/re-emit with `encoding/csv`. |
+| `v2/transformers_test.go` | Added quoted-CSV regression tests for both transformers. |
+
+## Verification
+
+**Automated:**
+- [x] Regression tests pass
+- [x] Full test suite passes
+- [x] Linters/validators pass
+
+**Manual verification:**
+- Confirmed the regression tests fail before the fix and pass after.
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Use `encoding/csv` for any CSV parsing rather than `strings.Split`.
+- When a transformer claims support for a structured format, parse with that
+  format's canonical reader instead of generic separator detection.
+
+## Related
+
+- Transit ticket T-1269
+- Related transformer fixes in the same file: T-1267 (emoji word boundaries),
+  T-1221 (Markdown separator row).

--- a/v2/transformers.go
+++ b/v2/transformers.go
@@ -1,7 +1,9 @@
 package output
 
 import (
+	"bytes"
 	"context"
+	"encoding/csv"
 	"regexp"
 	"sort"
 	"strconv"
@@ -173,9 +175,16 @@ func (s *SortTransformer) CanTransform(format string) bool {
 }
 
 // Transform sorts the tabular data by the specified key
-func (s *SortTransformer) Transform(_ context.Context, input []byte, _ string) ([]byte, error) {
+func (s *SortTransformer) Transform(_ context.Context, input []byte, format string) ([]byte, error) {
 	if s.key == "" {
 		return input, nil
+	}
+
+	// CSV is parsed with encoding/csv so quoted fields containing commas,
+	// separators, or embedded newlines are kept intact (T-1269). Other tabular
+	// formats (table/markdown) use line-based splitting below.
+	if format == FormatCSV {
+		return s.transformCSV(input)
 	}
 
 	content := string(input)
@@ -299,6 +308,86 @@ func (s *SortTransformer) Transform(_ context.Context, input []byte, _ string) (
 	return []byte(strings.Join(result, "\n")), nil
 }
 
+// transformCSV sorts CSV input using encoding/csv so that quoted fields with
+// commas, separators, or embedded newlines are parsed and re-emitted correctly.
+// The first record is treated as the header. If the input cannot be parsed as
+// CSV, has no data rows, or the sort key is missing, the input is returned
+// unchanged.
+func (s *SortTransformer) transformCSV(input []byte) ([]byte, error) {
+	records, err := readCSVRecords(input)
+	if err != nil || len(records) < 2 {
+		// Not parseable as CSV or no data rows to sort; leave input untouched.
+		return input, nil
+	}
+
+	header := records[0]
+	sortColumnIndex := -1
+	for i, h := range header {
+		if strings.TrimSpace(h) == s.key {
+			sortColumnIndex = i
+			break
+		}
+	}
+	if sortColumnIndex == -1 {
+		return input, nil // Sort key not found
+	}
+
+	dataRows := records[1:]
+	sort.SliceStable(dataRows, func(i, j int) bool {
+		valueI := cellValue(dataRows[i], sortColumnIndex)
+		valueJ := cellValue(dataRows[j], sortColumnIndex)
+
+		// Try numeric comparison first, mirroring the line-based path.
+		if numI, errI := strconv.ParseFloat(valueI, 64); errI == nil {
+			if numJ, errJ := strconv.ParseFloat(valueJ, 64); errJ == nil {
+				if s.ascending {
+					return numI < numJ
+				}
+				return numI > numJ
+			}
+		}
+
+		if s.ascending {
+			return valueI < valueJ
+		}
+		return valueI > valueJ
+	})
+
+	return writeCSVRecords(records)
+}
+
+// cellValue returns the trimmed value at index from a CSV record, or an empty
+// string when the index is out of range.
+func cellValue(record []string, index int) string {
+	if index < 0 || index >= len(record) {
+		return ""
+	}
+	return strings.TrimSpace(record[index])
+}
+
+// readCSVRecords parses input as CSV, allowing a variable number of fields per
+// record so that malformed or ragged rows do not cause a hard failure.
+func readCSVRecords(input []byte) ([][]string, error) {
+	reader := csv.NewReader(bytes.NewReader(input))
+	reader.FieldsPerRecord = -1 // allow ragged rows
+	return reader.ReadAll()
+}
+
+// writeCSVRecords re-emits records as canonical CSV using encoding/csv, which
+// quotes fields containing commas, quotes, or newlines as required by RFC 4180.
+func writeCSVRecords(records [][]string) ([]byte, error) {
+	var buf bytes.Buffer
+	writer := csv.NewWriter(&buf)
+	if err := writer.WriteAll(records); err != nil {
+		return nil, err
+	}
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
 // isMarkdownSeparatorRow reports whether a trimmed line is a Markdown table
 // separator/alignment row, such as "| --- | --- |" or "|:---|---:|". Such rows
 // consist solely of pipes, dashes, colons, and spaces, and contain at least one
@@ -355,7 +444,14 @@ func (l *LineSplitTransformer) CanTransform(format string) bool {
 }
 
 // Transform splits multi-line cells into separate rows
-func (l *LineSplitTransformer) Transform(_ context.Context, input []byte, _ string) ([]byte, error) {
+func (l *LineSplitTransformer) Transform(_ context.Context, input []byte, format string) ([]byte, error) {
+	// CSV is parsed with encoding/csv so quoted fields containing commas,
+	// separators, or embedded newlines are kept intact (T-1269). Other tabular
+	// formats (table/markdown) use line-based splitting below.
+	if format == FormatCSV {
+		return l.transformCSV(input)
+	}
+
 	content := string(input)
 	lines := strings.Split(content, "\n")
 
@@ -428,6 +524,67 @@ func (l *LineSplitTransformer) Transform(_ context.Context, input []byte, _ stri
 	}
 
 	return []byte(strings.Join(result, "\n")), nil
+}
+
+// transformCSV splits multi-value CSV cells into separate rows using
+// encoding/csv. Records are parsed with full RFC 4180 semantics so quoted
+// commas, separators, and embedded newlines are preserved, and the result is
+// re-emitted as canonical CSV. If the input cannot be parsed as CSV it is
+// returned unchanged.
+func (l *LineSplitTransformer) transformCSV(input []byte) ([]byte, error) {
+	records, err := readCSVRecords(input)
+	if err != nil || len(records) == 0 {
+		return input, nil
+	}
+
+	result := make([][]string, 0, len(records))
+	// The header (first record) is emitted as-is; only data rows are split.
+	result = append(result, records[0])
+
+	for _, row := range records[1:] {
+		result = append(result, l.splitRecord(row)...)
+	}
+
+	return writeCSVRecords(result)
+}
+
+// splitRecord expands a single CSV record into multiple records when any cell
+// contains the line separator. Cells without the separator keep their value in
+// the first emitted row and are blank in subsequent rows, matching the
+// line-based transformer's behaviour. A record with no splittable cell is
+// returned unchanged.
+func (l *LineSplitTransformer) splitRecord(row []string) [][]string {
+	maxSplits := 1
+	for _, cell := range row {
+		if strings.Contains(cell, l.separator) {
+			if n := len(strings.Split(cell, l.separator)); n > maxSplits {
+				maxSplits = n
+			}
+		}
+	}
+
+	if maxSplits == 1 {
+		return [][]string{row}
+	}
+
+	out := make([][]string, 0, maxSplits)
+	for i := range maxSplits {
+		newCells := make([]string, len(row))
+		for c, cell := range row {
+			switch {
+			case strings.Contains(cell, l.separator):
+				splits := strings.Split(cell, l.separator)
+				if i < len(splits) {
+					newCells[c] = strings.TrimSpace(splits[i])
+				}
+			case i == 0:
+				// Non-split cells show their value only in the first row.
+				newCells[c] = cell
+			}
+		}
+		out = append(out, newCells)
+	}
+	return out
 }
 
 // RemoveColorsTransformer removes ANSI color codes from output (for file output)

--- a/v2/transformers_test.go
+++ b/v2/transformers_test.go
@@ -423,6 +423,53 @@ func TestSortTransformer_MarkdownSeparatorRow(t *testing.T) {
 	}
 }
 
+// TestSortTransformer_QuotedCSV verifies that quoted CSV fields are parsed with
+// RFC 4180 semantics rather than naive string splitting.
+//
+// Bug T-1269: SortTransformer parsed CSV with strings.Split on a single
+// separator, so a quoted field such as "Smith, Bob" was split into multiple
+// cells. Sorting by a later column then read the wrong value. Embedded newlines
+// inside quoted fields were also broken by splitting the whole payload on "\n".
+// Expected: fields are parsed as whole values and the rows are sorted by the
+// requested column's true value, with the CSV re-emitted using encoding/csv.
+func TestSortTransformer_QuotedCSV(t *testing.T) {
+	ctx := context.Background()
+
+	tests := map[string]struct {
+		transformer *SortTransformer
+		input       string
+		expected    string
+	}{
+		"quoted field with comma sorts by correct column": {
+			// Both name fields contain a comma. Sorting by City must use the
+			// real City value (NY / CA), not a fragment of the quoted name.
+			transformer: NewSortTransformerAscending("City"),
+			input:       "Name,City\n\"Smith, Bob\",NY\n\"Adams, Al\",CA\n",
+			expected:    "Name,City\n\"Adams, Al\",CA\n\"Smith, Bob\",NY\n",
+		},
+		"quoted field with embedded newline stays one record": {
+			// The Address field contains an embedded newline inside quotes. It
+			// must remain a single record while rows sort by Age.
+			transformer: NewSortTransformerAscending("Age"),
+			input:       "Name,Age,Address\nBob,30,\"12 Main St\nApt 4\"\nAlice,25,\"9 Oak Rd\nUnit 1\"\n",
+			expected:    "Name,Age,Address\nAlice,25,\"9 Oak Rd\nUnit 1\"\nBob,30,\"12 Main St\nApt 4\"\n",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			result, err := test.transformer.Transform(ctx, []byte(test.input), FormatCSV)
+			if err != nil {
+				t.Fatalf("SortTransformer.Transform() error = %v", err)
+			}
+
+			if string(result) != test.expected {
+				t.Errorf("SortTransformer.Transform()\n got = %q\nwant = %q", string(result), test.expected)
+			}
+		})
+	}
+}
+
 // Test LineSplitTransformer
 
 func TestLineSplitTransformer_Name(t *testing.T) {
@@ -506,6 +553,51 @@ func TestLineSplitTransformer_Transform(t *testing.T) {
 
 			if string(result) != test.expected {
 				t.Errorf("LineSplitTransformer.Transform() = %q, want %q", string(result), test.expected)
+			}
+		})
+	}
+}
+
+// TestLineSplitTransformer_QuotedCSV verifies that quoted CSV fields are parsed
+// with RFC 4180 semantics before being split into rows.
+//
+// Bug T-1269: LineSplitTransformer parsed CSV with strings.Split on a single
+// separator and split the whole payload on "\n". A quoted field containing a
+// comma was broken into the wrong cells, and quoted fields with embedded
+// newlines were torn across records. Expected: fields parse as whole values,
+// only the intended cell is split into rows, and CSV is re-emitted with
+// encoding/csv so commas and newlines stay quoted.
+func TestLineSplitTransformer_QuotedCSV(t *testing.T) {
+	ctx := context.Background()
+
+	tests := map[string]struct {
+		transformer *LineSplitTransformer
+		input       string
+		expected    string
+	}{
+		"quoted field with comma is preserved while splitting another cell": {
+			transformer: NewLineSplitTransformer(";"),
+			input:       "Name,Skills\n\"Smith, Bob\",Java;Go\n",
+			expected:    "Name,Skills\n\"Smith, Bob\",Java\n,Go\n",
+		},
+		"embedded newline in quoted field is not treated as a record boundary": {
+			// The Notes field has an embedded newline; only Skills (separated by
+			// ";") should split into rows. The quoted newline must survive.
+			transformer: NewLineSplitTransformer(";"),
+			input:       "Name,Skills,Notes\nAlice,Java;Go,\"line1\nline2\"\n",
+			expected:    "Name,Skills,Notes\nAlice,Java,\"line1\nline2\"\n,Go,\n",
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			result, err := test.transformer.Transform(ctx, []byte(test.input), FormatCSV)
+			if err != nil {
+				t.Fatalf("LineSplitTransformer.Transform() error = %v", err)
+			}
+
+			if string(result) != test.expected {
+				t.Errorf("LineSplitTransformer.Transform()\n got = %q\nwant = %q", string(result), test.expected)
 			}
 		})
 	}


### PR DESCRIPTION
## Bug

`SortTransformer` and `LineSplitTransformer` in `v2/transformers.go` advertise CSV support (`CanTransform` returns true for `FormatCSV`), but both parse the rendered CSV bytes with `strings.Split` and `detectSeparator` instead of `encoding/csv`. This ignores RFC 4180 quoting:

- A quoted field containing a comma, e.g. `"Smith, Bob",NY`, is split into three cells, so sorting by a later column compares the wrong value.
- `LineSplitTransformer` also splits the whole payload on `\n`, breaking valid quoted multiline records.

## Root cause

Both transformers operate on already-rendered bytes using single-character string splitting that assumes a separator never appears inside a value and that a newline always ends a record. CSV allows commas, the separator, and newlines inside double-quoted fields, so byte-level splitting mis-parses them.

## Fix

Route the `FormatCSV` path of both transformers through `encoding/csv`:

- `SortTransformer.transformCSV` parses records (ragged rows allowed), sorts by the requested column using the true field value, and re-emits with `encoding/csv`.
- `LineSplitTransformer.transformCSV` parses records, splits only the targeted cell into rows, and re-emits with `encoding/csv`.

Non-CSV (table/markdown) paths are unchanged, preserving existing behaviour including the T-1221 Markdown separator handling.

## Tests

Added `TestSortTransformer_QuotedCSV` and `TestLineSplitTransformer_QuotedCSV` covering quoted fields with commas and embedded newlines. Both failed before the fix and pass after. Full unit + integration suites and `make lint` pass.

See `specs/bugfixes/tabular-transformers-quoted-csv/report.md` for the full bugfix report.