### PR TITLE
Fix T-1253: Nested Renderers Drop Caller Context

### DIFF
--- a/v2/html_renderer.go
+++ b/v2/html_renderer.go
@@ -49,7 +49,9 @@ func (h *htmlRenderer) Format() string {
 
 func (h *htmlRenderer) Render(ctx context.Context, doc *Document) ([]byte, error) {
 	// Render the document
-	result, err := h.renderDocumentWithFormat(ctx, doc, h.renderContent, FormatHTML)
+	result, err := h.renderDocumentWithFormat(ctx, doc, func(content Content) ([]byte, error) {
+		return h.renderContent(ctx, content)
+	}, FormatHTML)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +88,9 @@ func (h *htmlRenderer) RenderTo(ctx context.Context, doc *Document, w io.Writer)
 	}
 
 	// Render document content
-	if err := h.renderDocumentTo(ctx, doc, w, h.renderContentTo); err != nil {
+	if err := h.renderDocumentTo(ctx, doc, w, func(content Content, w io.Writer) error {
+		return h.renderContentTo(ctx, content, w)
+	}); err != nil {
 		return err
 	}
 
@@ -117,7 +121,7 @@ func (h *htmlRenderer) SupportsStreaming() bool {
 }
 
 // renderContent renders content specifically for HTML format
-func (h *htmlRenderer) renderContent(content Content) ([]byte, error) {
+func (h *htmlRenderer) renderContent(ctx context.Context, content Content) ([]byte, error) {
 	switch c := content.(type) {
 	case *TableContent:
 		return h.renderTableContentHTML(c)
@@ -126,9 +130,9 @@ func (h *htmlRenderer) renderContent(content Content) ([]byte, error) {
 	case *RawContent:
 		return h.renderRawContentHTML(c)
 	case *SectionContent:
-		return h.renderSectionContentHTML(c)
+		return h.renderSectionContentHTML(ctx, c)
 	case *DefaultCollapsibleSection:
-		return h.renderCollapsibleSection(c)
+		return h.renderCollapsibleSection(ctx, c)
 	case *ChartContent:
 		return h.renderChartContentHTML(c)
 	default:
@@ -143,8 +147,8 @@ func (h *htmlRenderer) renderContent(content Content) ([]byte, error) {
 }
 
 // renderContentTo renders content to a writer for HTML format
-func (h *htmlRenderer) renderContentTo(content Content, w io.Writer) error {
-	data, err := h.renderContent(content)
+func (h *htmlRenderer) renderContentTo(ctx context.Context, content Content, w io.Writer) error {
+	data, err := h.renderContent(ctx, content)
 	if err != nil {
 		return err
 	}
@@ -262,7 +266,7 @@ func (h *htmlRenderer) renderRawContentHTML(raw *RawContent) ([]byte, error) {
 }
 
 // renderSectionContentHTML renders section content as HTML with nested content
-func (h *htmlRenderer) renderSectionContentHTML(section *SectionContent) ([]byte, error) {
+func (h *htmlRenderer) renderSectionContentHTML(ctx context.Context, section *SectionContent) ([]byte, error) {
 	var result strings.Builder
 
 	// Create section with appropriate heading level
@@ -275,12 +279,12 @@ func (h *htmlRenderer) renderSectionContentHTML(section *SectionContent) ([]byte
 	// Render nested content
 	for _, content := range section.Contents() {
 		// Apply per-content transformations before rendering
-		transformed, err := applyContentTransformations(context.Background(), content)
+		transformed, err := applyContentTransformations(ctx, content)
 		if err != nil {
 			return nil, err
 		}
 
-		contentHTML, err := h.renderContent(transformed)
+		contentHTML, err := h.renderContent(ctx, transformed)
 		if err != nil {
 			return nil, fmt.Errorf("failed to render nested content: %w", err)
 		}
@@ -505,7 +509,7 @@ func (h *htmlRenderer) formatDetailsAsHTMLWithCodeFences(details any, language s
 }
 
 // renderCollapsibleSection renders a CollapsibleSection as semantic HTML5 elements (Requirement 15.6)
-func (h *htmlRenderer) renderCollapsibleSection(section *DefaultCollapsibleSection) ([]byte, error) {
+func (h *htmlRenderer) renderCollapsibleSection(ctx context.Context, section *DefaultCollapsibleSection) ([]byte, error) {
 	var result strings.Builder
 
 	openAttr := ""
@@ -529,7 +533,14 @@ func (h *htmlRenderer) renderCollapsibleSection(section *DefaultCollapsibleSecti
 
 	// Render all nested content with indentation (Requirement 15.6)
 	for _, content := range section.Content() {
-		contentHTML, err := h.renderContent(content)
+		// Apply per-content transformations before rendering so nested
+		// content observes the caller's context (cancellation/deadlines).
+		transformed, err := applyContentTransformations(ctx, content)
+		if err != nil {
+			return nil, err
+		}
+
+		contentHTML, err := h.renderContent(ctx, transformed)
 		if err != nil {
 			return nil, fmt.Errorf("failed to render section content: %w", err)
 		}

--- a/v2/json_yaml_renderer.go
+++ b/v2/json_yaml_renderer.go
@@ -133,13 +133,15 @@ func (j *jsonRenderer) SupportsStreaming() bool {
 
 // renderDocumentJSON renders entire document as a single JSON structure
 func (j *jsonRenderer) renderDocumentJSON(ctx context.Context, doc *Document) ([]byte, error) {
-	return renderDocumentGeneric(ctx, doc, "JSON", j.renderContent, json.Unmarshal, func(v any) ([]byte, error) {
+	return renderDocumentGeneric(ctx, doc, "JSON", func(content Content) ([]byte, error) {
+		return j.renderContent(ctx, content)
+	}, json.Unmarshal, func(v any) ([]byte, error) {
 		return json.MarshalIndent(v, "", "  ")
 	})
 }
 
 // renderContent renders content specifically for JSON format
-func (j *jsonRenderer) renderContent(content Content) ([]byte, error) {
+func (j *jsonRenderer) renderContent(ctx context.Context, content Content) ([]byte, error) {
 	switch c := content.(type) {
 	case *TableContent:
 		return j.renderTableContentJSON(c)
@@ -148,9 +150,9 @@ func (j *jsonRenderer) renderContent(content Content) ([]byte, error) {
 	case *RawContent:
 		return j.renderRawContentJSON(c)
 	case *SectionContent:
-		return j.renderSectionContentJSON(c)
+		return j.renderSectionContentJSON(ctx, c)
 	case *DefaultCollapsibleSection:
-		return j.renderCollapsibleSectionJSON(c)
+		return j.renderCollapsibleSectionJSON(ctx, c)
 	case *ChartContent:
 		return j.renderChartContentJSON(c)
 	case *GraphContent:
@@ -168,7 +170,7 @@ func (j *jsonRenderer) renderContent(content Content) ([]byte, error) {
 }
 
 // renderContentTo renders content to a writer for JSON format with streaming support
-func (j *jsonRenderer) renderContentTo(content Content, w io.Writer) error {
+func (j *jsonRenderer) renderContentTo(ctx context.Context, content Content, w io.Writer) error {
 	switch c := content.(type) {
 	case *TableContent:
 		return j.renderTableContentJSONStream(c, w)
@@ -177,10 +179,10 @@ func (j *jsonRenderer) renderContentTo(content Content, w io.Writer) error {
 	case *RawContent:
 		return j.renderRawContentJSONStream(c, w)
 	case *SectionContent:
-		return j.renderSectionContentJSONStream(c, w)
+		return j.renderSectionContentJSONStream(ctx, c, w)
 	case *ChartContent, *GraphContent, *DrawIOContent:
 		// These complex types fall back to buffered rendering
-		data, err := j.renderContent(content)
+		data, err := j.renderContent(ctx, content)
 		if err != nil {
 			return err
 		}
@@ -188,7 +190,7 @@ func (j *jsonRenderer) renderContentTo(content Content, w io.Writer) error {
 		return err
 	default:
 		// Fallback to buffered rendering
-		data, err := j.renderContent(content)
+		data, err := j.renderContent(ctx, content)
 		if err != nil {
 			return err
 		}
@@ -274,7 +276,7 @@ func (j *jsonRenderer) renderRawContentJSON(raw *RawContent) ([]byte, error) {
 }
 
 // renderSectionContentJSON renders section content as JSON with nested content
-func (j *jsonRenderer) renderSectionContentJSON(section *SectionContent) ([]byte, error) {
+func (j *jsonRenderer) renderSectionContentJSON(ctx context.Context, section *SectionContent) ([]byte, error) {
 	result := map[string]any{
 		keyType:  contentTypeNameSection,
 		keyTitle: section.Title(),
@@ -284,12 +286,12 @@ func (j *jsonRenderer) renderSectionContentJSON(section *SectionContent) ([]byte
 	var contents []any
 	for _, content := range section.Contents() {
 		// Apply per-content transformations before rendering
-		transformed, err := applyContentTransformations(context.Background(), content)
+		transformed, err := applyContentTransformations(ctx, content)
 		if err != nil {
 			return nil, err
 		}
 
-		contentJSON, err := j.renderContent(transformed)
+		contentJSON, err := j.renderContent(ctx, transformed)
 		if err != nil {
 			return nil, fmt.Errorf("failed to render nested content: %w", err)
 		}
@@ -491,7 +493,7 @@ func (j *jsonRenderer) renderRawContentJSONStream(raw *RawContent, w io.Writer) 
 }
 
 // renderSectionContentJSONStream renders section content as JSON to writer
-func (j *jsonRenderer) renderSectionContentJSONStream(section *SectionContent, w io.Writer) error {
+func (j *jsonRenderer) renderSectionContentJSONStream(ctx context.Context, section *SectionContent, w io.Writer) error {
 	// For sections with nested content, we need a more complex streaming approach
 	if _, err := w.Write([]byte("{\n")); err != nil {
 		return fmt.Errorf("failed to write opening brace: %w", err)
@@ -518,14 +520,14 @@ func (j *jsonRenderer) renderSectionContentJSONStream(section *SectionContent, w
 		}
 
 		// Apply per-content transformations before rendering
-		transformed, err := applyContentTransformations(context.Background(), content)
+		transformed, err := applyContentTransformations(ctx, content)
 		if err != nil {
 			return err
 		}
 
 		// Create a buffer for the nested content
 		var buf bytes.Buffer
-		if err := j.renderContentTo(transformed, &buf); err != nil {
+		if err := j.renderContentTo(ctx, transformed, &buf); err != nil {
 			return fmt.Errorf("failed to render nested content: %w", err)
 		}
 
@@ -622,11 +624,13 @@ func (y *yamlRenderer) SupportsStreaming() bool {
 
 // renderDocumentYAML renders entire document as a single YAML structure
 func (y *yamlRenderer) renderDocumentYAML(ctx context.Context, doc *Document) ([]byte, error) {
-	return renderDocumentGeneric(ctx, doc, "YAML", y.renderContent, yaml.Unmarshal, yaml.Marshal)
+	return renderDocumentGeneric(ctx, doc, "YAML", func(content Content) ([]byte, error) {
+		return y.renderContent(ctx, content)
+	}, yaml.Unmarshal, yaml.Marshal)
 }
 
 // renderContent renders content specifically for YAML format
-func (y *yamlRenderer) renderContent(content Content) ([]byte, error) {
+func (y *yamlRenderer) renderContent(ctx context.Context, content Content) ([]byte, error) {
 	switch c := content.(type) {
 	case *TableContent:
 		return y.renderTableContentYAML(c)
@@ -635,9 +639,9 @@ func (y *yamlRenderer) renderContent(content Content) ([]byte, error) {
 	case *RawContent:
 		return y.renderRawContentYAML(c)
 	case *SectionContent:
-		return y.renderSectionContentYAML(c)
+		return y.renderSectionContentYAML(ctx, c)
 	case *DefaultCollapsibleSection:
-		return y.renderCollapsibleSectionYAML(c)
+		return y.renderCollapsibleSectionYAML(ctx, c)
 	case *ChartContent:
 		return y.renderChartContentYAML(c)
 	case *GraphContent:
@@ -655,7 +659,7 @@ func (y *yamlRenderer) renderContent(content Content) ([]byte, error) {
 }
 
 // renderContentTo renders content to a writer for YAML format with streaming support
-func (y *yamlRenderer) renderContentTo(content Content, w io.Writer) error {
+func (y *yamlRenderer) renderContentTo(ctx context.Context, content Content, w io.Writer) error {
 	switch c := content.(type) {
 	case *TableContent:
 		return y.renderTableContentYAMLStream(c, w)
@@ -664,10 +668,10 @@ func (y *yamlRenderer) renderContentTo(content Content, w io.Writer) error {
 	case *RawContent:
 		return y.renderRawContentYAMLStream(c, w)
 	case *SectionContent:
-		return y.renderSectionContentYAMLStream(c, w)
+		return y.renderSectionContentYAMLStream(ctx, c, w)
 	case *ChartContent, *GraphContent, *DrawIOContent:
 		// These complex types fall back to buffered rendering
-		data, err := y.renderContent(content)
+		data, err := y.renderContent(ctx, content)
 		if err != nil {
 			return err
 		}
@@ -675,7 +679,7 @@ func (y *yamlRenderer) renderContentTo(content Content, w io.Writer) error {
 		return err
 	default:
 		// Fallback to buffered rendering
-		data, err := y.renderContent(content)
+		data, err := y.renderContent(ctx, content)
 		if err != nil {
 			return err
 		}
@@ -783,7 +787,7 @@ func (y *yamlRenderer) renderRawContentYAML(raw *RawContent) ([]byte, error) {
 }
 
 // renderSectionContentYAML renders section content as YAML with nested content
-func (y *yamlRenderer) renderSectionContentYAML(section *SectionContent) ([]byte, error) {
+func (y *yamlRenderer) renderSectionContentYAML(ctx context.Context, section *SectionContent) ([]byte, error) {
 	result := map[string]any{
 		keyType:  contentTypeNameSection,
 		keyTitle: section.Title(),
@@ -793,12 +797,12 @@ func (y *yamlRenderer) renderSectionContentYAML(section *SectionContent) ([]byte
 	var contents []any
 	for _, content := range section.Contents() {
 		// Apply per-content transformations before rendering
-		transformed, err := applyContentTransformations(context.Background(), content)
+		transformed, err := applyContentTransformations(ctx, content)
 		if err != nil {
 			return nil, err
 		}
 
-		contentYAML, err := y.renderContent(transformed)
+		contentYAML, err := y.renderContent(ctx, transformed)
 		if err != nil {
 			return nil, fmt.Errorf("failed to render nested content: %w", err)
 		}
@@ -985,7 +989,7 @@ func (y *yamlRenderer) renderRawContentYAMLStream(raw *RawContent, w io.Writer) 
 }
 
 // renderSectionContentYAMLStream renders section content as YAML to writer
-func (y *yamlRenderer) renderSectionContentYAMLStream(section *SectionContent, w io.Writer) error {
+func (y *yamlRenderer) renderSectionContentYAMLStream(ctx context.Context, section *SectionContent, w io.Writer) error {
 	encoder := yaml.NewEncoder(w)
 	defer func() {
 		_ = encoder.Close()
@@ -1000,12 +1004,12 @@ func (y *yamlRenderer) renderSectionContentYAMLStream(section *SectionContent, w
 	var contents []any
 	for _, content := range section.Contents() {
 		// Apply per-content transformations before rendering
-		transformed, err := applyContentTransformations(context.Background(), content)
+		transformed, err := applyContentTransformations(ctx, content)
 		if err != nil {
 			return err
 		}
 
-		contentYAML, err := y.renderContent(transformed)
+		contentYAML, err := y.renderContent(ctx, transformed)
 		if err != nil {
 			return fmt.Errorf("failed to render nested content: %w", err)
 		}
@@ -1056,7 +1060,7 @@ func (y *yamlRenderer) renderDrawIOContentYAML(content *DrawIOContent) ([]byte, 
 }
 
 // renderCollapsibleSectionJSON renders a CollapsibleSection as structured JSON (Requirement 15.5)
-func (j *jsonRenderer) renderCollapsibleSectionJSON(section *DefaultCollapsibleSection) ([]byte, error) {
+func (j *jsonRenderer) renderCollapsibleSectionJSON(ctx context.Context, section *DefaultCollapsibleSection) ([]byte, error) {
 	result := map[string]any{
 		keyType:     "collapsible_section", // Requirement 15.5: type indication
 		keyTitle:    section.Title(),       // Requirement 15.5: section metadata
@@ -1067,7 +1071,14 @@ func (j *jsonRenderer) renderCollapsibleSectionJSON(section *DefaultCollapsibleS
 	// Render nested content (Requirement 15.5: nested content)
 	var contentArray []any
 	for _, content := range section.Content() {
-		contentJSON, err := j.renderContent(content)
+		// Apply per-content transformations before rendering so nested
+		// content observes the caller's context (cancellation/deadlines).
+		transformed, err := applyContentTransformations(ctx, content)
+		if err != nil {
+			return nil, err
+		}
+
+		contentJSON, err := j.renderContent(ctx, transformed)
 		if err != nil {
 			return nil, fmt.Errorf("failed to render section content: %w", err)
 		}
@@ -1090,7 +1101,7 @@ func (j *jsonRenderer) renderCollapsibleSectionJSON(section *DefaultCollapsibleS
 }
 
 // renderCollapsibleSectionYAML renders a CollapsibleSection as structured YAML (Requirement 15.5)
-func (y *yamlRenderer) renderCollapsibleSectionYAML(section *DefaultCollapsibleSection) ([]byte, error) {
+func (y *yamlRenderer) renderCollapsibleSectionYAML(ctx context.Context, section *DefaultCollapsibleSection) ([]byte, error) {
 	result := map[string]any{
 		keyType:     "collapsible_section", // Requirement 15.5: type indication
 		keyTitle:    section.Title(),       // Requirement 15.5: section metadata
@@ -1101,7 +1112,14 @@ func (y *yamlRenderer) renderCollapsibleSectionYAML(section *DefaultCollapsibleS
 	// Render nested content as YAML structures (Requirement 15.5: nested content)
 	var contentArray []any
 	for _, content := range section.Content() {
-		contentYAML, err := y.renderContent(content)
+		// Apply per-content transformations before rendering so nested
+		// content observes the caller's context (cancellation/deadlines).
+		transformed, err := applyContentTransformations(ctx, content)
+		if err != nil {
+			return nil, err
+		}
+
+		contentYAML, err := y.renderContent(ctx, transformed)
 		if err != nil {
 			return nil, fmt.Errorf("failed to render section content: %w", err)
 		}

--- a/v2/markdown_renderer.go
+++ b/v2/markdown_renderer.go
@@ -87,7 +87,7 @@ func (m *markdownRenderer) renderDocumentMarkdown(ctx context.Context, doc *Docu
 			return nil, err
 		}
 
-		contentMD, err := m.renderContent(transformed)
+		contentMD, err := m.renderContent(ctx, transformed)
 		if err != nil {
 			return nil, fmt.Errorf("failed to render content %s: %w", content.ID(), err)
 		}
@@ -148,7 +148,7 @@ func (m *markdownRenderer) addSubsectionsToToC(toc *strings.Builder, contents []
 }
 
 // renderContent renders content specifically for Markdown format
-func (m *markdownRenderer) renderContent(content Content) ([]byte, error) {
+func (m *markdownRenderer) renderContent(ctx context.Context, content Content) ([]byte, error) {
 	switch c := content.(type) {
 	case *TableContent:
 		return m.renderTableContentMarkdown(c)
@@ -157,9 +157,9 @@ func (m *markdownRenderer) renderContent(content Content) ([]byte, error) {
 	case *RawContent:
 		return m.renderRawContentMarkdown(c)
 	case *SectionContent:
-		return m.renderSectionContentMarkdown(c)
+		return m.renderSectionContentMarkdown(ctx, c)
 	case *DefaultCollapsibleSection:
-		return m.renderCollapsibleSection(c)
+		return m.renderCollapsibleSection(ctx, c)
 	case *ChartContent:
 		return m.renderChartContentMarkdown(c)
 	default:
@@ -285,8 +285,8 @@ func (m *markdownRenderer) renderRawContentMarkdown(raw *RawContent) ([]byte, er
 }
 
 // renderSectionContentMarkdown renders section content with proper heading levels
-func (m *markdownRenderer) renderSectionContentMarkdown(section *SectionContent) ([]byte, error) {
-	return m.renderSectionContentMarkdownWithDepth(context.Background(), section, m.headingLevel)
+func (m *markdownRenderer) renderSectionContentMarkdown(ctx context.Context, section *SectionContent) ([]byte, error) {
+	return m.renderSectionContentMarkdownWithDepth(ctx, section, m.headingLevel)
 }
 
 // renderSectionContentMarkdownWithDepth renders section content with explicit depth tracking
@@ -318,7 +318,7 @@ func (m *markdownRenderer) renderSectionContentMarkdownWithDepth(ctx context.Con
 			// Increase depth for nested sections
 			contentMD, err = m.renderSectionContentMarkdownWithDepth(ctx, nestedSection, depth+1)
 		} else {
-			contentMD, err = m.renderContent(transformed)
+			contentMD, err = m.renderContent(ctx, transformed)
 		}
 
 		if err != nil {
@@ -751,7 +751,7 @@ func (m *markdownRenderer) getSafeDetailsWithCodeFences(cv CollapsibleValue, lan
 }
 
 // renderCollapsibleSection renders a CollapsibleSection as nested HTML details structure (Requirement 15.4)
-func (m *markdownRenderer) renderCollapsibleSection(section *DefaultCollapsibleSection) ([]byte, error) {
+func (m *markdownRenderer) renderCollapsibleSection(ctx context.Context, section *DefaultCollapsibleSection) ([]byte, error) {
 	var result strings.Builder
 
 	// Create nested details structure
@@ -771,12 +771,12 @@ func (m *markdownRenderer) renderCollapsibleSection(section *DefaultCollapsibleS
 		}
 
 		// Apply per-content transformations before rendering
-		transformed, err := applyContentTransformations(context.Background(), content)
+		transformed, err := applyContentTransformations(ctx, content)
 		if err != nil {
 			return nil, err
 		}
 
-		contentMD, err := m.renderContent(transformed)
+		contentMD, err := m.renderContent(ctx, transformed)
 		if err != nil {
 			return nil, fmt.Errorf("failed to render section content: %w", err)
 		}

--- a/v2/renderer_nested_context_test.go
+++ b/v2/renderer_nested_context_test.go
@@ -1,0 +1,124 @@
+package output
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// T-1253 regression tests: nested renderers (sections and collapsible sections)
+// must thread the active render context into applyContentTransformations so that
+// cancelled/timed-out renders stop consistently at all depths, not just for
+// top-level content.
+//
+// The top-level render loops already short-circuit on an already-cancelled
+// context before they reach the nested section helpers, so an
+// already-cancelled context cannot prove the nested bug for every format.
+// Instead these tests cancel the context mid-render from inside the first
+// nested content's transformation, then assert that a *second* nested content
+// observes the cancellation. With the bug present, the section/collapsible
+// helpers passed context.Background() to applyContentTransformations, so the
+// second nested content never saw the cancellation and the render completed.
+// With the fix, the caller's context is threaded through and the render stops
+// with context.Canceled.
+
+// cancellingOperation cancels the supplied context the first time it is applied.
+// It is used as the first nested content's transformation to simulate a render
+// being cancelled partway through.
+type cancellingOperation struct {
+	cancel context.CancelFunc
+}
+
+func (c *cancellingOperation) Name() string { return "cancel" }
+
+func (c *cancellingOperation) Validate() error { return nil }
+
+func (c *cancellingOperation) Apply(_ context.Context, content Content) (Content, error) {
+	c.cancel()
+	return content, nil
+}
+
+func (c *cancellingOperation) CanOptimize(Operation) bool { return false }
+
+// newTableWithTransformation builds a table content carrying the supplied
+// transformations. Transformations are required so applyContentTransformations
+// performs its per-operation ctx.Err() check during rendering.
+func newTableWithTransformation(t *testing.T, ops ...Operation) *TableContent {
+	t.Helper()
+	table, err := NewTableContent(
+		"nested",
+		[]map[string]any{{"name": "Alice"}},
+		WithKeys("name"),
+		WithTransformations(ops...),
+	)
+	if err != nil {
+		t.Fatalf("failed to build table content: %v", err)
+	}
+	return table
+}
+
+// nestedContents returns two table contents: the first cancels the context when
+// its transformation is applied, the second carries a no-op transformation so
+// applyContentTransformations checks ctx.Err() and surfaces the cancellation.
+func nestedContents(t *testing.T, cancel context.CancelFunc) []Content {
+	t.Helper()
+	first := newTableWithTransformation(t, &cancellingOperation{cancel: cancel})
+	second := newTableWithTransformation(t, &mockTransformOperation{name: "noop"})
+	return []Content{first, second}
+}
+
+func sectionWithNestedContents(t *testing.T, cancel context.CancelFunc) *SectionContent {
+	t.Helper()
+	section := NewSectionContent("section")
+	for _, c := range nestedContents(t, cancel) {
+		section.AddContent(c)
+	}
+	return section
+}
+
+func collapsibleWithNestedContents(t *testing.T, cancel context.CancelFunc) *DefaultCollapsibleSection {
+	t.Helper()
+	return NewCollapsibleSection("collapsible", nestedContents(t, cancel))
+}
+
+func TestNestedRendererPropagatesCancelledContext(t *testing.T) {
+	type builder func(t *testing.T, cancel context.CancelFunc) Content
+
+	sectionBuilder := func(t *testing.T, cancel context.CancelFunc) Content {
+		return sectionWithNestedContents(t, cancel)
+	}
+	collapsibleBuilder := func(t *testing.T, cancel context.CancelFunc) Content {
+		return collapsibleWithNestedContents(t, cancel)
+	}
+
+	tests := map[string]struct {
+		renderer Renderer
+		build    builder
+	}{
+		"json section":                 {renderer: &jsonRenderer{}, build: sectionBuilder},
+		"json collapsible section":     {renderer: &jsonRenderer{}, build: collapsibleBuilder},
+		"yaml section":                 {renderer: &yamlRenderer{}, build: sectionBuilder},
+		"yaml collapsible section":     {renderer: &yamlRenderer{}, build: collapsibleBuilder},
+		"html section":                 {renderer: &htmlRenderer{}, build: sectionBuilder},
+		"html collapsible section":     {renderer: &htmlRenderer{}, build: collapsibleBuilder},
+		"markdown section":             {renderer: &markdownRenderer{}, build: sectionBuilder},
+		"markdown collapsible section": {renderer: &markdownRenderer{}, build: collapsibleBuilder},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			doc := New().AddContent(tc.build(t, cancel)).Build()
+
+			_, err := tc.renderer.Render(ctx, doc)
+			if err == nil {
+				t.Fatalf("expected render to fail with a context error, got nil")
+			}
+			if !errors.Is(err, context.Canceled) {
+				t.Fatalf("expected context.Canceled, got %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Bug

Several v2 nested-content rendering paths called `applyContentTransformations(context.Background(), content)` instead of passing the render caller's context. As a result, cancellation and deadlines were ignored for transformations applied to content nested inside sections and collapsible sections, even though top-level content correctly observed the caller's context. Affected the JSON, YAML, HTML, and Markdown renderers.

## Root cause

The renderers' internal content-dispatch methods (`renderContent`, `renderContentTo`) and the section/collapsible-section helpers did not carry the render context. When a helper needed to apply per-content transformations to nested content, it had no context to pass and substituted `context.Background()`, which is never cancelled — so the `ctx.Err()` check inside `applyContentTransformations` always returned nil for nested content.

## Fix

- Added a leading `ctx context.Context` parameter to each renderer's `renderContent`/`renderContentTo` dispatch methods and to all section/collapsible-section helper functions.
- Threaded the caller's context from the top-level render entry points down into every `applyContentTransformations` call, removing all `context.Background()` usages in nested render paths.
- The JSON and YAML collapsible-section helpers previously did not apply transformations at all; they now apply them with the caller's context, matching the section helpers.
- Shared base-renderer callbacks (`renderDocumentWithFormat`, `renderDocumentTo`, `renderDocumentGeneric`) keep their signatures; renderers pass ctx-capturing closures, keeping the change scoped to the three renderer files.

## Tests

Added `TestNestedRendererPropagatesCancelledContext` (`v2/renderer_nested_context_test.go`): renders a transformation-bearing table nested inside a section and a collapsible section with a context cancelled mid-render, and asserts the render returns `context.Canceled`, for JSON, YAML, HTML, and Markdown. The test was confirmed failing before the fix and passing after.

`make test`, `make test-integration`, and `make lint` (0 issues) all pass.