### PR TITLE
Fix T-1183: Output Ignores Transformer Priority Ordering

### DIFF
--- a/specs/bugfixes/output-transformer-priority-ordering/report.md
+++ b/specs/bugfixes/output-transformer-priority-ordering/report.md
@@ -1,0 +1,127 @@
+# Bugfix Report: Output Ignores Transformer Priority Ordering
+
+**Date:** 2026-05-25
+**Status:** Fixed
+
+## Description of the Issue
+
+`Output` accepts transformers via `WithTransformer` / `WithTransformers`, but
+`processFormatData` (`v2/output.go`) applied the copied `[]Transformer` slice in
+caller-argument (insertion) order rather than sorting by `Transformer.Priority()`.
+This contradicts the transformer pipeline contract — `TransformPipeline` sorts
+lower priority first — and the v2 design requirement for priority-based execution.
+
+**Reproduction steps:**
+1. Construct `NewOutput(WithFormat(...), WithTransformers(high, low), WithWriter(...))`
+   where `high.Priority() == 100` and `low.Priority() == 10`, and both mutate the
+   rendered bytes.
+2. Call `Render`.
+3. Observe that the high-priority transformer runs before the low-priority one —
+   render order follows the argument order, not `Priority()`.
+
+**Impact:** Any consumer relying on transformer priority (the documented contract)
+gets incorrect, order-dependent output. Severity is correctness: results depend on
+the order transformers happen to be registered rather than their declared priority.
+
+## Investigation Summary
+
+- **Symptoms examined:** With two byte-mutating transformers registered in reverse
+  priority order, the output reflected argument order (`[high][low]`) instead of
+  priority order (`[low][high]`).
+- **Code inspected:** `v2/output.go` (`Render`, `renderWithConfig`,
+  `processFormatData`) and `v2/transformer.go` (`TransformPipeline`,
+  `sortTransformers`, `Transform`).
+- **Hypotheses tested:** Confirmed the `Transformer` interface exposes `Priority()`
+  (lower = earlier) and that `TransformPipeline.sortTransformers` sorts ascending by
+  priority. Confirmed `Output` never routes through `TransformPipeline` and instead
+  iterates its own copied slice directly, skipping the sort step.
+
+## Discovered Root Cause
+
+`processFormatData` iterated the transformer slice in the order it was built by
+`WithTransformer` / `WithTransformers`, never applying the priority sort that the
+pipeline contract requires.
+
+**Defect type:** Logic error — missing ordering step.
+
+**Why it occurred:** `Output` reimplemented the transformer-application loop instead
+of reusing `TransformPipeline`. The reimplementation omitted the priority-sort step
+that lives in `TransformPipeline.sortTransformers`.
+
+**Five Whys:**
+1. Why does render order follow argument order? `processFormatData` iterates the
+   transformer slice directly.
+2. Why is the slice in argument order? `WithTransformer`/`WithTransformers` append
+   in call order and `Render` copies the slice verbatim.
+3. Why isn't it sorted? The sort logic only exists in
+   `TransformPipeline.sortTransformers`, which `Output` never invokes.
+4. Why doesn't `Output` use `TransformPipeline`? `Output` was implemented with its
+   own ad-hoc transformer loop that bypasses the pipeline.
+5. Root cause: the transformer-application path in `Output` duplicates pipeline
+   behaviour but omits the priority-sort the contract requires.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `v2/output.go` — `processFormatData` now sorts a local copy of the transformer
+  slice by `Priority()` (ascending, stable) before applying them, so execution order
+  always honours the declared priority regardless of registration order.
+
+**Approach rationale:** Per the ticket scope constraint, the change is confined to
+`v2/output.go`. A local stable sort by `Priority()` is the minimal change: it does
+not mutate the caller's slice (a fresh copy is sorted) and uses `sort.SliceStable`
+so transformers with equal priority keep their insertion order, matching the
+pipeline's behaviour.
+
+**Alternatives considered:**
+- **Route through `TransformPipeline`** — Would also fix the bug and reuse existing
+  logic, but it is heavier (constructing a pipeline per render) and a parallel ticket
+  (T-1131) owns changes to `transformer.go`; routing through it risks coupling and
+  merge conflicts. Rejected to keep the change isolated to `output.go`.
+- **Sort the shared slice once in `Render`/`renderWithConfig`** — Would work but
+  `processFormatData` is the documented locus of the bug and is called per format;
+  sorting a local copy there keeps the fix localized and avoids mutating the shared
+  copied slice that other code paths may rely on.
+
+## Regression Test
+
+**Test file:** `v2/output_test.go`
+**Test name:** `TestOutput_Render_TransformerPriorityOrder`
+
+**What it verifies:** Two byte-mutating transformers are registered in reverse
+priority order (`high` before `low`); the test asserts the lower-priority
+transformer's marker appears earlier in the output, proving priority order is
+honoured regardless of argument order.
+
+**Run command:** `go test -run TestOutput_Render_TransformerPriorityOrder ./v2/...`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `v2/output.go` | Sort transformers by `Priority()` in `processFormatData` |
+| `v2/output_test.go` | Add `TestOutput_Render_TransformerPriorityOrder` regression test |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Linters/validators pass
+
+**Manual verification:**
+- Confirmed the regression test fails before the fix (output `[high][low]`) and
+  passes after (output `[low][high]`).
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Prefer routing through `TransformPipeline` rather than reimplementing the
+  transformer-application loop, so the priority contract lives in one place.
+- When duplicating behaviour from an existing abstraction, add a test that asserts
+  the contract (here, priority ordering) holds.
+
+## Related
+
+- Transit ticket T-1183
+- Related ticket T-1131 (owns `transformer.go` nil-handling changes)

