### PR TITLE
Fix T-1358: prettyProgress.SetContext Can Spuriously Fail Progress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Unreleased
 
 ### Fixed
+- **Pretty Progress SetContext Stale Watcher** - Fixed `prettyProgress.SetContext` spuriously marking a healthy progress as failed when the context was replaced (the same stale-watcher defect previously fixed for `textProgress` in T-1254)
+  - The watcher goroutine now captures its own derived context (`watchedCtx`) as a local instead of reading the shared `p.ctx` field, removing a data race and ignoring stale completions when the context has been replaced (`p.ctx != watchedCtx`)
+  - `SetContext(nil)` now clears `p.ctx`/`p.cancel` and returns early
+  - Added regression test `TestPrettyProgress_SetContext_Replacement_DoesNotFail`
 - **GroupBy Composite Key Collision** - Fixed `GroupByOp.createGroupKey` merging distinct groups when grouped values contain the `||` separator (e.g. `{a:"x||y", b:"z"}` and `{a:"x", b:"y||z"}` both produced key `x||y||z`)
   - Replaced fixed-delimiter concatenation with a collision-safe length-prefixed encoding (`<len>:<value>` per column)
   - Missing values now use a distinct `nil:` marker so they no longer collide with the literal string `"<nil>"`

--- a/v2/progress_core_test.go
+++ b/v2/progress_core_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	ptprogress "github.com/jedib0t/go-pretty/v6/progress"
 )
 
 func TestNewProgress(t *testing.T) {
@@ -770,6 +772,91 @@ func TestPrettyProgress_V1Compatibility_SetContext(t *testing.T) {
 	}
 
 	progress.Close()
+}
+
+// newTestPrettyProgress builds a *prettyProgress directly so the test does not
+// depend on a TTY. NewPrettyProgress falls back to textProgress when stderr is
+// not a terminal (as in CI), which would otherwise make it impossible to
+// exercise the prettyProgress code path.
+func newTestPrettyProgress(w *bytes.Buffer) *prettyProgress {
+	config := defaultProgressConfig()
+	WithProgressWriter(w)(config)
+	WithUpdateInterval(0)(config)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	p := &prettyProgress{
+		config:    config,
+		startTime: time.Now(),
+		active:    true,
+		ctx:       ctx,
+		cancel:    cancel,
+		signals:   make(chan os.Signal, 1),
+	}
+	p.writer = ptprogress.NewWriter()
+	p.writer.SetOutputWriter(config.Writer)
+	p.writer.SetUpdateFrequency(config.UpdateInterval)
+	p.writer.SetStyle(ptprogress.StyleDefault)
+	p.writer.SetNumTrackersExpected(1)
+	return p
+}
+
+// TestPrettyProgress_SetContext_Replacement_DoesNotFail is a regression test for
+// T-1358 (the prettyProgress counterpart of the T-1254 textProgress fix).
+//
+// SetContext cancels the previously derived context when a new context is
+// installed. The watcher goroutine for the old context must NOT mark the
+// progress as failed when it is released by that replacement cancellation.
+//
+// Bug: the old watcher read p.ctx (the shared struct field) instead of the
+// context it was created for, so after replacement it saw the new context's
+// error (or none) and called MarkAsErrored, failing a still-healthy progress.
+//
+// Expected: replacing a progress context leaves the progress active and
+// unfailed; only the live context's cancellation should fail it.
+func TestPrettyProgress_SetContext_Replacement_DoesNotFail(t *testing.T) {
+	var buf bytes.Buffer
+	p := newTestPrettyProgress(&buf)
+
+	// Create a tracker so the watcher's (p.active && p.tracker != nil) guard
+	// is satisfied — otherwise the bug cannot manifest.
+	p.SetTotal(100)
+	p.SetCurrent(50)
+
+	// Install the first context.
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	defer cancel1()
+	p.SetContext(ctx1)
+
+	// Replace it with a fresh, live context. This cancels the first derived
+	// context internally and releases the first watcher goroutine.
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+	p.SetContext(ctx2)
+
+	// Give the released first watcher time to (incorrectly) run and fail us.
+	time.Sleep(50 * time.Millisecond)
+
+	// The progress must still be active and unfailed: replacing the context
+	// is not a failure condition.
+	if !p.IsActive() {
+		t.Error("progress should remain active after the context is replaced")
+	}
+
+	p.mu.RLock()
+	failed, err := p.failed, p.err
+	p.mu.RUnlock()
+	if failed {
+		t.Errorf("progress should not be marked failed after context replacement, err=%v", err)
+	}
+
+	// The live context must still be able to fail the progress.
+	cancel2()
+	time.Sleep(50 * time.Millisecond)
+	if p.IsActive() {
+		t.Error("progress should fail when the live (current) context is cancelled")
+	}
+
+	p.Close()
 }
 
 func TestPrettyProgress_FailureHandling(t *testing.T) {

--- a/v2/progress_pretty.go
+++ b/v2/progress_pretty.go
@@ -306,27 +306,45 @@ func (p *prettyProgress) SetContext(ctx context.Context) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	// Cancel any existing context
+	// Cancel any existing context. This releases the previous watcher
+	// goroutine, but that goroutine ignores its own (replacement) cancellation
+	// because the context it watches is no longer p.ctx (see below).
 	if p.cancel != nil {
 		p.cancel()
 	}
 
-	// Create new context with cancellation
-	if ctx != nil {
-		p.ctx, p.cancel = context.WithCancel(ctx)
-
-		// Start goroutine to watch for cancellation
-		go func() {
-			<-p.ctx.Done()
-			p.mu.Lock()
-			if p.active && p.tracker != nil {
-				p.failed = true
-				p.active = false
-				p.err = p.ctx.Err()
-				p.tracker.MarkAsErrored()
-				p.tracker.UpdateMessage(p.getStatusMessage())
-			}
-			p.mu.Unlock()
-		}()
+	if ctx == nil {
+		p.ctx = nil
+		p.cancel = nil
+		return
 	}
+
+	// Create a new derived context with cancellation.
+	watchedCtx, cancel := context.WithCancel(ctx)
+	p.ctx = watchedCtx
+	p.cancel = cancel
+
+	// Start a goroutine to watch for cancellation. The watcher captures its
+	// own derived context (watchedCtx) rather than reading the shared p.ctx
+	// field, so a later SetContext call cannot make this watcher read the
+	// wrong context. When this watcher fires it only fails the progress if its
+	// context is still the current one; if it has been replaced, the
+	// completion is stale and ignored.
+	go func() {
+		<-watchedCtx.Done()
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		if p.ctx != watchedCtx {
+			// This context was replaced by a newer SetContext call. Its
+			// cancellation is the result of replacement, not a real failure.
+			return
+		}
+		if p.active && p.tracker != nil {
+			p.failed = true
+			p.active = false
+			p.err = watchedCtx.Err()
+			p.tracker.MarkAsErrored()
+			p.tracker.UpdateMessage(p.getStatusMessage())
+		}
+	}()
 }


### PR DESCRIPTION
## Bug

`prettyProgress.SetContext` (v2/progress_pretty.go) starts a watcher goroutine that, when its context is cancelled, marks the progress as errored. The watcher read the shared `p.ctx` struct field directly (`<-p.ctx.Done()` and `p.ctx.Err()`) rather than the context it was created for. When `SetContext` was called a second time, the previous derived context was cancelled to release its watcher — but that watcher then observed the **new** `p.ctx` and could mark a still-healthy progress as failed. The unsynchronised read of `p.ctx` was also a data race (confirmed by `go test -race`).

This is the same stale-watcher defect that was fixed for `textProgress` in T-1254 (PR #51), which explicitly scoped its change to a single file and left `prettyProgress` as a follow-up.

## Root cause

The watcher goroutine closed over the receiver `p` and dereferenced the mutable shared `p.ctx` field instead of capturing the specific derived context it was created to watch. There was no identity check tying a watcher to its own context, so replacement cancellation could not be distinguished from a real cancellation.

## Fix

Mirror the `textProgress` fix in `progress_pretty.go`:
- Capture the derived context (`watchedCtx`) and its `cancel` as locals.
- The watcher blocks on `watchedCtx.Done()`, takes the lock, and returns early when `p.ctx != watchedCtx` (the context was replaced — a stale completion to ignore).
- Use `watchedCtx.Err()` instead of `p.ctx.Err()`.
- `SetContext(nil)` now clears `p.ctx`/`p.cancel` and returns early.

Scope is limited to `v2/progress_pretty.go`; `progress_text.go` is unchanged.

## Tests

Added regression test `TestPrettyProgress_SetContext_Replacement_DoesNotFail` (with a `newTestPrettyProgress` helper that constructs `*prettyProgress` directly to bypass the non-TTY fallback to `textProgress`). It asserts that replacing the context leaves the progress active and unfailed, while cancelling the live context still fails it.

Verified:
- `go test -race ./...` — passes (test fails with a data race before the fix).
- `make lint` — 0 issues.