### PR TITLE
Fix T-1092: Graph Renderers Panic On Nil Documents

### DIFF
--- a/v2/graph_renderers.go
+++ b/v2/graph_renderers.go
@@ -46,6 +46,10 @@ func (d *dotRenderer) Format() string {
 }
 
 func (d *dotRenderer) Render(ctx context.Context, doc *Document) ([]byte, error) {
+	if doc == nil {
+		return nil, fmt.Errorf("document cannot be nil")
+	}
+
 	var buf bytes.Buffer
 
 	// Write DOT header
@@ -176,6 +180,10 @@ func (m *mermaidRenderer) Format() string {
 }
 
 func (m *mermaidRenderer) Render(ctx context.Context, doc *Document) ([]byte, error) {
+	if doc == nil {
+		return nil, fmt.Errorf("document cannot be nil")
+	}
+
 	var buf bytes.Buffer
 
 	// Process each content item. Apply per-content transformations
@@ -538,6 +546,10 @@ func (d *drawioRenderer) Format() string {
 }
 
 func (d *drawioRenderer) Render(ctx context.Context, doc *Document) ([]byte, error) {
+	if doc == nil {
+		return nil, fmt.Errorf("document cannot be nil")
+	}
+
 	var buf bytes.Buffer
 
 	// Process each content item. Apply per-content transformations

--- a/v2/graph_renderers_test.go
+++ b/v2/graph_renderers_test.go
@@ -1,10 +1,49 @@
 package output
 
 import (
+	"bytes"
 	"context"
 	"strings"
 	"testing"
 )
+
+// TestGraphRenderers_NilDocument verifies that the DOT, Mermaid, and Draw.io
+// renderers return a "document cannot be nil" error instead of panicking when
+// Render or RenderTo is called directly with a nil document (T-1092). Other
+// renderers (csv_renderer.go, base_renderer.go, table_renderer.go) already
+// guard against nil documents, so these graph renderers should behave the same.
+func TestGraphRenderers_NilDocument(t *testing.T) {
+	renderers := map[string]Renderer{
+		"DOT":     DOT().Renderer,
+		"Mermaid": Mermaid().Renderer,
+		"DrawIO":  DrawIO().Renderer,
+	}
+
+	ctx := context.Background()
+
+	for name, renderer := range renderers {
+		t.Run(name+"/Render", func(t *testing.T) {
+			_, err := renderer.Render(ctx, nil)
+			if err == nil {
+				t.Fatalf("%s.Render(ctx, nil) returned no error, want \"document cannot be nil\"", name)
+			}
+			if !strings.Contains(err.Error(), "document cannot be nil") {
+				t.Errorf("%s.Render(ctx, nil) error = %q, want it to contain \"document cannot be nil\"", name, err.Error())
+			}
+		})
+
+		t.Run(name+"/RenderTo", func(t *testing.T) {
+			var buf bytes.Buffer
+			err := renderer.RenderTo(ctx, nil, &buf)
+			if err == nil {
+				t.Fatalf("%s.RenderTo(ctx, nil, w) returned no error, want \"document cannot be nil\"", name)
+			}
+			if !strings.Contains(err.Error(), "document cannot be nil") {
+				t.Errorf("%s.RenderTo(ctx, nil, w) error = %q, want it to contain \"document cannot be nil\"", name, err.Error())
+			}
+		})
+	}
+}
 
 func TestDOTRenderer_Render(t *testing.T) {
 	tests := map[string]struct {


### PR DESCRIPTION
## Bug

The DOT, Mermaid, and Draw.io renderers in `v2/graph_renderers.go` dereferenced the `*Document` argument via `doc.GetContents()` without a nil check. Direct calls such as `DOT().Renderer.Render(ctx, nil)`, `Mermaid().Renderer.Render(ctx, nil)`, and `DrawIO().Renderer.Render(ctx, nil)` panicked with a nil pointer dereference instead of returning an error.

## Root cause

These three renderers omitted the nil-document guard that every other renderer applies (`csv_renderer.go`, `base_renderer.go`, `table_renderer.go` all return `"document cannot be nil"`). The high-level `Output.Render` path validates nil before dispatching, which masked the omission, but the public `Renderer` interface allows direct use where the panic surfaced.

## Fix

- Added `if doc == nil { return nil, fmt.Errorf("document cannot be nil") }` at the start of `(*dotRenderer).Render`, `(*mermaidRenderer).Render`, and `(*drawioRenderer).Render`, matching the existing convention.
- The three `RenderTo` methods delegate to their `Render` methods, so the error propagates before any write — no separate guard needed.
- Added `TestGraphRenderers_NilDocument` covering both `Render` and `RenderTo` with nil for all three renderers. The test panics before the fix and passes after.

## Verification

- `make test` — all unit tests pass
- `make lint` — 0 issues

Closes T-1092.