### PR TITLE
Fix T-1359: DefaultCollapsibleValue Aliases Caller-Owned Hint Map

### DIFF
--- a/v2/collapsible.go
+++ b/v2/collapsible.go
@@ -2,6 +2,7 @@ package output
 
 import (
 	"fmt"
+	"maps"
 	"sync"
 )
 
@@ -106,7 +107,9 @@ func WithFormatHint(format string, hints map[string]any) CollapsibleOption {
 		if cv.formatHints == nil {
 			cv.formatHints = make(map[string]map[string]any)
 		}
-		cv.formatHints[format] = hints
+		// Defensively copy the hints map so later mutation of the caller's
+		// map cannot alter renderer behavior (T-1359, matching T-1317).
+		cv.formatHints[format] = maps.Clone(hints)
 	}
 }
 
@@ -213,7 +216,8 @@ func (d *DefaultCollapsibleValue) IsExpanded() bool {
 // when a shared value is rendered from multiple goroutines (T-1233).
 func (d *DefaultCollapsibleValue) FormatHint(format string) map[string]any {
 	if hints, exists := d.formatHints[format]; exists {
-		return hints
+		// Return a copy so callers cannot mutate the stored hints (T-1359, matching T-1317).
+		return maps.Clone(hints)
 	}
 	return nil
 }

--- a/v2/collapsible_test.go
+++ b/v2/collapsible_test.go
@@ -364,3 +364,49 @@ func TestCollapsibleValue_EdgeCases(t *testing.T) {
 		}
 	})
 }
+
+// TestCollapsibleValueFormatHintInputImmutability verifies that mutating the
+// caller-provided hints map after construction does not affect renderer behavior.
+// Regression test for T-1359: WithFormatHint stored the caller map directly.
+func TestCollapsibleValueFormatHintInputImmutability(t *testing.T) {
+	hints := map[string]any{"class": "expandable"}
+
+	cv := NewCollapsibleValue("summary", "details",
+		WithFormatHint("html", hints))
+
+	// Mutate the caller-owned map after construction.
+	hints["class"] = "mutated"
+	hints["extra"] = "added"
+
+	got := cv.FormatHint("html")
+	if got["class"] != "expandable" {
+		t.Errorf("mutating caller hints map changed stored hints: got %v, want %v", got["class"], "expandable")
+	}
+	if _, exists := got["extra"]; exists {
+		t.Error("adding a key to the caller hints map leaked into stored hints")
+	}
+}
+
+// TestCollapsibleValueFormatHintOutputImmutability verifies that mutating the
+// map returned by FormatHint does not affect the value's internal state.
+// Regression test for T-1359: FormatHint returned the stored map directly.
+func TestCollapsibleValueFormatHintOutputImmutability(t *testing.T) {
+	hints := map[string]any{"class": "expandable"}
+
+	cv := NewCollapsibleValue("summary", "details",
+		WithFormatHint("html", hints))
+
+	// Mutate the returned map.
+	returned := cv.FormatHint("html")
+	returned["class"] = "mutated"
+	returned["extra"] = "added"
+
+	// A fresh read must be unaffected.
+	got := cv.FormatHint("html")
+	if got["class"] != "expandable" {
+		t.Errorf("mutating returned hints map changed stored hints: got %v, want %v", got["class"], "expandable")
+	}
+	if _, exists := got["extra"]; exists {
+		t.Error("adding a key to the returned hints map leaked into stored hints")
+	}
+}

