### PR TITLE
Fix T-1351: Section Callbacks Can Nil Sub-Builders

### DIFF
--- a/v2/builder_section_test.go
+++ b/v2/builder_section_test.go
@@ -349,6 +349,113 @@ func TestBuilder_SectionNilCallback(t *testing.T) {
 	}
 }
 
+// TestBuilder_SectionCallbackCallsBuild verifies that a callback which calls
+// Build() on the sub-builder does not panic the outer Section/CollapsibleSection
+// method. Before the fix, the section methods called subBuilder.Build() a second
+// time after the callback returned; if the callback already finalized the
+// sub-builder, the second Build() returned nil and the subsequent
+// GetContents() call panicked on a nil receiver (nil RWMutex.RLock).
+//
+// The expected behaviour is to not panic: the section is still added and a
+// builder error is recorded so callers can detect the misuse, consistent with
+// the builder's error-accumulation pattern.
+func TestBuilder_SectionCallbackCallsBuild(t *testing.T) {
+	tests := map[string]struct {
+		build func(*Builder) *Builder
+	}{
+		"section": {
+			build: func(b *Builder) *Builder {
+				return b.Section("details", func(sb *Builder) {
+					_ = sb.Build()
+				})
+			},
+		},
+		"collapsible section": {
+			build: func(b *Builder) *Builder {
+				return b.CollapsibleSection("details", func(sb *Builder) {
+					_ = sb.Build()
+				})
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			builder := New()
+
+			// This must not panic.
+			result := tt.build(builder)
+
+			// Fluent API: the method must return the same builder.
+			if result != builder {
+				t.Errorf("expected method to return the same builder for chaining")
+			}
+
+			// The misuse should be recorded as a builder error.
+			if !builder.HasErrors() {
+				t.Errorf("expected a builder error to be recorded when the callback finalizes the sub-builder")
+			}
+
+			// The section should still be added (as an empty section).
+			doc := builder.Build()
+			if len(doc.contents) != 1 {
+				t.Fatalf("expected 1 content (empty section), got %d", len(doc.contents))
+			}
+		})
+	}
+}
+
+// TestBuilder_SectionCallbackBuildsAfterAddingContent verifies that when a
+// callback adds content and then calls Build() on the sub-builder, the outer
+// section method still does not panic. The previously added content may be lost
+// (the callback consumed the document), but the operation must remain safe and
+// record an error rather than crash.
+func TestBuilder_SectionCallbackBuildsAfterAddingContent(t *testing.T) {
+	tests := map[string]struct {
+		build func(*Builder) *Builder
+	}{
+		"section": {
+			build: func(b *Builder) *Builder {
+				return b.Section("details", func(sb *Builder) {
+					sb.Text("some content")
+					_ = sb.Build()
+				})
+			},
+		},
+		"collapsible section": {
+			build: func(b *Builder) *Builder {
+				return b.CollapsibleSection("details", func(sb *Builder) {
+					sb.Text("some content")
+					_ = sb.Build()
+				})
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			builder := New()
+
+			// This must not panic.
+			result := tt.build(builder)
+
+			if result != builder {
+				t.Errorf("expected method to return the same builder for chaining")
+			}
+
+			if !builder.HasErrors() {
+				t.Errorf("expected a builder error to be recorded when the callback finalizes the sub-builder")
+			}
+
+			// The section should still be added.
+			doc := builder.Build()
+			if len(doc.contents) != 1 {
+				t.Fatalf("expected 1 content (section), got %d", len(doc.contents))
+			}
+		})
+	}
+}
+
 func TestBuilder_NestedSectionErrorsArePropagated(t *testing.T) {
 	tests := map[string]func(*Builder){
 		"section": func(builder *Builder) {

--- a/v2/document.go
+++ b/v2/document.go
@@ -183,10 +183,22 @@ func (b *Builder) Section(title string, fn func(*Builder), opts ...SectionOption
 		b.mu.Unlock()
 	}
 
-	// Add all contents from sub-builder to this section
+	// Add all contents from sub-builder to this section.
+	//
+	// The callback may have already finalized the sub-builder by calling its
+	// Build() method, in which case the sub-builder's document is nil and our
+	// Build() call returns nil. Guard against that to avoid a nil dereference,
+	// recording a builder error so callers can detect the misuse. The section is
+	// still added (as an empty section), keeping the fluent API non-panicking.
 	subDoc := subBuilder.Build()
-	for _, content := range subDoc.GetContents() {
-		section.AddContent(content)
+	if subDoc == nil {
+		b.mu.Lock()
+		b.addError(fmt.Errorf("Section %q: callback finalized the sub-builder by calling Build()", title))
+		b.mu.Unlock()
+	} else {
+		for _, content := range subDoc.GetContents() {
+			section.AddContent(content)
+		}
 	}
 
 	return b.AddContent(section)
@@ -258,9 +270,21 @@ func (b *Builder) CollapsibleSection(title string, fn func(*Builder), opts ...Co
 		b.mu.Unlock()
 	}
 
-	// Add all contents from sub-builder to collapsible section
-	subDoc := subBuilder.Build()
-	contents := subDoc.GetContents()
+	// Add all contents from sub-builder to collapsible section.
+	//
+	// The callback may have already finalized the sub-builder by calling its
+	// Build() method, in which case the sub-builder's document is nil and our
+	// Build() call returns nil. Guard against that to avoid a nil dereference,
+	// recording a builder error so callers can detect the misuse. The section is
+	// still added (as an empty section), keeping the fluent API non-panicking.
+	var contents []Content
+	if subDoc := subBuilder.Build(); subDoc != nil {
+		contents = subDoc.GetContents()
+	} else {
+		b.mu.Lock()
+		b.addError(fmt.Errorf("CollapsibleSection %q: callback finalized the sub-builder by calling Build()", title))
+		b.mu.Unlock()
+	}
 
 	section := NewCollapsibleSection(title, contents, opts...)
 	return b.AddContent(section)


### PR DESCRIPTION
## Bug

`Builder.Section` and `Builder.CollapsibleSection` (`v2/document.go`) pass a mutable sub-builder to the user callback, then unconditionally call `subBuilder.Build()` and `subDoc.GetContents()` after the callback returns. `Builder.Build()` clears `b.doc` (sets it nil) and returns the document.

If the callback itself calls `Build()` on the sub-builder, the outer method's later `subBuilder.Build()` returns nil and `subDoc.GetContents()` panics on a nil receiver (`d.mu.RLock()` at `document.go:18`).

Repro:
```go
output.New().Section("details", func(b *output.Builder) { _ = b.Build() })
```

## Root cause

Unguarded second finalization of the sub-builder. The section methods assumed the callback left the sub-builder buildable, so `subBuilder.Build()` was treated as always returning a non-nil document. The merged T-1127 fix only guards a nil callback (`fn == nil`); it does not cover the callback-calls-`Build()` case.

## Fix

Guard both `Section` and `CollapsibleSection` against a nil sub-document after the callback: record a builder error (following the existing `addError` pattern from T-1127/T-1209) and add the section as empty instead of dereferencing nil. The fluent API stays non-panicking and the misuse is observable via `HasErrors()`/`Errors()`.

## Tests

Added regression tests in `v2/builder_section_test.go`:
- `TestBuilder_SectionCallbackCallsBuild` — callback calls `Build()` (both Section and CollapsibleSection)
- `TestBuilder_SectionCallbackBuildsAfterAddingContent` — callback adds content then calls `Build()`

Both panicked before the fix and pass after. `make test` and `make lint` (0 issues) pass.