--- a/v2/output.go
+++ b/v2/output.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"maps"
+	"sort"
 	"sync"
 )
 
@@ -321,9 +322,18 @@ func (o *Output) renderWithConfig(ctx context.Context, doc *Document, formats []
 
 // processFormatData applies transformers and writes the data to all configured writers
 func (o *Output) processFormatData(ctx context.Context, format Format, data []byte, transformers []Transformer, writers []Writer, progress Progress, workDone *int, workMu *sync.Mutex) error {
-	// Apply transformers to the rendered data
+	// Apply transformers to the rendered data in priority order (lower priority
+	// runs first), matching the TransformPipeline contract. Sort a local copy so
+	// the caller's slice is not mutated; SliceStable keeps insertion order for
+	// transformers that share a priority.
+	ordered := make([]Transformer, len(transformers))
+	copy(ordered, transformers)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		return ordered[i].Priority() < ordered[j].Priority()
+	})
+
 	transformedData := data
-	for _, transformer := range transformers {
+	for _, transformer := range ordered {
 		if transformer.CanTransform(format.Name) {
 			GlobalTrace("transform", "applying %s transformer to %s format", transformer.Name(), format.Name)
 			progress.SetStatus(fmt.Sprintf("Applying %s transformer to %s", transformer.Name(), format.Name))

--- a/v2/output_test.go
+++ b/v2/output_test.go
@@ -471,6 +471,67 @@ func TestOutput_Render_WithTransformers(t *testing.T) {
 	})
 }
 
+// TestOutput_Render_TransformerPriorityOrder is a regression test for T-1183.
+//
+// Bug: processFormatData applied transformers in caller-argument (insertion)
+// order instead of Transformer.Priority() order. The transformer pipeline
+// contract requires lower-priority transformers to run first, regardless of the
+// order in which they were registered.
+//
+// Expected: transformers run in ascending Priority() order even when passed to
+// WithTransformers in the reverse order.
+func TestOutput_Render_TransformerPriorityOrder(t *testing.T) {
+	doc := New().
+		Text("seed").
+		Build()
+
+	// Each transformer appends its name to the byte stream when it runs, so the
+	// final output records the exact execution order.
+	low := &orderRecordingTransformer{name: "low", priority: 10}
+	high := &orderRecordingTransformer{name: "high", priority: 100}
+
+	// Register in reverse priority order (high first) to prove that argument
+	// order does NOT determine execution order.
+	testWriter := &testStdoutWriter{}
+	output := NewOutput(
+		WithFormat(JSON()),
+		WithTransformers(high, low),
+		WithWriter(testWriter),
+	)
+
+	if err := output.Render(context.Background(), doc); err != nil {
+		t.Fatalf("Render() failed: %v", err)
+	}
+	output.Close()
+
+	got := testWriter.GetOutput()
+
+	// The "low" priority transformer (10) must run before "high" (100),
+	// so its marker must appear earlier in the output.
+	lowIdx := strings.Index(got, "[low]")
+	highIdx := strings.Index(got, "[high]")
+	if lowIdx == -1 || highIdx == -1 {
+		t.Fatalf("expected both transformer markers in output, got: %q", got)
+	}
+	if lowIdx > highIdx {
+		t.Errorf("transformers applied in wrong order: want low (priority 10) before high (priority 100), got order %q", got)
+	}
+}
+
+// orderRecordingTransformer appends a marker so tests can observe the order in
+// which transformers were applied.
+type orderRecordingTransformer struct {
+	name     string
+	priority int
+}
+
+func (t *orderRecordingTransformer) Name() string                    { return t.name }
+func (t *orderRecordingTransformer) Priority() int                   { return t.priority }
+func (t *orderRecordingTransformer) CanTransform(format string) bool { return true }
+func (t *orderRecordingTransformer) Transform(_ context.Context, input []byte, _ string) ([]byte, error) {
+	return append(input, []byte("["+t.name+"]")...), nil
+}
+
 func TestOutput_RenderTo(t *testing.T) {
 	doc := New().
 		Table("Test", []map[string]any{


### PR DESCRIPTION
## Bug

`Output` accepts transformers via `WithTransformer` / `WithTransformers`, but `processFormatData` (`v2/output.go`) applied the copied `[]Transformer` slice in caller-argument (insertion) order instead of sorting by `Transformer.Priority()`. This contradicted the transformer pipeline contract (`TransformPipeline` sorts lower priority first) and the v2 design requirement for priority-based execution.

Repro: `NewOutput(WithFormat(Table()), WithTransformers(high, low), WithWriter(...))` where both transformers mutate bytes — render order followed argument order, not `Priority()`.

## Root Cause

`Output` reimplemented the transformer-application loop rather than routing through `TransformPipeline`, and the reimplementation omitted the priority-sort step that lives in `TransformPipeline.sortTransformers`. As a result, transformers ran in registration order.

## Fix

`processFormatData` now sorts a local copy of the transformer slice by `Priority()` (ascending, `sort.SliceStable`) before applying them. Sorting a copy avoids mutating the caller's slice; the stable sort preserves insertion order for transformers that share a priority, matching the pipeline's behaviour. The change is confined to `v2/output.go` (per scope constraint — `v2/transformer.go` is owned by parallel ticket T-1131).

## Tests

Added `TestOutput_Render_TransformerPriorityOrder` in `v2/output_test.go`: registers two byte-mutating transformers in reverse priority order and asserts the lower-priority transformer runs first regardless of argument order. Confirmed it fails before the fix (`[high][low]`) and passes after (`[low][high]`).

- `make test` — pass
- `make lint` — 0 issues

See `specs/bugfixes/output-transformer-priority-ordering/report.md` for the full investigation.