--- a/v2/specs/bugfixes/collapsiblevalue-hint-map-aliasing/report.md
+++ b/v2/specs/bugfixes/collapsiblevalue-hint-map-aliasing/report.md
@@ -1,0 +1,113 @@
+# Bugfix Report: DefaultCollapsibleValue Aliases Caller-Owned Hint Map
+
+**Date:** 2026-05-25
+**Status:** Fixed
+
+## Description of the Issue
+
+`DefaultCollapsibleValue` in `v2/collapsible.go` aliased caller-owned mutable
+data through its format-hints map. The `WithFormatHint` option stored the
+caller's `hints` map directly, and the `FormatHint` accessor returned the
+internal map directly. As a result, external mutation of the map passed to
+`WithFormatHint`, or of the map returned by `FormatHint`, changed renderer
+behavior after the value had been constructed. This violates the v2 design
+principle that values become effectively immutable after construction.
+
+**Reproduction steps:**
+1. Build a value: `cv := NewCollapsibleValue("s", "d", WithFormatHint("html", hints))`.
+2. Mutate the caller map after construction (`hints["class"] = "mutated"`), or
+   mutate the map returned by `cv.FormatHint("html")`.
+3. Observe that a subsequent `cv.FormatHint("html")` reflects the external
+   mutation instead of the originally configured hints.
+
+**Impact:** Medium. Renderer hints could silently change after construction,
+producing non-deterministic output. Scope limited to consumers that use
+collapsible-value format hints.
+
+## Investigation Summary
+
+- **Symptoms examined:** Stored hints reflecting external mutation of both the
+  input map and the returned map.
+- **Code inspected:** `v2/collapsible.go` (`WithFormatHint`, `FormatHint`),
+  compared against the already-fixed `v2/collapsible_section.go` (T-1317).
+- **Hypotheses tested:** Confirmed T-1233 only added `sync.Once` for the details
+  lazy cache and did not touch hint-map aliasing; confirmed T-1317 fixed the
+  equivalent issue in `DefaultCollapsibleSection` but not in
+  `DefaultCollapsibleValue`.
+
+## Discovered Root Cause
+
+`WithFormatHint` assigned the caller's map by reference
+(`cv.formatHints[format] = hints`) and `FormatHint` returned the stored map by
+reference. Maps in Go are reference types, so no defensive copy meant the
+internal state and external callers shared the same backing map.
+
+**Defect type:** Mutable shared state / missing defensive copy (immutability violation).
+
+**Why it occurred:** The collapsible value implementation predates the T-1317
+fix for the section type, and the defensive-copy pattern was not back-applied to
+the value type.
+
+**Contributing factors:** Two near-identical types (`DefaultCollapsibleValue`
+and `DefaultCollapsibleSection`) with separate hint-handling code; fixing one
+did not automatically fix the other.
+
+## Resolution for the Issue
+
+**Changes made:**
+- `v2/collapsible.go` - Added `maps` import.
+- `v2/collapsible.go` `WithFormatHint` - Store a defensive copy via `maps.Clone(hints)`.
+- `v2/collapsible.go` `FormatHint` - Return a defensive copy via `maps.Clone(hints)`.
+
+**Approach rationale:** `maps.Clone` matches the established T-1317 pattern in
+`collapsible_section.go`, keeping the two types consistent. `maps.Clone(nil)`
+returns `nil`, so the no-hints path is unchanged and existing behavior for
+unset formats is preserved.
+
+**Alternatives considered:**
+- Manual `make` + `maps.Copy` loop - More verbose with no benefit over
+  `maps.Clone`, and inconsistent with the section fix.
+
+## Regression Test
+
+**Test file:** `v2/collapsible_test.go`
+**Test names:** `TestCollapsibleValueFormatHintInputImmutability`,
+`TestCollapsibleValueFormatHintOutputImmutability`
+
+**What it verifies:** Mutating the caller-provided hints map after construction,
+and mutating the map returned by `FormatHint`, both leave the value's stored
+hints unchanged.
+
+**Run command:**
+`go test -run 'TestCollapsibleValueFormatHint(Input|Output)Immutability' ./...`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `v2/collapsible.go` | Defensive copy of hints map on input and output via `maps.Clone` |
+| `v2/collapsible_test.go` | Added input/output immutability regression tests |
+
+## Verification
+
+**Automated:**
+- [x] Regression tests pass
+- [x] Full test suite passes (`make test`)
+- [x] Linters pass (`make lint`, 0 issues)
+
+**Manual verification:**
+- Confirmed the new tests fail before the fix and pass after.
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- When introducing reference-type fields (maps, slices) configured by callers,
+  copy defensively on both input and output to preserve immutability.
+- When fixing an aliasing bug in one type, check for sibling types with the same
+  pattern (here, `DefaultCollapsibleValue` vs `DefaultCollapsibleSection`).
+
+## Related
+
+- T-1359 (this fix)
+- T-1317 - Equivalent fix for `DefaultCollapsibleSection` (the pattern matched here)
+- T-1233 - Added `sync.Once` for the details lazy cache (did not address aliasing)


### PR DESCRIPTION
## Bug

`DefaultCollapsibleValue` in `v2/collapsible.go` aliased caller-owned mutable data through its format-hints map, violating v2 immutability.

- `WithFormatHint` stored the caller's `hints` map directly (`cv.formatHints[format] = hints`) with no defensive copy.
- `FormatHint` returned the internal map directly.

External mutation of the passed map (after construction) or of the returned map changed renderer behavior after the value was built.

## Root Cause

Go maps are reference types. Without a defensive copy, the value's internal state and external callers shared the same backing map on both input and output. This is the same class of bug fixed for `DefaultCollapsibleSection` in T-1317, but it was never back-applied to `DefaultCollapsibleValue` (and T-1233 only added `sync.Once` for the details lazy cache, not hint aliasing).

## Fix

Defensively copy the hints map via `maps.Clone` on both input (`WithFormatHint`) and output (`FormatHint`), matching the T-1317 pattern in `collapsible_section.go`. `maps.Clone(nil)` returns `nil`, so the no-hints path is unchanged.

## Tests

Added two regression tests in `v2/collapsible_test.go` (verified failing before the fix, passing after):

- `TestCollapsibleValueFormatHintInputImmutability` - mutating the caller map after construction does not affect stored hints.
- `TestCollapsibleValueFormatHintOutputImmutability` - mutating the map returned by `FormatHint` does not affect stored hints.

`make test` and `make lint` pass (0 lint issues).

Report: `v2/specs/bugfixes/collapsiblevalue-hint-map-aliasing/report.md`

Closes T-1359.