### PR TITLE
Fix T-1346: Text Progress Panics When Current Exceeds Total

### DIFF
--- a/v2/progress_core_test.go
+++ b/v2/progress_core_test.go
@@ -496,6 +496,102 @@ func TestProgress_SetContext_Replacement_DoesNotFail(t *testing.T) {
 	progress.Close()
 }
 
+// TestTextProgress_OverrunDoesNotPanic is a regression test for T-1346.
+//
+// textProgress.renderDefault computed filled := int(progress * float64(barWidth))
+// and then strings.Repeat(" ", barWidth-filled). When current exceeds total
+// (e.g. SetTotal(10) then SetCurrent(11), or Increment past the total),
+// filled > barWidth, so barWidth-filled is negative and strings.Repeat panics.
+//
+// Expected: rendering clamps the bar to a full bar (and never produces a
+// negative repeat count) so the overrun cannot panic.
+func TestTextProgress_OverrunDoesNotPanic(t *testing.T) {
+	t.Run("SetCurrent beyond total does not panic", func(t *testing.T) {
+		var buf bytes.Buffer
+		progress := NewProgress(
+			WithProgressWriter(&buf),
+			WithUpdateInterval(0), // draw on every call
+			WithWidth(10),
+		)
+
+		progress.SetTotal(10)
+		// With the bug present, this overrun makes filled=11 > barWidth=10,
+		// so strings.Repeat(" ", -1) panics inside draw().
+		progress.SetCurrent(11)
+
+		if err := progress.Close(); err != nil {
+			t.Errorf("Close() should not return error, got %v", err)
+		}
+
+		// On overrun the bar should be full (no empty cells, no panic).
+		output := buf.String()
+		if !strings.Contains(output, "[==========]") {
+			t.Errorf("overrun should render a full bar, got %q", output)
+		}
+	})
+
+	t.Run("Increment beyond total does not panic", func(t *testing.T) {
+		var buf bytes.Buffer
+		progress := NewProgress(
+			WithProgressWriter(&buf),
+			WithUpdateInterval(0),
+			WithWidth(10),
+		)
+
+		progress.SetTotal(5)
+		// Increment past the total: 0 -> 7, current(7) > total(5).
+		progress.Increment(7)
+
+		if err := progress.Close(); err != nil {
+			t.Errorf("Close() should not return error, got %v", err)
+		}
+
+		output := buf.String()
+		if !strings.Contains(output, "[==========]") {
+			t.Errorf("overrun should render a full bar, got %q", output)
+		}
+	})
+}
+
+// TestTextProgress_NegativeWidthDoesNotPanic is a regression test for T-1346.
+//
+// WithWidth(-1) / WithTrackerLength(-1) set ProgressConfig.Width to a negative
+// value. renderDefault then computed barWidth = -1, filled = 0, and called
+// strings.Repeat(" ", barWidth-filled) = strings.Repeat(" ", -1), which panics.
+//
+// Expected: a non-positive configured width is guarded so no negative repeat
+// count is produced.
+func TestTextProgress_NegativeWidthDoesNotPanic(t *testing.T) {
+	tests := map[string]struct {
+		opt ProgressOption
+	}{
+		"WithWidth(-1)":         {opt: WithWidth(-1)},
+		"WithTrackerLength(-1)": {opt: WithTrackerLength(-1)},
+		"WithWidth(0)":          {opt: WithWidth(0)},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			var buf bytes.Buffer
+			progress := NewProgress(
+				WithProgressWriter(&buf),
+				WithUpdateInterval(0),
+				tt.opt,
+			)
+
+			// Any draw with total > 0 reaches the bar math; with the bug present
+			// the negative width causes strings.Repeat to panic.
+			progress.SetTotal(10)
+			progress.SetCurrent(5)
+			progress.Complete()
+
+			if err := progress.Close(); err != nil {
+				t.Errorf("Close() should not return error, got %v", err)
+			}
+		})
+	}
+}
+
 func TestProgress_V1Compatibility_ProgressOptions(t *testing.T) {
 	var buf bytes.Buffer
 	progress := NewProgress(

--- a/v2/progress_text.go
+++ b/v2/progress_text.go
@@ -136,8 +136,24 @@ func (p *textProgress) renderDefault() string {
 	// Add progress bar
 	if p.total > 0 {
 		progress := float64(p.current) / float64(p.total)
+
+		// Guard against a non-positive configured width (e.g. WithWidth(-1) or
+		// WithTrackerLength(-1)); a negative width would otherwise feed a
+		// negative count into strings.Repeat below.
 		barWidth := p.config.Width
+		if barWidth < 0 {
+			barWidth = 0
+		}
+
+		// Clamp filled to [0, barWidth] so an overrun (current > total) renders
+		// a full bar instead of producing a negative empty-cell count, which
+		// would panic in strings.Repeat.
 		filled := int(progress * float64(barWidth))
+		if filled < 0 {
+			filled = 0
+		} else if filled > barWidth {
+			filled = barWidth
+		}
 
 		bar := fmt.Sprintf("[%s%s]",
 			strings.Repeat("=", filled),

--- a/v2/specs/bugfixes/progress-bar-overflow-panic/report.md
+++ b/v2/specs/bugfixes/progress-bar-overflow-panic/report.md
@@ -1,0 +1,126 @@
+# Bugfix Report: progress-bar-overflow-panic
+
+**Date:** 2026-05-25
+**Status:** Fixed
+
+## Description of the Issue
+
+`textProgress.renderDefault` rendered the progress bar by computing
+`filled := int(progress * float64(barWidth))` and then
+`strings.Repeat(" ", barWidth-filled)`. When the current count exceeded the
+total, `filled` exceeded `barWidth`, making `barWidth-filled` negative.
+`strings.Repeat` panics on a negative count, crashing any program that drove
+the progress past its total.
+
+A separate trigger of the same panic: configuring a negative bar width via
+`WithWidth(-1)` or `WithTrackerLength(-1)` made `barWidth` itself negative, so
+even `filled = 0` produced `strings.Repeat(" ", -1)`.
+
+**Reproduction steps:**
+1. `p := NewProgress(WithWidth(10))`
+2. `p.SetTotal(10)` then `p.SetCurrent(11)` (or `p.Increment(11)`)
+3. Observe `panic: strings: negative Repeat count` inside `renderDefault`.
+
+Alternatively:
+1. `p := NewProgress(WithWidth(-1))` (or `WithTrackerLength(-1)`)
+2. `p.SetTotal(10)`; `p.SetCurrent(5)`
+3. Observe the same panic.
+
+**Impact:** Runtime panic (crash) in any caller using the text progress
+indicator that overruns the configured total or supplies a non-positive width.
+Scope is limited to `textProgress`; the no-op and pretty progress backends are
+not affected.
+
+## Investigation Summary
+
+- **Symptoms examined:** `panic: strings: negative Repeat count` originating
+  from `progress_text.go` during a `draw()` call.
+- **Code inspected:** `v2/progress_text.go` (`renderDefault` bar math) and
+  `v2/progress.go` (`WithWidth`, `WithTrackerLength`, `ProgressConfig.Width`).
+- **Hypotheses tested:** Confirmed two independent inputs reach the unguarded
+  subtraction — `current > total` (filled > barWidth) and a negative configured
+  `Width` (barWidth < 0). Both were reproduced with failing tests.
+
+## Discovered Root Cause
+
+The bar math performed `strings.Repeat(" ", barWidth-filled)` without bounding
+either operand. Two unbounded inputs could drive the count negative:
+`filled` could exceed `barWidth` (overrun), and `barWidth` could be negative
+(bad config).
+
+**Defect type:** Missing input validation / unbounded arithmetic.
+
+**Why it occurred:** The renderer assumed `0 <= current <= total` and a
+positive `Width`, but the public API (`SetCurrent`, `Increment`, `WithWidth`,
+`WithTrackerLength`) does not enforce those invariants.
+
+**Contributing factors:** Existing tests covered only in-range values, so the
+overrun and negative-width paths were never exercised.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `v2/progress_text.go:137-150` - In `renderDefault`, clamp `barWidth` to a
+  minimum of 0 and clamp `filled` to the `[0, barWidth]` range before calling
+  `strings.Repeat`. On overrun the bar renders full; a non-positive width
+  renders an empty `[]` bar without panicking.
+
+**Approach rationale:** Clamping at the render site is the minimal, localized
+fix. It keeps the public API permissive (callers may still pass any value) while
+guaranteeing the renderer never produces a negative repeat count. Showing a full
+bar on overrun matches user expectations (100% is the visual ceiling).
+
+**Alternatives considered:**
+- Clamp `current`/`total` in the setters (`SetCurrent`, `Increment`) - Rejected:
+  more invasive, changes observable state (the `(11/10)` count display), and
+  would not cover the negative-width trigger.
+- Validate `Width` in `WithWidth`/`WithTrackerLength` - Rejected: only addresses
+  one of the two triggers and silently alters caller-supplied config; the render
+  guard is needed regardless.
+
+## Regression Test
+
+**Test file:** `v2/progress_core_test.go`
+**Test names:** `TestTextProgress_OverrunDoesNotPanic`,
+`TestTextProgress_NegativeWidthDoesNotPanic`
+
+**What it verifies:**
+- `SetCurrent` and `Increment` beyond the total do not panic and render a full
+  bar (`[==========]`).
+- `WithWidth(-1)`, `WithTrackerLength(-1)`, and `WithWidth(0)` do not panic
+  during draw/complete.
+
+**Run command:**
+`go test -run 'TestTextProgress_OverrunDoesNotPanic|TestTextProgress_NegativeWidthDoesNotPanic' .`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `v2/progress_text.go` | Clamp `barWidth` (>= 0) and `filled` ([0, barWidth]) in `renderDefault` |
+| `v2/progress_core_test.go` | Added overrun and negative-width regression tests |
+
+## Verification
+
+**Automated:**
+- [x] Regression test passes
+- [x] Full test suite passes (`make test`)
+- [x] Linters/validators pass (`make lint`, 0 issues)
+
+**Manual verification:**
+- Confirmed the new tests panic on the pre-fix code (red) and pass after the
+  fix (green).
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Guard any `strings.Repeat`/slice arithmetic that derives a count from external
+  inputs; clamp before use.
+- When adding configuration options that feed into sizing math, cover boundary
+  and invalid values (negative, zero, over-max) in tests.
+
+## Related
+
+- Transit ticket T-1346
+- Note: `progress_text.go` was also touched by T-1254 (SetContext); this fix is
+  isolated to the bar math in `renderDefault`.


### PR DESCRIPTION
## Bug

`textProgress.renderDefault` (`v2/progress_text.go`) crashed with `panic: strings: negative Repeat count` in two situations:

1. **Overrun:** `SetTotal(10)` then `SetCurrent(11)` (or `Increment` past the total). `filled := int(progress * float64(barWidth))` exceeded `barWidth`, so `strings.Repeat(" ", barWidth-filled)` got a negative count.
2. **Negative width:** `WithWidth(-1)` / `WithTrackerLength(-1)` set `ProgressConfig.Width` negative, so `barWidth` itself was negative and even `filled = 0` produced `strings.Repeat(" ", -1)`.

## Root cause

The bar math passed `barWidth-filled` straight into `strings.Repeat` without bounding either operand. The renderer assumed `0 <= current <= total` and a positive `Width`, but the public API does not enforce those invariants.

## Fix

In `renderDefault`, clamp `barWidth` to a minimum of 0 and clamp `filled` to `[0, barWidth]` before rendering. An overrun now renders a full bar (`[==========]`); a non-positive width renders an empty bar — never a negative repeat count.

The fix is isolated to the bar math and does not touch the `SetContext` work added by T-1254 in the same file.

## Tests

Added regression tests in `v2/progress_core_test.go`:
- `TestTextProgress_OverrunDoesNotPanic` — `SetCurrent`/`Increment` beyond total render a full bar without panic.
- `TestTextProgress_NegativeWidthDoesNotPanic` — `WithWidth(-1)`, `WithTrackerLength(-1)`, `WithWidth(0)` do not panic.

Both fail (panic) on pre-fix code and pass after the fix. `make test` and `make lint` (0 issues) pass.

Report: `v2/specs/bugfixes/progress-bar-overflow-panic/report.md`

Closes T-1346.