### PR TITLE
Fix T-1338: Markdown Front Matter Order Is Nondeterministic

### DIFF
--- a/v2/markdown_renderer.go
+++ b/v2/markdown_renderer.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 )
 
@@ -50,11 +52,13 @@ func (m *markdownRenderer) renderDocumentMarkdown(ctx context.Context, doc *Docu
 
 	var result strings.Builder
 
-	// Add front matter if configured
+	// Add front matter if configured. frontMatter is a map, so iterate over
+	// sorted keys to ensure deterministic output across renders and processes
+	// (see T-1338).
 	if len(m.frontMatter) > 0 {
 		result.WriteString("---\n")
-		for key, value := range m.frontMatter {
-			fmt.Fprintf(&result, "%s: %s\n", key, m.escapeYAMLValue(value))
+		for _, key := range slices.Sorted(maps.Keys(m.frontMatter)) {
+			fmt.Fprintf(&result, "%s: %s\n", key, m.escapeYAMLValue(m.frontMatter[key]))
 		}
 		result.WriteString("---\n\n")
 	}

--- a/v2/renderer_markdown_test.go
+++ b/v2/renderer_markdown_test.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -838,4 +839,81 @@ func TestMarkdownRenderer_RenderToNilDocument(t *testing.T) {
 	if buf.Len() != 0 {
 		t.Errorf("expected no output for nil document, got %q", buf.String())
 	}
+}
+
+// TestMarkdownRenderer_FrontMatterDeterministicOrder is a regression test for T-1338.
+// Front matter is stored in a map, so iterating it directly produces a
+// nondeterministic key order. The renderer must emit keys in a stable
+// (sorted) order so Markdown output is reproducible across renders and
+// processes (avoiding golden/snapshot churn).
+func TestMarkdownRenderer_FrontMatterDeterministicOrder(t *testing.T) {
+	// Use enough keys that map iteration order is overwhelmingly unlikely
+	// to coincidentally match the sorted order.
+	frontMatter := map[string]string{
+		"zeta":    "1",
+		"author":  "Test Author",
+		"title":   "Test Document",
+		"date":    "2024-01-01",
+		"beta":    "2",
+		"gamma":   "3",
+		"alpha":   "4",
+		"version": "5",
+	}
+
+	doc := New().Text("Document Content").Build()
+	ctx := context.Background()
+
+	// Expected sorted key order.
+	wantKeyOrder := []string{"alpha", "author", "beta", "date", "gamma", "title", "version", "zeta"}
+
+	// Render many times; every render must produce the same, sorted order.
+	var first string
+	for i := range 50 {
+		renderer := NewMarkdownRendererWithFrontMatter(frontMatter)
+		result, err := renderer.Render(ctx, doc)
+		if err != nil {
+			t.Fatalf("render %d failed: %v", i, err)
+		}
+		out := string(result)
+
+		// Extract front matter key order from the rendered output.
+		gotKeyOrder := frontMatterKeyOrder(t, out)
+		if !slices.Equal(gotKeyOrder, wantKeyOrder) {
+			t.Fatalf("render %d: front matter key order = %v, want %v", i, gotKeyOrder, wantKeyOrder)
+		}
+
+		// Output must be byte-for-byte identical across renders.
+		if i == 0 {
+			first = out
+		} else if out != first {
+			t.Fatalf("render %d output differs from first render:\nfirst:\n%s\ngot:\n%s", i, first, out)
+		}
+	}
+}
+
+// frontMatterKeyOrder extracts the ordered list of YAML keys from the front
+// matter block at the start of a rendered Markdown document.
+func frontMatterKeyOrder(t *testing.T, out string) []string {
+	t.Helper()
+	if !strings.HasPrefix(out, "---\n") {
+		t.Fatalf("output missing front matter delimiter, got: %q", out)
+	}
+	body := strings.TrimPrefix(out, "---\n")
+	end := strings.Index(body, "---\n")
+	if end == -1 {
+		t.Fatalf("front matter block not terminated, got: %q", out)
+	}
+	lines := strings.Split(strings.TrimRight(body[:end], "\n"), "\n")
+	keys := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if line == "" {
+			continue
+		}
+		key, _, found := strings.Cut(line, ":")
+		if !found {
+			t.Fatalf("malformed front matter line: %q", line)
+		}
+		keys = append(keys, key)
+	}
+	return keys
 }


### PR DESCRIPTION
## Bug

The Markdown renderer emitted YAML front matter by ranging directly over the `frontMatter` map. Because Go randomizes map iteration order, the emitted key order changed between renders and processes, making Markdown output unstable and churning golden/snapshot comparisons and generated docs. (Transit T-1338)

## Root cause

In `v2/markdown_renderer.go`, `renderDocumentMarkdown` iterated the `frontMatter` map directly:

```go
for key, value := range m.frontMatter {
    fmt.Fprintf(&result, "%s: %s\n", key, m.escapeYAMLValue(value))
}
```

Map iteration order is intentionally randomized in Go, so front matter key order was nondeterministic.

## Fix

Iterate over `slices.Sorted(maps.Keys(m.frontMatter))` so keys are emitted in a stable, sorted order. `frontMatter` is a `map[string]string` throughout the codebase with no upstream insertion-order representation, so sorting at render time is the simplest stable choice and requires no API change.

## Tests

Added `TestMarkdownRenderer_FrontMatterDeterministicOrder` in `v2/renderer_markdown_test.go`, which asserts that multiple front matter keys are emitted in sorted order and that output is byte-for-byte identical across 50 renders. The test was confirmed to fail before the fix (red) and pass after (green).

- `make test`: pass
- `make lint`: 0 issues