### PR TITLE
Fix T-1131: TransformPipeline Panics On Nil Transformers

### DIFF
--- a/v2/format_aware.go
+++ b/v2/format_aware.go
@@ -78,8 +78,14 @@ type FormatAwareTransformer struct {
 	detector    *FormatDetector
 }
 
-// NewFormatAwareTransformer wraps a transformer with format awareness
+// NewFormatAwareTransformer wraps a transformer with format awareness. It
+// returns nil when the supplied transformer is nil, since wrapping nil would
+// only defer a nil-pointer panic to the wrapper's Name/Priority/CanTransform/
+// Transform methods.
 func NewFormatAwareTransformer(transformer Transformer) *FormatAwareTransformer {
+	if transformer == nil {
+		return nil
+	}
 	return &FormatAwareTransformer{
 		transformer: transformer,
 		detector:    NewFormatDetector(),

--- a/v2/format_aware_test.go
+++ b/v2/format_aware_test.go
@@ -188,6 +188,17 @@ func TestFormatAwareTransformer_Wrapping(t *testing.T) {
 	}
 }
 
+// Regression test for T-1131: NewFormatAwareTransformer must not wrap a nil
+// transformer and later panic when its Name/Priority/CanTransform/Transform
+// methods dereference the embedded nil transformer. Expected behaviour: wrapping
+// a nil transformer returns nil so callers can detect the invalid input.
+func TestNewFormatAwareTransformer_Nil(t *testing.T) {
+	wrapper := NewFormatAwareTransformer(nil)
+	if wrapper != nil {
+		t.Fatalf("NewFormatAwareTransformer(nil) = %v, want nil", wrapper)
+	}
+}
+
 func TestFormatAwareTransformer_EmojiCanTransform(t *testing.T) {
 	emojiTransformer := &EmojiTransformer{}
 	wrapper := NewFormatAwareTransformer(emojiTransformer)

--- a/v2/specs/bugfixes/transformpipeline-nil-transformer/report.md
+++ b/v2/specs/bugfixes/transformpipeline-nil-transformer/report.md
@@ -1,0 +1,116 @@
+# Bugfix Report: TransformPipeline Panics On Nil Transformers
+
+**Date:** 2026-05-25
+**Status:** Fixed
+
+## Description of the Issue
+
+`TransformPipeline` accepted nil transformers and stored them, and
+`NewFormatAwareTransformer` wrapped nil transformers. Any later call that invoked
+an interface method on the stored/wrapped transformer dereferenced the nil
+interface value and panicked with a nil-pointer segfault.
+
+**Reproduction steps:**
+1. `pipeline := output.NewTransformPipeline()`
+2. `pipeline.Add(nil)`
+3. Call `pipeline.Info()` (or `Transform`/`Has`/`Get`/`Remove`) — panics.
+4. Similarly, `output.NewFormatAwareTransformer(nil)` returns a wrapper whose
+   `Name()`/`Priority()`/`CanTransform()`/`Transform()` panic.
+
+**Impact:** A nil transformer passed by a caller crashes the whole process
+instead of producing a recoverable error. This is inconsistent with the rest of
+the transformation API, which validates invalid inputs (nil filter predicates,
+nil aggregate functions, nil config transformers/writers) rather than crashing.
+
+## Investigation Summary
+
+- **Symptoms examined:** Nil-pointer panic in `sortTransformers` (`Priority()`)
+  and in the `Name()`/`CanTransform()`/`Transform()` calls of the pipeline
+  methods.
+- **Code inspected:** `v2/transformer.go` (`Add`, `Remove`, `Has`, `Get`,
+  `Transform`, `Info`, `sortTransformers`), `v2/format_aware.go`
+  (`NewFormatAwareTransformer` and the `FormatAwareTransformer` methods),
+  `v2/output.go` (`validateConfigEntries`), `v2/operations.go`
+  (`FilterOp.Validate`, `GroupByOp.Validate`) for the existing nil-validation
+  convention.
+- **Hypotheses tested:** Confirmed the panic originates from storing/wrapping a
+  nil `Transformer` interface value, not from any data-dependent path.
+
+## Discovered Root Cause
+
+Missing input validation. `TransformPipeline.Add` appended the transformer
+without a nil check, and `NewFormatAwareTransformer` wrapped without one. The
+pipeline's read methods then assumed every stored element was non-nil.
+
+**Defect type:** Missing validation (nil dereference).
+
+**Why it occurred:** `Add` has a void signature, so unlike the validating
+operations (`FilterOp.Validate`, `GroupByOp.Validate`) and `validateConfigEntries`
+it had no channel to report invalid input — the nil case was never handled.
+
+**Contributing factors:** The `Transformer` interface is consumed in several
+methods, each of which independently trusted that stored values were non-nil.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `v2/transformer.go` — `Add` now ignores nil transformers (never stores them).
+  `sortTransformers`, `Remove`, `Has`, `Get`, `Transform`, and `Info` skip any
+  nil entries defensively so the pipeline cannot panic even if a nil slips in.
+- `v2/format_aware.go` — `NewFormatAwareTransformer(nil)` returns nil instead of
+  wrapping a nil transformer.
+
+**Approach rationale:** Rejecting/skipping nil at insertion and wrapping time is
+the cleanest fix and matches the "skip them consistently" option from the ticket.
+`Add` is a void method used by many call sites, so silently skipping nil keeps the
+public signature stable while guaranteeing nothing nil is ever stored. The
+defensive skips in the iteration methods are belt-and-suspenders.
+
+**Alternatives considered:**
+- Change `Add` to return an error — rejected: breaks the existing void signature
+  and every current call site, and T-1131 explicitly allows the skip-consistently
+  option.
+- Panic with a clearer message — rejected: the rest of the API avoids panics for
+  invalid input.
+
+## Regression Test
+
+**Test files:** `v2/transformer_test.go`, `v2/format_aware_test.go`
+**Test names:** `TestTransformPipeline_AddNil`, `TestNewFormatAwareTransformer_Nil`
+
+**What it verifies:** Adding nil transformers does not store them and does not
+panic across `Info`/`Transform`/`Has`/`Get`/`Remove`; wrapping a nil transformer
+with `NewFormatAwareTransformer` returns nil.
+
+**Run command:**
+`go test -run 'TestTransformPipeline_AddNil|TestNewFormatAwareTransformer_Nil' ./...`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `v2/transformer.go` | Skip nil transformers in `Add` and all read/iterate methods |
+| `v2/format_aware.go` | `NewFormatAwareTransformer(nil)` returns nil |
+| `v2/transformer_test.go` | Add `TestTransformPipeline_AddNil` regression test |
+| `v2/format_aware_test.go` | Add `TestNewFormatAwareTransformer_Nil` regression test |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Linters/validators pass
+
+**Manual verification:**
+- Confirmed red (failing/panicking) state before the fix.
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Validate nil interface inputs at the boundary where they enter a collection.
+- When a setter cannot return an error, decide explicitly between skipping and
+  documenting the behaviour rather than storing invalid values.
+
+## Related
+
+- Transit ticket T-1131

--- a/v2/transformer.go
+++ b/v2/transformer.go
@@ -37,8 +37,15 @@ func NewTransformPipeline() *TransformPipeline {
 	}
 }
 
-// Add adds a transformer to the pipeline
+// Add adds a transformer to the pipeline. Nil transformers are ignored so the
+// pipeline never stores a value that would panic when its interface methods are
+// called later (matching how the rest of the transformation API rejects nil
+// inputs rather than crashing).
 func (tp *TransformPipeline) Add(transformer Transformer) {
+	if transformer == nil {
+		return
+	}
+
 	tp.mu.Lock()
 	defer tp.mu.Unlock()
 
@@ -52,6 +59,9 @@ func (tp *TransformPipeline) Remove(name string) bool {
 	defer tp.mu.Unlock()
 
 	for i, t := range tp.transformers {
+		if t == nil {
+			continue
+		}
 		if t.Name() == name {
 			tp.transformers = append(tp.transformers[:i], tp.transformers[i+1:]...)
 			return true
@@ -66,6 +76,9 @@ func (tp *TransformPipeline) Has(name string) bool {
 	defer tp.mu.RUnlock()
 
 	for _, t := range tp.transformers {
+		if t == nil {
+			continue
+		}
 		if t.Name() == name {
 			return true
 		}
@@ -79,6 +92,9 @@ func (tp *TransformPipeline) Get(name string) Transformer {
 	defer tp.mu.RUnlock()
 
 	for _, t := range tp.transformers {
+		if t == nil {
+			continue
+		}
 		if t.Name() == name {
 			return t
 		}
@@ -110,7 +126,16 @@ func (tp *TransformPipeline) sortTransformers() {
 	}
 
 	sort.Slice(tp.transformers, func(i, j int) bool {
-		return tp.transformers[i].Priority() < tp.transformers[j].Priority()
+		// Guard against nil entries so a stray nil cannot panic during sorting.
+		// Nil is treated as lowest priority; iteration methods skip nil anyway.
+		switch {
+		case tp.transformers[i] == nil:
+			return tp.transformers[j] != nil
+		case tp.transformers[j] == nil:
+			return false
+		default:
+			return tp.transformers[i].Priority() < tp.transformers[j].Priority()
+		}
 	})
 	tp.sorted = true
 }
@@ -123,6 +148,9 @@ func (tp *TransformPipeline) Transform(ctx context.Context, input []byte, format
 	// Create a copy of transformers to avoid holding the lock during transformation
 	applicable := make([]Transformer, 0, len(tp.transformers))
 	for _, t := range tp.transformers {
+		if t == nil {
+			continue
+		}
 		if t.CanTransform(format) {
 			applicable = append(applicable, t)
 		}
@@ -162,6 +190,9 @@ func (tp *TransformPipeline) Info() []TransformInfo {
 
 	info := make([]TransformInfo, 0, len(tp.transformers))
 	for _, t := range tp.transformers {
+		if t == nil {
+			continue
+		}
 		// Test common formats to see which ones this transformer supports
 		formats := make([]string, 0)
 		testFormats := []string{FormatJSON, FormatYAML, FormatCSV, FormatHTML, FormatTable, FormatMarkdown, FormatDOT, FormatMermaid, FormatDrawIO}

--- a/v2/transformer_test.go
+++ b/v2/transformer_test.go
@@ -162,6 +162,60 @@ func TestTransformPipeline_Clear(t *testing.T) {
 	}
 }
 
+// Regression test for T-1131: TransformPipeline must not panic when a nil
+// transformer is added. Previously Add appended nil directly and the pipeline
+// methods (Info, Transform, Has, Get, Remove, sortTransformers) dereferenced it,
+// causing a nil-interface panic. Expected behaviour: nil transformers are
+// rejected at insertion time and never stored, so subsequent calls are safe.
+func TestTransformPipeline_AddNil(t *testing.T) {
+	pipeline := NewTransformPipeline()
+
+	// Add a nil transformer alongside a valid one.
+	pipeline.Add(nil)
+	pipeline.Add(newMockTransformer("real", 100, []string{FormatJSON}, ""))
+	pipeline.Add(nil)
+
+	// nil transformers must not be stored.
+	if got := pipeline.Count(); got != 1 {
+		t.Errorf("Count() = %d, want 1 (nil transformers should be skipped)", got)
+	}
+
+	// Each of these previously panicked when a nil transformer was stored.
+	t.Run("Info", func(t *testing.T) {
+		info := pipeline.Info()
+		if len(info) != 1 {
+			t.Errorf("Info() length = %d, want 1", len(info))
+		}
+	})
+
+	t.Run("Transform", func(t *testing.T) {
+		if _, err := pipeline.Transform(context.Background(), []byte("input"), FormatJSON); err != nil {
+			t.Errorf("Transform() error = %v, want nil", err)
+		}
+	})
+
+	t.Run("Has", func(t *testing.T) {
+		if pipeline.Has("nonexistent") {
+			t.Error("Has() = true, want false")
+		}
+		if !pipeline.Has("real") {
+			t.Error("Has(\"real\") = false, want true")
+		}
+	})
+
+	t.Run("Get", func(t *testing.T) {
+		if got := pipeline.Get("real"); got == nil {
+			t.Error("Get(\"real\") = nil, want transformer")
+		}
+	})
+
+	t.Run("Remove", func(t *testing.T) {
+		if pipeline.Remove("nonexistent") {
+			t.Error("Remove() = true, want false")
+		}
+	})
+}
+
 // Test priority-based ordering
 
 func TestTransformPipeline_PriorityOrdering(t *testing.T) {


### PR DESCRIPTION
## Bug

`TransformPipeline` accepted nil transformers and `NewFormatAwareTransformer` wrapped nil transformers. Any later interface-method call on the stored/wrapped value dereferenced the nil interface and panicked (segfault). Repro: `pipeline.Add(nil); pipeline.Info()` panics; `NewFormatAwareTransformer(nil)` returns a wrapper whose `Name/Priority/CanTransform/Transform` panic.

## Root cause

Missing input validation. `TransformPipeline.Add` appended without a nil check and `NewFormatAwareTransformer` wrapped without one, while the read/iterate methods assumed every stored transformer was non-nil. This is inconsistent with the rest of the transformation API, which validates nil filter predicates, nil aggregate functions, and nil config transformers/writers rather than crashing.

## Fix

- `v2/transformer.go`: `Add` ignores nil transformers so they are never stored. `Remove`, `Has`, `Get`, `Transform`, `Info`, and the `sortTransformers` comparator defensively skip nil entries.
- `v2/format_aware.go`: `NewFormatAwareTransformer(nil)` returns nil instead of wrapping a nil transformer.

`Add` keeps its void signature (used by many call sites), matching the ticket's "skip them consistently" option.

## Tests

- `TestTransformPipeline_AddNil` (`v2/transformer_test.go`): adding nil does not store it and does not panic across `Info`/`Transform`/`Has`/`Get`/`Remove`.
- `TestNewFormatAwareTransformer_Nil` (`v2/format_aware_test.go`): wrapping nil returns nil.

Both confirmed red before the fix (reproduced the ticket panic) and green after. Full `make test` and `make lint` pass.

Report: `v2/specs/bugfixes/transformpipeline-nil-transformer/report.md`

Closes T-1131.