### PR TITLE
Fix T-1127: Builder Section Methods Panic On Nil Callbacks

### DIFF
--- a/v2/builder_section_test.go
+++ b/v2/builder_section_test.go
@@ -301,6 +301,54 @@ func TestBuilder_CollapsibleSection_Mixed_Content(t *testing.T) {
 	}
 }
 
+// TestBuilder_SectionNilCallback verifies that passing a nil callback to
+// Section and CollapsibleSection does not panic. Before the fix, both methods
+// called fn(subBuilder) unconditionally, which panicked on a nil fn. The
+// expected behaviour is to record a builder error and still produce an empty
+// section, keeping the fluent API non-panicking and consistent with the
+// builder's error-accumulation pattern used by other methods.
+func TestBuilder_SectionNilCallback(t *testing.T) {
+	tests := map[string]struct {
+		build func(*Builder) *Builder
+	}{
+		"section": {
+			build: func(b *Builder) *Builder {
+				return b.Section("empty", nil)
+			},
+		},
+		"collapsible section": {
+			build: func(b *Builder) *Builder {
+				return b.CollapsibleSection("empty", nil)
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			builder := New()
+
+			// This must not panic.
+			result := tt.build(builder)
+
+			// Fluent API: the method must return the same builder.
+			if result != builder {
+				t.Errorf("expected method to return the same builder for chaining")
+			}
+
+			// A nil callback should be recorded as a builder error.
+			if !builder.HasErrors() {
+				t.Errorf("expected a builder error to be recorded for a nil callback")
+			}
+
+			// The section should still be added as an empty section.
+			doc := builder.Build()
+			if len(doc.contents) != 1 {
+				t.Fatalf("expected 1 content (empty section), got %d", len(doc.contents))
+			}
+		})
+	}
+}
+
 func TestBuilder_NestedSectionErrorsArePropagated(t *testing.T) {
 	tests := map[string]func(*Builder){
 		"section": func(builder *Builder) {

--- a/v2/document.go
+++ b/v2/document.go
@@ -163,7 +163,17 @@ func (b *Builder) Section(title string, fn func(*Builder), opts ...SectionOption
 
 	// Create sub-builder for section contents
 	subBuilder := &Builder{doc: &Document{metadata: make(map[string]any)}}
-	fn(subBuilder)
+
+	// A nil callback is invalid input: record a builder error and skip invoking
+	// it. The section is still added as an empty section, keeping the fluent API
+	// non-panicking and consistent with the builder's error-accumulation pattern.
+	if fn == nil {
+		b.mu.Lock()
+		b.addError(fmt.Errorf("Section %q: callback function is nil", title))
+		b.mu.Unlock()
+	} else {
+		fn(subBuilder)
+	}
 
 	if subErrors := subBuilder.Errors(); len(subErrors) > 0 {
 		b.mu.Lock()
@@ -228,7 +238,17 @@ func (b *Builder) AddCollapsibleTable(title string, table *TableContent, opts ..
 func (b *Builder) CollapsibleSection(title string, fn func(*Builder), opts ...CollapsibleSectionOption) *Builder {
 	// Create sub-builder for section contents
 	subBuilder := &Builder{doc: &Document{metadata: make(map[string]any)}}
-	fn(subBuilder)
+
+	// A nil callback is invalid input: record a builder error and skip invoking
+	// it. The section is still added as an empty section, keeping the fluent API
+	// non-panicking and consistent with the builder's error-accumulation pattern.
+	if fn == nil {
+		b.mu.Lock()
+		b.addError(fmt.Errorf("CollapsibleSection %q: callback function is nil", title))
+		b.mu.Unlock()
+	} else {
+		fn(subBuilder)
+	}
 
 	if subErrors := subBuilder.Errors(); len(subErrors) > 0 {
 		b.mu.Lock()


### PR DESCRIPTION
## Summary

`Builder.Section` and `Builder.CollapsibleSection` accept a `func(*Builder)` callback to populate section contents. Neither method validated the callback before calling it, so passing `nil` (e.g. `builder.Section("empty", nil)`) caused a nil function call panic.

## Root cause

Both methods called `fn(subBuilder)` directly without a nil check. Other builder methods (`AddContent`, `Table`, `Raw`) accumulate a builder error for invalid input rather than panicking, but the section methods lacked the equivalent guard.

## Fix

Guard the callback in both `Section` and `CollapsibleSection`:
- When `fn` is nil, record a builder error via `addError` and skip the call.
- The section is still added as an empty section (empty sections are already a supported state), keeping the fluent API non-panicking and consistent with the builder's error-accumulation pattern.

## Tests

Added `TestBuilder_SectionNilCallback` (`v2/builder_section_test.go`) covering both methods: it asserts no panic, that the method returns the same builder for chaining, that a builder error is recorded, and that a single empty section is added. The test panics before the fix and passes after.

`make test` and `make lint` both pass.

Closes T-1127.