### PR TITLE
Fix T-1353: Section Content Accepts Nil Nested Content

### DIFF
--- a/v2/content.go
+++ b/v2/content.go
@@ -564,17 +564,32 @@ func (s *SectionContent) Contents() []Content {
 	return contents
 }
 
-// AddContent adds content to this section
+// AddContent adds content to this section.
+//
+// Nil content is skipped rather than stored: SectionContent's consumers (Clone,
+// AppendText, and the renderers that recurse into Contents()) assume every entry
+// is non-nil, and a nil entry would otherwise cause a nil dereference panic.
+// AddContent returns no value and SectionContent has no error channel, so a nil
+// argument is silently dropped (consistent with Builder.AddContent rejecting nil
+// for top-level content).
 func (s *SectionContent) AddContent(content Content) {
+	if content == nil {
+		return
+	}
 	s.contents = append(s.contents, content)
 }
 
 // Clone creates a deep copy of the SectionContent
 func (s *SectionContent) Clone() Content {
-	// Deep copy the nested contents
-	newContents := make([]Content, len(s.contents))
-	for i, content := range s.contents {
-		newContents[i] = content.Clone()
+	// Deep copy the nested contents. Skip any nil entry defensively so a nil
+	// that reached contents by some route cannot cause a nil dereference (the
+	// primary guard is in AddContent).
+	newContents := make([]Content, 0, len(s.contents))
+	for _, content := range s.contents {
+		if content == nil {
+			continue
+		}
+		newContents = append(newContents, content.Clone())
 	}
 
 	// Shallow copy transformations (share same operation instances)
@@ -618,6 +633,11 @@ func (s *SectionContent) AppendText(b []byte) ([]byte, error) {
 
 	// Render all nested content
 	for i, content := range s.contents {
+		// Skip any nil entry defensively to avoid a nil dereference (the primary
+		// guard is in AddContent).
+		if content == nil {
+			continue
+		}
 		if i > 0 {
 			b = append(b, '\n')
 		}

--- a/v2/section_content_test.go
+++ b/v2/section_content_test.go
@@ -772,3 +772,110 @@ func TestSectionContent_Clone_NestedContent(t *testing.T) {
 		})
 	}
 }
+
+// TestSectionContent_AddContent_RejectsNil verifies that adding nil content to a
+// section is skipped rather than stored. Before the T-1353 fix, AddContent
+// appended any value including nil, leaving a nil entry in the section's
+// contents slice.
+//
+// Bug: SectionContent.AddContent appended nil without validation.
+// Expected: nil content is skipped; Contents() never returns a nil entry.
+func TestSectionContent_AddContent_RejectsNil(t *testing.T) {
+	section := NewSectionContent("Test Section")
+
+	section.AddContent(nil)
+	section.AddContent(NewTextContent("real content"))
+	section.AddContent(nil)
+
+	contents := section.Contents()
+	if len(contents) != 1 {
+		t.Fatalf("Expected 1 content after skipping nils, got %d", len(contents))
+	}
+	for i, c := range contents {
+		if c == nil {
+			t.Errorf("Contents()[%d] is nil; nil content should never be stored", i)
+		}
+	}
+}
+
+// TestSectionContent_Clone_WithNilContent verifies Clone does not panic when a
+// section somehow holds a nil nested content.
+//
+// Bug: Clone called content.Clone() unconditionally, panicking on a nil entry.
+// Expected: Clone skips nil entries and returns a usable copy.
+func TestSectionContent_Clone_WithNilContent(t *testing.T) {
+	section := NewSectionContent("Test Section")
+	section.AddContent(NewTextContent("real content"))
+	// Force a nil entry directly into the slice to exercise the defensive guard,
+	// bypassing AddContent's validation.
+	section.contents = append(section.contents, nil)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Clone panicked with nil nested content: %v", r)
+		}
+	}()
+
+	cloned := section.Clone()
+	if cloned == nil {
+		t.Fatal("Clone returned nil")
+	}
+	for i, c := range cloned.(*SectionContent).contents {
+		if c == nil {
+			t.Errorf("cloned contents[%d] is nil; nil should be skipped during Clone", i)
+		}
+	}
+}
+
+// TestSectionContent_AppendText_WithNilContent verifies AppendText does not panic
+// when a section holds a nil nested content.
+//
+// Bug: AppendText called content.AppendText(nil) and content.ID() on a nil
+// entry, causing a nil dereference panic.
+// Expected: AppendText skips nil entries and renders the valid content.
+func TestSectionContent_AppendText_WithNilContent(t *testing.T) {
+	section := NewSectionContent("Test Section")
+	section.AddContent(NewTextContent("real content"))
+	section.contents = append(section.contents, nil)
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("AppendText panicked with nil nested content: %v", r)
+		}
+	}()
+
+	result, err := section.AppendText(nil)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	if !strings.Contains(string(result), "real content") {
+		t.Errorf("Expected output to contain valid content, got %q", string(result))
+	}
+}
+
+// TestSectionContent_Render_WithNilContent verifies that rendering a document
+// containing a section that a caller tried to populate with nil content does not
+// panic. Renderers recurse into section.Contents() and assume non-nil entries, so
+// AddContent must keep nil out of the slice.
+//
+// Bug: AddContent stored nil, and renderers then dereferenced it.
+// Expected: AddContent skips nil and rendering completes without panicking.
+func TestSectionContent_Render_WithNilContent(t *testing.T) {
+	section := NewSectionContent("Test Section")
+	section.AddContent(nil)
+	section.AddContent(NewTextContent("real content"))
+	section.AddContent(nil)
+
+	doc := New().AddContent(section).Build()
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Render panicked with nil nested content: %v", r)
+		}
+	}()
+
+	renderer := &markdownRenderer{}
+	if _, err := renderer.Render(context.Background(), doc); err != nil {
+		t.Fatalf("Unexpected render error: %v", err)
+	}
+}


