### PR TITLE
Fix T-1337: GroupBy Aggregate Columns Are Nondeterministic

### DIFF
--- a/v2/operations.go
+++ b/v2/operations.go
@@ -491,6 +491,12 @@ func (o *GroupByOp) Apply(ctx context.Context, content Content) (Content, error)
 		groups[groupKey] = append(groups[groupKey], record)
 	}
 
+	// Derive a stable aggregate-name order once and reuse it everywhere
+	// (result records, schema keyOrder, and schema fields). Map iteration
+	// order is randomized, so this is the single source of truth for
+	// aggregate column ordering.
+	aggNames := o.sortedAggregateNames()
+
 	// Create result records with aggregated data
 	resultRecords := make([]Record, 0, len(groups))
 
@@ -511,8 +517,10 @@ func (o *GroupByOp) Apply(ctx context.Context, content Content) (Content, error)
 			resultRecord[column] = sampleRecord[column]
 		}
 
-		// Apply aggregate functions
-		for aggName, aggFunc := range o.aggregates {
+		// Apply aggregate functions in a deterministic order so result
+		// records, schema fields, and keyOrder stay consistent across runs.
+		for _, aggName := range aggNames {
+			aggFunc := o.aggregates[aggName]
 			// For count aggregate, field parameter is ignored
 			field := ""
 			if aggName != "count" {
@@ -526,7 +534,7 @@ func (o *GroupByOp) Apply(ctx context.Context, content Content) (Content, error)
 	}
 
 	// Create new schema with preserved key order
-	newSchema := o.createAggregatedSchema(cloned.schema)
+	newSchema := o.createAggregatedSchema(cloned.schema, aggNames)
 
 	// Update the cloned content
 	cloned.records = resultRecords
@@ -588,18 +596,32 @@ func (o *GroupByOp) inferFieldFromAggregateName(aggName string) string {
 	return aggName
 }
 
-// createAggregatedSchema creates a schema for aggregated results
-func (o *GroupByOp) createAggregatedSchema(originalSchema *Schema) *Schema {
-	// Build key order: groupBy columns first, then aggregate columns
-	keyOrder := make([]string, 0, len(o.groupBy)+len(o.aggregates))
+// sortedAggregateNames returns the aggregate result column names in a
+// deterministic order. Aggregates are stored in a map, whose iteration order
+// Go randomizes, so names are sorted alphabetically to guarantee a stable
+// column order across runs.
+func (o *GroupByOp) sortedAggregateNames() []string {
+	names := make([]string, 0, len(o.aggregates))
+	for aggName := range o.aggregates {
+		names = append(names, aggName)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// createAggregatedSchema creates a schema for aggregated results. aggNames is
+// the deterministic aggregate column order (see sortedAggregateNames) and must
+// match the order used when building result records.
+func (o *GroupByOp) createAggregatedSchema(originalSchema *Schema, aggNames []string) *Schema {
+	// Build key order: groupBy columns first, then aggregate columns in the
+	// deterministic order supplied by the caller.
+	keyOrder := make([]string, 0, len(o.groupBy)+len(aggNames))
 
 	// Add groupBy columns
 	keyOrder = append(keyOrder, o.groupBy...)
 
-	// Add aggregate columns (order may vary due to map iteration)
-	for aggName := range o.aggregates {
-		keyOrder = append(keyOrder, aggName)
-	}
+	// Add aggregate columns in deterministic order
+	keyOrder = append(keyOrder, aggNames...)
 
 	// Create fields for the new schema
 	fields := make([]Field, 0, len(keyOrder))
@@ -616,8 +638,8 @@ func (o *GroupByOp) createAggregatedSchema(originalSchema *Schema) *Schema {
 		fields = append(fields, Field{Name: column})
 	}
 
-	// Add fields for aggregate columns
-	for aggName := range o.aggregates {
+	// Add fields for aggregate columns in the same deterministic order
+	for _, aggName := range aggNames {
 		fields = append(fields, Field{Name: aggName})
 	}
 

--- a/v2/operations_aggregate_test.go
+++ b/v2/operations_aggregate_test.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"context"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -724,4 +725,75 @@ func TestGroupByNilAggregateFunc(t *testing.T) {
 			t.Errorf("expected render error to explain the function cannot be nil, got %q", err.Error())
 		}
 	})
+}
+
+// TestAggregateColumnOrderDeterministic is a regression test for T-1337.
+//
+// GroupByOp previously stored aggregates in a map and ranged that map when
+// building result records, schema keyOrder, and schema fields. Go randomizes
+// map iteration order, so aggregate columns (e.g. count, total_salary) could
+// render in different orders across runs, conflicting with v2's key-order
+// preservation goals.
+//
+// Expected behaviour: aggregate columns follow a deterministic order
+// (groupBy columns first, then aggregate names sorted alphabetically) and that
+// order is identical on every Apply, regardless of map iteration randomization.
+func TestAggregateColumnOrderDeterministic(t *testing.T) {
+	records := []Record{
+		{"name": "Alice", "department": "HR", "salary": 50000},
+		{"name": "Bob", "department": "IT", "salary": 75000},
+		{"name": "Charlie", "department": "HR", "salary": 60000},
+		{"name": "David", "department": "IT", "salary": 80000},
+	}
+
+	// groupBy column first, then aggregate names sorted alphabetically:
+	// avg_salary, count, max_salary, min_salary, total_salary.
+	wantOrder := []string{
+		"department",
+		"avg_salary",
+		"count",
+		"max_salary",
+		"min_salary",
+		"total_salary",
+	}
+
+	// Run many times: a freshly constructed map is re-ranged each iteration,
+	// so any reliance on map iteration order surfaces as an order mismatch.
+	const iterations = 200
+	for i := range iterations {
+		groupByOp := &GroupByOp{
+			groupBy: []string{"department"},
+			aggregates: map[string]AggregateFunc{
+				"count":        CountAggregate(),
+				"total_salary": SumAggregate("salary"),
+				"avg_salary":   AverageAggregate("salary"),
+				"min_salary":   MinAggregate("salary"),
+				"max_salary":   MaxAggregate("salary"),
+			},
+		}
+
+		doc := New().Table("test", records).Build()
+		tableContent := doc.GetContents()[0].(*TableContent)
+
+		result, err := groupByOp.Apply(context.Background(), tableContent)
+		if err != nil {
+			t.Fatalf("iteration %d: Apply() failed: %v", i, err)
+		}
+		resultTable := result.(*TableContent)
+
+		// Schema keyOrder must match the deterministic order every run.
+		gotKeyOrder := resultTable.schema.GetKeyOrder()
+		if !slices.Equal(gotKeyOrder, wantOrder) {
+			t.Fatalf("iteration %d: keyOrder = %v, want %v", i, gotKeyOrder, wantOrder)
+		}
+
+		// Schema field order must match keyOrder.
+		gotFieldOrder := make([]string, len(resultTable.schema.Fields))
+		for j, f := range resultTable.schema.Fields {
+			gotFieldOrder[j] = f.Name
+		}
+		if !slices.Equal(gotFieldOrder, wantOrder) {
+			t.Fatalf("iteration %d: field order = %v, want %v", i, gotFieldOrder, wantOrder)
+		}
+	}
 }


### PR DESCRIPTION
## Bug

`GroupByOp` (`v2/operations.go`) produced aggregated table output where the aggregate columns (e.g. `count`, `total_salary`, `avg_salary`) appeared in a different order on different runs of the same program. This conflicts with v2's exact key-order preservation and produces unstable CSV/Markdown/Table output for identical input.

Transit: T-1337.

## Root Cause

`GroupByOp.aggregates` is a `map[string]AggregateFunc`, and the code ranged that map directly in three independent places to build the output:
- result records (~line 515)
- schema `keyOrder` (~line 600, with a comment noting "order may vary due to map iteration")
- schema fields (~line 620)

Go intentionally randomizes map iteration order, so all three were nondeterministic and could even disagree with each other.

## Fix

- Added `GroupByOp.sortedAggregateNames()`, returning aggregate names sorted alphabetically — a single deterministic source of truth for column order.
- `Apply` computes the sorted names once and ranges that slice when building result records.
- `createAggregatedSchema` now takes the ordered names and uses them for both `keyOrder` and schema fields. Removed the two remaining map ranges and the stale "order may vary" comment.

Result column order is now: groupBy columns first, then aggregate names sorted alphabetically — identical on every run.

This keeps the public `GroupByOp` / `NewGroupByOp` API (which accepts a map) unchanged.

## Regression Test

`TestAggregateColumnOrderDeterministic` in `v2/operations_aggregate_test.go`: with five aggregates and one groupBy column, asserts the resulting schema `keyOrder` and field order both equal the deterministic order on every one of 200 fresh `Apply` runs. Fails before the fix (keyOrder in map order), passes after.

## Verification

- Regression test passes
- Full unit suite passes (`make test`)
- Lint clean (`make lint`)