### PR TITLE
Fix T-1339: Graph Renderers Emit Unstable Row Order

### DIFF
--- a/v2/graph_content.go
+++ b/v2/graph_content.go
@@ -148,17 +148,22 @@ func (g *GraphContent) GetTitle() string {
 	return g.title
 }
 
-// GetNodes returns unique nodes from all edges
+// GetNodes returns the unique nodes from all edges in first-seen (insertion)
+// order. Order is derived from the edges rather than a map so output is
+// deterministic: ranging a set map would expose Go's randomized map iteration
+// order to callers such as the Draw.io and JSON/YAML renderers.
 func (g *GraphContent) GetNodes() []string {
-	nodeMap := make(map[string]bool)
-	for _, edge := range g.edges {
-		nodeMap[edge.From] = true
-		nodeMap[edge.To] = true
+	seen := make(map[string]bool)
+	nodes := make([]string, 0, len(g.edges)*2)
+	addNode := func(node string) {
+		if !seen[node] {
+			seen[node] = true
+			nodes = append(nodes, node)
+		}
 	}
-
-	nodes := make([]string, 0, len(nodeMap))
-	for node := range nodeMap {
-		nodes = append(nodes, node)
+	for _, edge := range g.edges {
+		addNode(edge.From)
+		addNode(edge.To)
 	}
 	return nodes
 }

--- a/v2/graph_content_mutation_test.go
+++ b/v2/graph_content_mutation_test.go
@@ -1,6 +1,9 @@
 package output
 
-import "testing"
+import (
+	"slices"
+	"testing"
+)
 
 // Regression tests for T-1295: Graph and Draw.io content expose mutable
 // caller-owned data. Constructors and getters must defensively copy slices
@@ -282,5 +285,33 @@ func TestChartContent_CloneIndependentPie(t *testing.T) {
 	origData := c.GetData().(*PieData)
 	if origData.Slices[0].Label != "A" {
 		t.Errorf("mutating clone changed original slice: got %q, want A", origData.Slices[0].Label)
+	}
+}
+
+// TestGraphContent_GetNodesStableOrder is a regression test for T-1339: GetNodes
+// built a set as a map and ranged it to produce the result, so node order was
+// derived from Go's randomized map iteration. GetNodes must instead return nodes
+// in first-seen (insertion) order across the edges, deduplicated.
+//
+// The assertion runs many times because a single map-range may coincidentally
+// produce the expected order; repeated runs make the randomized iteration
+// reliably surface the regression.
+func TestGraphContent_GetNodesStableOrder(t *testing.T) {
+	g := NewGraphContent("Workflow", []Edge{
+		{From: "Start", To: "Process"},
+		{From: "Process", To: "Review"},
+		{From: "Review", To: "Deploy"},
+		{From: "Deploy", To: "End"},
+		{From: "Process", To: "Rollback"}, // From already seen; To is new
+	})
+
+	// First-seen order across (From, To) pairs, deduplicated.
+	want := []string{"Start", "Process", "Review", "Deploy", "End", "Rollback"}
+
+	for i := 0; i < 100; i++ {
+		got := g.GetNodes()
+		if !slices.Equal(got, want) {
+			t.Fatalf("GetNodes() returned unstable/unexpected order on iteration %d:\ngot:  %v\nwant: %v", i, got, want)
+		}
 	}
 }

--- a/v2/graph_renderers.go
+++ b/v2/graph_renderers.go
@@ -348,8 +348,12 @@ func (m *mermaidRenderer) renderGanttChart(buf *bytes.Buffer, chart *ChartConten
 		fmt.Fprintf(buf, "    axisFormat %s\n", ganttData.AxisFormat)
 	}
 
-	// Group tasks by section
+	// Group tasks by section, tracking first-seen section order separately so
+	// rendering is deterministic. Ranging the section map directly would expose
+	// Go's randomized map iteration order, reordering section blocks even when
+	// the input task order is stable.
 	sections := make(map[string][]GanttTask)
+	sectionOrder := make([]string, 0, len(ganttData.Tasks))
 	defaultSection := "Tasks"
 
 	for _, task := range ganttData.Tasks {
@@ -357,11 +361,15 @@ func (m *mermaidRenderer) renderGanttChart(buf *bytes.Buffer, chart *ChartConten
 		if section == "" {
 			section = defaultSection
 		}
+		if _, exists := sections[section]; !exists {
+			sectionOrder = append(sectionOrder, section)
+		}
 		sections[section] = append(sections[section], task)
 	}
 
-	// Render sections and tasks
-	for sectionName, tasks := range sections {
+	// Render sections and tasks in first-seen order
+	for _, sectionName := range sectionOrder {
+		tasks := sections[sectionName]
 		if sectionName != defaultSection || len(sections) > 1 {
 			fmt.Fprintf(buf, "    section %s\n", sectionName)
 		}

--- a/v2/graph_renderers_test.go
+++ b/v2/graph_renderers_test.go
@@ -746,3 +746,45 @@ func TestDrawioRenderer_AppliesTableTransformations(t *testing.T) {
 		}
 	}
 }
+
+// TestDrawioRenderer_StableNodeOrder is a regression test for T-1339: the
+// Draw.io graph renderer emitted node rows via GraphContent.GetNodes, which
+// ranged a map and therefore produced node rows in randomized order. Node rows
+// must appear in first-seen (insertion) order so generated diagrams are
+// deterministic.
+//
+// The assertion runs many times because a single map-range may coincidentally
+// produce the expected order; repeated runs reliably surface the regression.
+func TestDrawioRenderer_StableNodeOrder(t *testing.T) {
+	ctx := context.Background()
+	renderer := &drawioRenderer{}
+
+	doc := New().
+		Graph("Workflow", []Edge{
+			{From: "Start", To: "Process"},
+			{From: "Process", To: "Review"},
+			{From: "Review", To: "Deploy"},
+			{From: "Deploy", To: "End"},
+		}).
+		Build()
+
+	// Node rows are written before edge rows, each as "<node>,,," in first-seen
+	// order across the edges.
+	wantNodeBlock := strings.Join([]string{
+		"Start,,,",
+		"Process,,,",
+		"Review,,,",
+		"Deploy,,,",
+		"End,,,",
+	}, "\n")
+
+	for i := 0; i < 100; i++ {
+		got, err := renderer.Render(ctx, doc)
+		if err != nil {
+			t.Fatalf("DrawioRenderer.Render() error = %v", err)
+		}
+		if !strings.Contains(string(got), wantNodeBlock) {
+			t.Fatalf("DrawioRenderer.Render() node rows out of order on iteration %d:\nwant node block:\n%s\n\ngot:\n%s", i, wantNodeBlock, string(got))
+		}
+	}
+}

--- a/v2/mermaid_chart_test.go
+++ b/v2/mermaid_chart_test.go
@@ -195,6 +195,56 @@ func TestMermaidRenderer_GanttSections(t *testing.T) {
 	}
 }
 
+// TestMermaidRenderer_GanttSectionOrder is a regression test for T-1339: the
+// Gantt renderer grouped tasks into a map keyed by section and ranged that map,
+// so section blocks were emitted in randomized order even when the input task
+// order was stable. Section blocks must appear in first-seen order based on the
+// input task order.
+//
+// The assertion runs many times because a single map-range may coincidentally
+// produce the expected order; repeated runs reliably surface the regression.
+func TestMermaidRenderer_GanttSectionOrder(t *testing.T) {
+	tasks := []GanttTask{
+		{Title: "A1", StartDate: "2024-01-01", Duration: "1d", Section: "Alpha"},
+		{Title: "B1", StartDate: "2024-01-02", Duration: "1d", Section: "Beta"},
+		{Title: "G1", StartDate: "2024-01-03", Duration: "1d", Section: "Gamma"},
+		{Title: "D1", StartDate: "2024-01-04", Duration: "1d", Section: "Delta"},
+		{Title: "A2", StartDate: "2024-01-05", Duration: "1d", Section: "Alpha"}, // section seen again
+	}
+
+	chart := NewGanttChart("Ordered Project", tasks)
+	doc := New().AddContent(chart).Build()
+	renderer := &mermaidRenderer{}
+
+	// First-seen section order from the task list.
+	wantOrder := []string{
+		"section Alpha",
+		"section Beta",
+		"section Gamma",
+		"section Delta",
+	}
+
+	for iter := 0; iter < 100; iter++ {
+		result, err := renderer.Render(context.Background(), doc)
+		if err != nil {
+			t.Fatalf("Render() error = %v", err)
+		}
+		output := string(result)
+
+		prev := -1
+		for _, section := range wantOrder {
+			idx := strings.Index(output, section)
+			if idx == -1 {
+				t.Fatalf("iteration %d: output missing %q\ngot:\n%s", iter, section, output)
+			}
+			if idx <= prev {
+				t.Fatalf("iteration %d: sections out of first-seen order; %q at %d not after previous section at %d\ngot:\n%s", iter, section, idx, prev, output)
+			}
+			prev = idx
+		}
+	}
+}
+
 func TestMermaidRenderer_GanttTaskProperties(t *testing.T) {
 	tasks := []GanttTask{
 		{

--- a/v2/specs/bugfixes/graph-unstable-row-order/report.md
+++ b/v2/specs/bugfixes/graph-unstable-row-order/report.md
@@ -1,0 +1,131 @@
+# Bugfix Report: Graph Renderers Emit Unstable Row Order
+
+**Date:** 2026-05-25
+**Status:** Fixed
+
+## Description of the Issue
+
+Graph and chart rendering exposed Go's randomized map iteration order in
+user-facing output, making generated diagrams nondeterministic between runs.
+
+Two sites were affected:
+
+1. **Draw.io graph node rows** — `GraphContent.GetNodes` built a `map[string]bool`
+   set and ranged it to produce the result slice. The Draw.io renderer
+   (`renderGraphAsDrawIO`) wrote one CSV node row per returned node, so node
+   rows appeared in a different order on each render. The same `GetNodes` also
+   feeds the JSON and YAML renderers, so those were affected too.
+2. **Mermaid Gantt sections** — `renderGanttChart` grouped tasks into a
+   `map[string][]GanttTask` keyed by section and ranged that map to emit section
+   blocks, so section ordering was randomized even when the input task order was
+   stable.
+
+**Reproduction steps:**
+1. Build a `GraphContent` with several edges, or a Gantt chart with tasks across
+   multiple sections.
+2. Render to Draw.io (graph) or Mermaid (Gantt) repeatedly.
+3. Observe that node rows / section blocks appear in a different order on
+   different runs.
+
+**Impact:** Medium. No data loss, but nondeterministic output breaks
+reproducible builds, diffing of generated diagrams, and golden-file testing.
+
+## Investigation Summary
+
+- **Symptoms examined:** Draw.io CSV node rows and Mermaid Gantt section blocks
+  reordering across renders.
+- **Code inspected:** `v2/graph_content.go` (`GetNodes`), `v2/graph_renderers.go`
+  (`renderGanttChart`, `renderGraphAsDrawIO`), `v2/json_yaml_renderer.go`
+  (other `GetNodes` consumers).
+- **Hypotheses tested:** Confirmed both sites rely on ranging a map. Edge order
+  and task order are themselves stable (stored as slices and defensively
+  cloned), so the only nondeterminism source is the map iteration.
+
+## Discovered Root Cause
+
+Both sites used a map purely as a deduplication/grouping mechanism and then
+ranged that map to produce ordered output. Go intentionally randomizes map
+iteration order, so any ordering derived from ranging a map is nondeterministic.
+
+**Defect type:** Logic error (relying on map iteration order for user-facing
+ordering).
+
+**Why it occurred:** A map is the natural structure for set membership and
+grouping, but the code conflated "deduplicate/group" with "produce ordered
+output" by ranging the map directly instead of tracking order separately.
+
+**Contributing factors:** None environmental; the input data (edges, tasks) was
+already in a stable slice order that simply needed to be preserved.
+
+## Resolution for the Issue
+
+Preserve first-seen (insertion) order by tracking an ordered slice alongside the
+map, rather than ranging the map.
+
+**Changes made:**
+- `v2/graph_content.go` (`GetNodes`) — replace the set-map range with a `seen`
+  map plus an ordered `nodes` slice, appending each node the first time it is
+  seen across the edges.
+- `v2/graph_renderers.go` (`renderGanttChart`) — keep the section grouping map
+  but also build a `sectionOrder` slice recording each section the first time it
+  appears, then range `sectionOrder` to emit section blocks.
+
+**Approach rationale:** First-seen order keeps output intuitive (it mirrors the
+order the user supplied edges/tasks in) and is the smallest change that makes
+output deterministic. Sorting was rejected because it would reorder
+user-supplied data, which is contrary to the library's key-order-preservation
+philosophy.
+
+**Alternatives considered:**
+- **Sort nodes/sections alphabetically** — deterministic, but reorders
+  user-supplied data and loses the intuitive input ordering.
+
+## Regression Test
+
+**Test files:**
+- `v2/graph_content_mutation_test.go` — `TestGraphContent_GetNodesStableOrder`
+- `v2/graph_renderers_test.go` — `TestDrawioRenderer_StableNodeOrder`
+- `v2/mermaid_chart_test.go` — `TestMermaidRenderer_GanttSectionOrder`
+
+**What they verify:** `GetNodes` returns nodes in first-seen order; the Draw.io
+renderer emits node rows in first-seen order; the Mermaid Gantt renderer emits
+section blocks in first-seen order. Each test asserts the expected order across
+100 iterations so randomized map iteration cannot coincidentally pass.
+
+**Run command:**
+`go test -run 'TestGraphContent_GetNodesStableOrder|TestDrawioRenderer_StableNodeOrder|TestMermaidRenderer_GanttSectionOrder' ./v2/...`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `v2/graph_content.go` | `GetNodes` returns nodes in first-seen order via a `seen` set + ordered slice |
+| `v2/graph_renderers.go` | `renderGanttChart` tracks first-seen section order and ranges that instead of the map |
+| `v2/graph_content_mutation_test.go` | Added `TestGraphContent_GetNodesStableOrder` |
+| `v2/graph_renderers_test.go` | Added `TestDrawioRenderer_StableNodeOrder` |
+| `v2/mermaid_chart_test.go` | Added `TestMermaidRenderer_GanttSectionOrder` |
+
+## Verification
+
+**Automated:**
+- [x] Regression tests pass
+- [x] Full test suite passes (`make test`)
+- [x] Linters pass (`make lint`, 0 issues)
+
+**Manual verification:**
+- Confirmed the three new tests fail on the pre-fix code (red) showing randomized
+  ordering, then pass after the fix (green).
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Never derive user-facing ordering from ranging a Go map. Use a map only for
+  membership/grouping and track order with a separate slice.
+- When deduplicating or grouping, default to first-seen order to preserve the
+  caller's intent (consistent with the library's key-order-preservation design).
+- Order-sensitive output should be covered by tests that run multiple iterations
+  to defeat coincidental map-iteration passes.
+
+## Related
+
+- Transit ticket: T-1339


### PR DESCRIPTION
## Bug

Graph/chart rendering exposed Go's randomized map iteration order in user-facing output, making generated diagrams nondeterministic between runs (T-1339).

- **Draw.io graph node rows**: `GraphContent.GetNodes` built a `map[string]bool` set and ranged it, so node rows reordered each render. (Also feeds the JSON/YAML renderers.)
- **Mermaid Gantt sections**: `renderGanttChart` grouped tasks into a section map and ranged it, so section blocks reordered even when input task order was stable.

## Root cause

Both sites used a map purely for deduplication/grouping but then ranged that map to produce ordered output. Go intentionally randomizes map iteration order, so any ordering derived from ranging a map is nondeterministic. The underlying edge/task slices were already stable.

## Fix

Preserve first-seen (insertion) order by tracking an ordered slice alongside the dedup/group map:

- `v2/graph_content.go` — `GetNodes` now uses a `seen` set plus an ordered `nodes` slice, appending each node the first time it appears across edges.
- `v2/graph_renderers.go` — `renderGanttChart` builds a `sectionOrder` slice recording each section's first appearance and ranges that instead of the map.

First-seen order was chosen over sorting to keep output intuitive and consistent with the library's key-order-preservation philosophy.

## Tests

Added regression tests, each asserting expected order across 100 iterations to defeat coincidental map-iteration passes:

- `TestGraphContent_GetNodesStableOrder` (`v2/graph_content_mutation_test.go`)
- `TestDrawioRenderer_StableNodeOrder` (`v2/graph_renderers_test.go`)
- `TestMermaidRenderer_GanttSectionOrder` (`v2/mermaid_chart_test.go`)

Confirmed red before the fix, green after. Full `make test` and `make lint` (0 issues) pass.

Report: `v2/specs/bugfixes/graph-unstable-row-order/report.md`