### PR TITLE
Fix T-1120: RenderTo Implementations Panic On Nil Writers

### DIFF
--- a/specs/bugfixes/renderto-nil-writer/report.md
+++ b/specs/bugfixes/renderto-nil-writer/report.md
@@ -1,0 +1,105 @@
+# Bugfix Report: RenderTo Implementations Panic On Nil Writers
+
+**Date:** 2026-05-25
+**Status:** Fixed
+
+## Description of the Issue
+
+Several renderer `RenderTo` methods write to the `io.Writer` argument without
+first checking whether it is nil. After rendering succeeds, the final
+`w.Write(data)` (or, for HTML with templating, an earlier header write) panics
+with a nil pointer dereference instead of returning an error.
+
+This was inconsistent with `baseRenderer.renderDocumentTo` and the CSV streaming
+renderer, both of which explicitly return `writer cannot be nil`.
+
+**Reproduction steps:**
+1. Build any document.
+2. Call a renderer's `RenderTo(ctx, doc, nil)` (e.g. JSON, YAML, Markdown, Table, DOT, Mermaid, Draw.io, or HTML with a template).
+3. Observe a `runtime error: invalid memory address or nil pointer dereference` panic.
+
+**Impact:** Medium. A nil writer is a caller programming error, but the library
+should fail gracefully with a clear error rather than panicking. The behaviour
+was inconsistent across renderers (CSV returned an error; others panicked).
+
+## Investigation Summary
+
+- **Symptoms examined:** Nil pointer panic from `w.Write` after a successful render.
+- **Code inspected:** Every public `RenderTo` in `v2/json_yaml_renderer.go`, `v2/markdown_renderer.go`, `v2/table_renderer.go`, `v2/graph_renderers.go`, `v2/html_renderer.go`, plus the reference guards in `v2/base_renderer.go` and `v2/csv_renderer.go`.
+- **Hypotheses tested:** Confirmed via a regression test that JSON, YAML, Markdown, Table, DOT, Mermaid, Draw.io, and HTML-with-template panic, while CSV and HTML-without-template already return the error (CSV has its own guard; HTML-without-template delegates straight to `renderDocumentTo`, which guards).
+
+## Discovered Root Cause
+
+The affected `RenderTo` methods render to a byte slice and then unconditionally
+call `w.Write(...)`. None of them check `w == nil` first. `htmlRenderer.RenderTo`
+additionally writes a template header to `w` before delegating to the guarded
+`renderDocumentTo`, so it panics earlier when template output is enabled.
+
+**Defect type:** Missing input validation (nil guard).
+
+**Why it occurred:** The nil-writer guard lived only in `renderDocumentTo` and
+the CSV renderer. Renderers that build their output independently and write it in
+one shot never inherited that guard.
+
+**Contributing factors:** Each renderer implements `RenderTo` separately, so the
+guard was easy to omit in the renderers that do not route through
+`renderDocumentTo`.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `v2/json_yaml_renderer.go` - Added `if w == nil` guard at the top of `jsonRenderer.RenderTo` and `yamlRenderer.RenderTo`.
+- `v2/markdown_renderer.go` - Added the guard at the top of `markdownRenderer.RenderTo`.
+- `v2/table_renderer.go` - Added the guard at the top of `tableRenderer.RenderTo`.
+- `v2/graph_renderers.go` - Added the guard at the top of `dotRenderer.RenderTo`, `mermaidRenderer.RenderTo`, and `drawioRenderer.RenderTo`.
+- `v2/html_renderer.go` - Added the guard at the top of `htmlRenderer.RenderTo`, before the template header write.
+
+**Approach rationale:** Match the existing pattern. Each guard returns
+`fmt.Errorf("writer cannot be nil")`, identical to `renderDocumentTo` and the CSV
+renderer, and runs before any write so no partial output is produced.
+
+**Alternatives considered:**
+- Wrap all writes in a shared helper - Rejected as larger than necessary; the renderers build output differently and a one-line guard per method is clearer and lower risk.
+
+## Regression Test
+
+**Test file:** `v2/renderer_nil_writer_test.go`
+**Test name:** `TestRenderTo_NilWriter`, `TestHTMLRenderer_NilWriterWithTemplate`
+
+**What it verifies:** Every built-in renderer's `RenderTo` returns an error
+containing `writer cannot be nil` (and does not panic) when passed a nil writer.
+The HTML-with-template case is covered separately because it panics on an earlier
+write than the other renderers.
+
+**Run command:** `cd v2 && go test . -run 'TestRenderTo_NilWriter|TestHTMLRenderer_NilWriterWithTemplate' -v`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `v2/json_yaml_renderer.go` | Nil-writer guard in JSON and YAML `RenderTo` |
+| `v2/markdown_renderer.go` | Nil-writer guard in Markdown `RenderTo` |
+| `v2/table_renderer.go` | Nil-writer guard in Table `RenderTo` |
+| `v2/graph_renderers.go` | Nil-writer guard in DOT, Mermaid, Draw.io `RenderTo` |
+| `v2/html_renderer.go` | Nil-writer guard in HTML `RenderTo` before header write |
+| `v2/renderer_nil_writer_test.go` | New regression tests |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes
+- [x] Linters/validators pass
+
+**Manual verification:**
+- Confirmed the regression tests fail (panic) before the fix and pass after.
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Validate `io.Writer` arguments at the top of every public method that writes to them.
+- Keep nil-argument behaviour consistent across renderers (return an error, never panic).
+
+## Related
+
+- Transit ticket T-1120