### PR DESCRIPTION
## Bug

`SectionContent.AddContent` appended any `Content` value without validation, so a caller could add `nil` directly to a section. Common section operations then dereferenced the nil pointer and panicked:

- `SectionContent.Clone` called `content.Clone()` on each entry.
- `SectionContent.AppendText` called `content.AppendText(nil)` and `content.ID()` on each entry.
- All renderers (JSON, YAML, Markdown, CSV, table, HTML) recurse into `section.Contents()` and assume non-nil entries.

This is separate from T-1209 (`Builder.AddContent` for top-level documents) and T-1317 (collapsible_section); the public `SectionContent` API had the same nil-acceptance shape for nested content.

## Root cause

The non-nil invariant of `SectionContent.contents` is assumed by every consumer but enforced nowhere. The only mutation point that can violate it, `AddContent`, performed no validation. `AddContent` returns `void` and `SectionContent` has no error-accumulation channel, so there was no obvious place to report a rejection and validation was omitted.

## Fix

Contained to `v2/content.go`:

- **`AddContent`**: skip `nil` so it can never enter `contents`. Mirrors T-1209 (reject nil) and T-1208 (skip nil). Since the method returns `void` with no error channel, nil is dropped silently.
- **`Clone`** and **`AppendText`**: skip `nil` entries defensively, making the invariant explicit and protecting against a nil reaching the slice by any other route. With `AddContent` and `Clone` clean, renderers can no longer receive a nil from `Contents()`, so no renderer changes are needed.

## Tests

Added four regression tests in `v2/section_content_test.go` (each fails before the fix — 3 panic, 1 assertion):

- `TestSectionContent_AddContent_RejectsNil` — nil is skipped, never stored.
- `TestSectionContent_Clone_WithNilContent` — Clone does not panic with a nil entry.
- `TestSectionContent_AppendText_WithNilContent` — AppendText does not panic with a nil entry.
- `TestSectionContent_Render_WithNilContent` — markdown render of a section built via `AddContent(nil)` does not panic.

`make test` and `make lint` pass.