--- a/v2/graph_renderers.go
+++ b/v2/graph_renderers.go
@@ -91,6 +91,9 @@ func (d *dotRenderer) Render(ctx context.Context, doc *Document) ([]byte, error)
 }
 
 func (d *dotRenderer) RenderTo(ctx context.Context, doc *Document, w io.Writer) error {
+	if w == nil {
+		return fmt.Errorf("writer cannot be nil")
+	}
 	data, err := d.Render(ctx, doc)
 	if err != nil {
 		return err
@@ -278,6 +281,9 @@ func (m *mermaidRenderer) Render(ctx context.Context, doc *Document) ([]byte, er
 }
 
 func (m *mermaidRenderer) RenderTo(ctx context.Context, doc *Document, w io.Writer) error {
+	if w == nil {
+		return fmt.Errorf("writer cannot be nil")
+	}
 	data, err := m.Render(ctx, doc)
 	if err != nil {
 		return err
@@ -606,6 +612,9 @@ func (d *drawioRenderer) Render(ctx context.Context, doc *Document) ([]byte, err
 }
 
 func (d *drawioRenderer) RenderTo(ctx context.Context, doc *Document, w io.Writer) error {
+	if w == nil {
+		return fmt.Errorf("writer cannot be nil")
+	}
 	data, err := d.Render(ctx, doc)
 	if err != nil {
 		return err

--- a/v2/html_renderer.go
+++ b/v2/html_renderer.go
@@ -69,6 +69,10 @@ func (h *htmlRenderer) Render(ctx context.Context, doc *Document) ([]byte, error
 }
 
 func (h *htmlRenderer) RenderTo(ctx context.Context, doc *Document, w io.Writer) error {
+	if w == nil {
+		return fmt.Errorf("writer cannot be nil")
+	}
+
 	// Write template header if needed
 	if h.useTemplate {
 		tmpl := h.template

--- a/v2/json_yaml_renderer.go
+++ b/v2/json_yaml_renderer.go
@@ -116,6 +116,9 @@ func (j *jsonRenderer) Render(ctx context.Context, doc *Document) ([]byte, error
 }
 
 func (j *jsonRenderer) RenderTo(ctx context.Context, doc *Document, w io.Writer) error {
+	if w == nil {
+		return fmt.Errorf("writer cannot be nil")
+	}
 	data, err := j.renderDocumentJSON(ctx, doc)
 	if err != nil {
 		return err
@@ -602,6 +605,9 @@ func (y *yamlRenderer) Render(ctx context.Context, doc *Document) ([]byte, error
 }
 
 func (y *yamlRenderer) RenderTo(ctx context.Context, doc *Document, w io.Writer) error {
+	if w == nil {
+		return fmt.Errorf("writer cannot be nil")
+	}
 	data, err := y.renderDocumentYAML(ctx, doc)
 	if err != nil {
 		return err

--- a/v2/markdown_renderer.go
+++ b/v2/markdown_renderer.go
@@ -27,6 +27,9 @@ func (m *markdownRenderer) Render(ctx context.Context, doc *Document) ([]byte, e
 }
 
 func (m *markdownRenderer) RenderTo(ctx context.Context, doc *Document, w io.Writer) error {
+	if w == nil {
+		return fmt.Errorf("writer cannot be nil")
+	}
 	data, err := m.renderDocumentMarkdown(ctx, doc)
 	if err != nil {
 		return err

--- a/v2/renderer_nil_writer_test.go
+++ b/v2/renderer_nil_writer_test.go
@@ -1,0 +1,83 @@
+package output
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestRenderTo_NilWriter is a regression test for T-1120.
+//
+// Every built-in renderer's RenderTo wrote to the io.Writer without first
+// checking whether it was nil. After a successful render this caused a nil
+// pointer panic on w.Write(...) rather than returning an error. This was
+// inconsistent with baseRenderer.renderDocumentTo and the CSV renderer, which
+// already returned a "writer cannot be nil" error.
+//
+// Expected behaviour: RenderTo returns an error containing "writer cannot be
+// nil" and does not panic. Actual behaviour before the fix: a nil pointer
+// panic from w.Write.
+func TestRenderTo_NilWriter(t *testing.T) {
+	doc := New().
+		Table("people", []map[string]any{
+			{"name": "Alice", "age": 30},
+		}, WithKeys("name", "age")).
+		Text("some text").
+		Build()
+
+	renderers := map[string]Renderer{
+		"json":        &jsonRenderer{},
+		"yaml":        &yamlRenderer{},
+		"markdown":    &markdownRenderer{headingLevel: 1},
+		"table":       &tableRenderer{},
+		"csv":         &csvRenderer{},
+		"html":        &htmlRenderer{useTemplate: true, template: DefaultHTMLTemplate},
+		"html-noTmpl": &htmlRenderer{useTemplate: false},
+		"dot":         &dotRenderer{},
+		"mermaid":     &mermaidRenderer{},
+		"drawio":      &drawioRenderer{},
+	}
+
+	for name, renderer := range renderers {
+		t.Run(name, func(t *testing.T) {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("RenderTo panicked on nil writer: %v", r)
+				}
+			}()
+
+			err := renderer.RenderTo(context.Background(), doc, nil)
+			if err == nil {
+				t.Fatal("expected error for nil writer, got nil")
+			}
+			if !strings.Contains(err.Error(), "writer cannot be nil") {
+				t.Errorf("expected error containing %q, got %q", "writer cannot be nil", err.Error())
+			}
+		})
+	}
+}
+
+// TestHTMLRenderer_NilWriterWithTemplate is a regression test for T-1120.
+//
+// htmlRenderer.RenderTo writes the template header to w before delegating to
+// baseRenderer.renderDocumentTo (which has its own nil-writer guard). With
+// template output enabled this earlier write panicked on a nil writer. The
+// guard must run before any write so the error is returned instead.
+func TestHTMLRenderer_NilWriterWithTemplate(t *testing.T) {
+	doc := New().Text("hello").Build()
+	renderer := &htmlRenderer{useTemplate: true, template: DefaultHTMLTemplate}
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("RenderTo panicked on nil writer: %v", r)
+		}
+	}()
+
+	err := renderer.RenderTo(context.Background(), doc, nil)
+	if err == nil {
+		t.Fatal("expected error for nil writer, got nil")
+	}
+	if !strings.Contains(err.Error(), "writer cannot be nil") {
+		t.Errorf("expected error containing %q, got %q", "writer cannot be nil", err.Error())
+	}
+}

--- a/v2/table_renderer.go
+++ b/v2/table_renderer.go
@@ -27,6 +27,9 @@ func (t *tableRenderer) Render(ctx context.Context, doc *Document) ([]byte, erro
 }
 
 func (t *tableRenderer) RenderTo(ctx context.Context, doc *Document, w io.Writer) error {
+	if w == nil {
+		return fmt.Errorf("writer cannot be nil")
+	}
 	data, err := t.renderDocumentTable(ctx, doc)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Bug

Several renderer `RenderTo` methods wrote to the `io.Writer` argument without checking whether it was nil. After a successful render, the final `w.Write(data)` panicked with a nil pointer dereference instead of returning an error. This affected the JSON, YAML, Markdown, Table, DOT, Mermaid, and Draw.io renderers. `htmlRenderer.RenderTo` panicked even earlier — on the template header write — when template output was enabled.

This was inconsistent with `baseRenderer.renderDocumentTo` and the CSV streaming renderer, both of which already returned `writer cannot be nil`.

## Root cause

The nil-writer guard lived only in `renderDocumentTo` and the CSV renderer. Renderers that build their output independently and write it in one shot never inherited that guard, so a nil writer reached `w.Write(...)` and panicked.

## Fix

Add an explicit `if w == nil { return fmt.Errorf("writer cannot be nil") }` guard at the top of every public `RenderTo` implementation, before any write. The message matches the existing guards for consistency. For HTML the guard runs before the template header write so no partial output is produced.

Files changed:
- `v2/json_yaml_renderer.go` — JSON and YAML `RenderTo`
- `v2/markdown_renderer.go` — Markdown `RenderTo`
- `v2/table_renderer.go` — Table `RenderTo`
- `v2/graph_renderers.go` — DOT, Mermaid, Draw.io `RenderTo`
- `v2/html_renderer.go` — HTML `RenderTo` (before header write)

## Tests

Added `v2/renderer_nil_writer_test.go` with `TestRenderTo_NilWriter` (covers every built-in renderer) and `TestHTMLRenderer_NilWriterWithTemplate`. These panic before the fix and pass after; they assert the returned error contains `writer cannot be nil` and that no panic occurs.

`make test` and `make lint` both pass.

See `specs/bugfixes/renderto-nil-writer/report.md` for the full bugfix report.