### PR TITLE
T-1539: Add draw.io CSV reader (ParseDrawIOCSV/ParseDrawIOFile)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## Unreleased
 
+### Added
+- **Draw.io CSV Writer Round-Trip Support** (drawio-csv-reader phase 1) - Writer changes so draw.io CSV output can round-trip through the upcoming parser
+  - `DrawIOContent` gains an explicit column order: new `DrawIOOption` type with `WithDrawIOColumns()`, variadic options on `NewDrawIOContent`, `NewDrawIOContentFromTable`, and `Builder.DrawIO`, plus a `GetColumns()` accessor (backward compatible)
+  - `NewDrawIOContentFromTable` now captures the table schema's field order instead of leaving columns to be alphabetized at render time
+  - The renderer uses the explicit column order when set (including the header row with zero records); record keys outside the column list are not rendered
+  - `# connect:` directives are now emitted via `json.Encoder` with HTML escaping disabled: quotes/backslashes escaped per JSON, `&`/`<`/`>` verbatim, `invert` always present, byte-identical to the previous output for escape-free values
+  - Data fields starting with `#` and single-empty-field rows are now quoted so they cannot be mistaken for comments, directives, or blank lines
+
 ### Fixed
 - **Pretty Progress SetContext Stale Watcher** - Fixed `prettyProgress.SetContext` spuriously marking a healthy progress as failed when the context was replaced (the same stale-watcher defect previously fixed for `textProgress` in T-1254)
   - The watcher goroutine now captures its own derived context (`watchedCtx`) as a local instead of reading the shared `p.ctx` field, removing a data race and ignoring stale completions when the context has been replaced (`p.ctx != watchedCtx`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## Unreleased
 
 ### Added
+- **Draw.io CSV Parser** (drawio-csv-reader phase 2) - New `ParseDrawIOCSV(io.Reader)` and `ParseDrawIOFile(path)` functions parse draw.io CSV (as written by the drawio renderer) into a `ParsedDrawIO` struct with header directives, column order, and records
+  - All 18 directive keys map onto `DrawIOHeader` fields; grammar is case-sensitive `# key: ` exact-prefix with verbatim untrimmed values; unknown directives and comments are ignored; scalar directives are last-wins while `# connect:` appends all occurrences in order
+  - Handles UTF-8 BOM, CRLF line endings, blank lines, quoted fields containing commas/quotes/newlines, data rows starting with `#`, and multi-line quoted column names; empty cells materialize as empty strings; absent directives leave header fields zero-valued
+  - New sentinel errors (`ErrDrawIONoColumnHeader`, `ErrDrawIOTrailingDirective`, `ErrDrawIODuplicateColumn`, `ErrDrawIODirective`) discriminable via `errors.Is`, wrapped with line/directive context; trailing-directive detection takes precedence over CSV field-count errors; CSV parse errors report whole-file line numbers
 - **Draw.io CSV Writer Round-Trip Support** (drawio-csv-reader phase 1) - Writer changes so draw.io CSV output can round-trip through the upcoming parser
   - `DrawIOContent` gains an explicit column order: new `DrawIOOption` type with `WithDrawIOColumns()`, variadic options on `NewDrawIOContent`, `NewDrawIOContentFromTable`, and `Builder.DrawIO`, plus a `GetColumns()` accessor (backward compatible)
   - `NewDrawIOContentFromTable` now captures the table schema's field order instead of leaving columns to be alphabetized at render time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## Unreleased
 
 ### Added
+- **Draw.io CSV Round-Trip Guarantees** (drawio-csv-reader phase 3) - Property-based tests (via new test-only dependency `pgregory.net/rapid`) verifying the writer/parser round-trip contracts
+  - Idempotency: render → parse → render → parse → render stabilizes from the first re-render onward for arbitrary headers, columns, and records
+  - Byte identity: for CR-free content, the first re-render is byte-identical to the original render
+  - No-panic: the parser returns a result or an error (never panics) for arbitrary byte input, including malformed `# connect:` JSON and non-integer numeric directives
+  - Example-based golden round-trip with a realistic awstools-style file as an anchor against generator blind spots
 - **Draw.io CSV Parser** (drawio-csv-reader phase 2) - New `ParseDrawIOCSV(io.Reader)` and `ParseDrawIOFile(path)` functions parse draw.io CSV (as written by the drawio renderer) into a `ParsedDrawIO` struct with header directives, column order, and records
   - All 18 directive keys map onto `DrawIOHeader` fields; grammar is case-sensitive `# key: ` exact-prefix with verbatim untrimmed values; unknown directives and comments are ignored; scalar directives are last-wins while `# connect:` appends all occurrences in order
   - Handles UTF-8 BOM, CRLF line endings, blank lines, quoted fields containing commas/quotes/newlines, data rows starting with `#`, and multi-line quoted column names; empty cells materialize as empty strings; absent directives leave header fields zero-valued

--- a/docs/agent-notes/drawio-csv.md
+++ b/docs/agent-notes/drawio-csv.md
@@ -1,0 +1,28 @@
+# draw.io CSV (v2 writer/reader)
+
+Spec: `specs/drawio-csv-reader/` (T-1539). Writer-changes phase (tasks 1-4) implemented; parser (`ParseDrawIOCSV`/`ParseDrawIOFile` in `v2/drawio_reader.go`) comes in later tasks.
+
+## Column-order plumbing
+
+- `DrawIOContent` has a private `columns []string` field (`v2/graph_content.go`). Nil/empty means the renderer falls back to `extractColumnNames` (alphabetized from record keys) — the pre-feature behavior.
+- Set via `WithDrawIOColumns(...)` (a `DrawIOOption`); `NewDrawIOContent`, `NewDrawIOContentFromTable`, and `Builder.DrawIO` (`v2/document.go`) all take variadic `opts ...DrawIOOption`. Backward compatible: no pre-existing caller passed options.
+- `NewDrawIOContentFromTable` captures `table.schema.GetFieldNames()` order (Decision 13) — behavior change: table-sourced drawio CSV columns went from alphabetical to schema order. Nil table leaves columns nil. `GetKeyOrder` already returns a clone, so no aliasing.
+- `GetColumns()` returns a defensive copy; `Clone()` does `slices.Clone(d.columns)`.
+- Silent-drop contract: record keys outside the explicit column list are not rendered; columns missing from a record render as `""`. With explicit columns, the header row is written even with zero records.
+
+## Connect JSON wire format (Decisions 10 + 14)
+
+- `# connect:` values are encoded via the private `drawioConnectionJSON` mirror struct (`v2/drawio_reader.go`) with json tags `from/to/invert/label/style` — `Invert` has **no omitempty** (`"invert":false` is load-bearing for byte identity).
+- `writeDrawIOHeader` uses `json.Encoder` with `SetEscapeHTML(false)` (so `&<>` stay verbatim); `Encode`'s trailing `\n` is the directive line terminator. Output is byte-identical to the old Sprintf for escape-free values.
+- Do NOT add json tags to the public `DrawIOConnection`: `renderDrawIOContentJSON` marshals `GetHeader()`, so tags would flip JSON-document key casing. Guarded by `TestJSONRenderer_DrawIOConnectionKeyCasing`.
+- Conversion `drawioConnectionJSON(conn)` works because field order/types match; staticcheck S1016 enforces it.
+
+## CSV quoting (requirement 3.6)
+
+`writeCSVRow` (`v2/graph_renderers.go`) quotes a field when it contains `,"\n\r`, **starts with `#`** (would look like a comment/directive), or is the **single empty sole field of a row** (would render as a blank line CSV readers skip). Empty fields in multi-field rows stay unquoted.
+
+## Gotchas
+
+- Tests are internal (package `output`); renderers are instantiated directly (`&drawioRenderer{}`, `&jsonRenderer{}`).
+- The Makefile lives at the repo root, not in v2/ (targets operate on v2).
+- `rune` CLI arg order is `rune complete <file> <task-id>`.

--- a/docs/agent-notes/drawio-csv.md
+++ b/docs/agent-notes/drawio-csv.md
@@ -1,6 +1,6 @@
 # draw.io CSV (v2 writer/reader)
 
-Spec: `specs/drawio-csv-reader/` (T-1539). Writer-changes phase (tasks 1-4) and parser phase (tasks 5-8, `ParseDrawIOCSV`/`ParseDrawIOFile` in `v2/drawio_reader.go`) implemented; round-trip/property tests (tasks 9-10) remain.
+Spec: `specs/drawio-csv-reader/` (T-1539). All phases implemented: writer changes (tasks 1-4), parser (tasks 5-8, `ParseDrawIOCSV`/`ParseDrawIOFile` in `v2/drawio_reader.go`), and round-trip property tests + validation (tasks 9-10, `v2/drawio_roundtrip_test.go`).
 
 ## Parser (`v2/drawio_reader.go`)
 
@@ -33,6 +33,16 @@ Spec: `specs/drawio-csv-reader/` (T-1539). Writer-changes phase (tasks 1-4) and 
 ## CSV quoting (requirement 3.6)
 
 `writeCSVRow` (`v2/graph_renderers.go`) quotes a field when it contains `,"\n\r`, **starts with `#`** (would look like a comment/directive), or is the **single empty sole field of a row** (would render as a blank line CSV readers skip). Empty fields in multi-field rows stay unquoted.
+
+## Round-trip property tests (`v2/drawio_roundtrip_test.go`)
+
+- Uses `pgregory.net/rapid` v1.3.0 (direct test-only require in `v2/go.mod`; example go.sum files gained its hashes via the local `replace`). Run more cases with `go test -rapid.checks=20000 -run TestProperty`.
+- Four properties: idempotency (3.1, renders 2 and 3 byte-equal), byte-identity (3.2, CR-free values, render 1 == render 2), no-panic on arbitrary bytes, and no-panic on directive-biased input (`# connect:`/`# padding:` with malformed JSON/non-integer tokens so the unmarshal/Atoi paths are hit). Plus `TestDrawIORoundTripGoldenFile`, an awstools-style literal asserting field values, first-re-render byte identity, and idempotency.
+- No implementation bugs surfaced at 20k checks per property — phases 1-2 (quoting rules, connect JSON encoder, explicit columns) already closed the gaps.
+- Generator gotcha found while writing the tests: column names must be distinct **after** CRLF normalization, not just as raw strings. Parsing turns `\r\n` into `\n` inside quoted fields, so columns `"a\r\nb"` and `"a\nb"` collide on re-parse and correctly trigger `ErrDrawIODuplicateColumn`. The columns generator uses `strings.ReplaceAll(s, "\r\n", "\n")` as its distinctness key.
+- Known theoretical edge, not covered by generators (spec says printable strings): a fully zero-value header plus a first column name starting with U+FEFF puts a BOM at file start; the parser strips it (req 1.6), so the column name loses its BOM prefix and 3.2 byte-identity fails for that pathological file. Idempotency (3.1) still holds. Inherent ambiguity of BOM tolerance; deliberately not "fixed".
+- Round-trip render helper contract: `New().AddContent(NewDrawIOContent(title, records, header, WithDrawIOColumns(parsed.Columns...))).Build()` rendered via `&drawioRenderer{}`. Writer suppressions (parentstyle without parent, left/top without `layout: none`, non-positive numerics) are symmetric across renders, so they never break either property.
+- Golden-file note: directive lines must follow the writer's emission order (label, style, identity, parent, parentstyle, namespace, connects, height, width, ignore, nodespacing, levelspacing, edgespacing, padding, link, left, top, layout) or byte-identity assertions fail.
 
 ## Gotchas
 

--- a/docs/agent-notes/drawio-csv.md
+++ b/docs/agent-notes/drawio-csv.md
@@ -1,6 +1,19 @@
 # draw.io CSV (v2 writer/reader)
 
-Spec: `specs/drawio-csv-reader/` (T-1539). Writer-changes phase (tasks 1-4) implemented; parser (`ParseDrawIOCSV`/`ParseDrawIOFile` in `v2/drawio_reader.go`) comes in later tasks.
+Spec: `specs/drawio-csv-reader/` (T-1539). Writer-changes phase (tasks 1-4) and parser phase (tasks 5-8, `ParseDrawIOCSV`/`ParseDrawIOFile` in `v2/drawio_reader.go`) implemented; round-trip/property tests (tasks 9-10) remain.
+
+## Parser (`v2/drawio_reader.go`)
+
+- `ParseDrawIOCSV(io.Reader) (*ParsedDrawIO, error)`; `ParsedDrawIO{Header DrawIOHeader, Columns []string, Records []Record}`. `ParseDrawIOFile` is `os.Open` + parse, open error wrapped with `%w`.
+- Pipeline: read-all → strip UTF-8 BOM → line split (`\r\n` stripped, lone `\r` kept — matches encoding/csv so directives/data normalize identically) → directive pre-pass → quote-parity scan → `csv.Reader` over header+data → duplicate-column check → record fill.
+- Directive grammar: exact prefix `"# "` + case-sensitive key + `": "`, value verbatim untrimmed to EOL (`matchDrawIODirective`). 18 keys. Anything else `#`-leading before the column header is silently ignored; after the header it is **data** (no `Comment` mode on csv.Reader, Decision 8).
+- Scalars last-wins; `connect` append-all (order preserved), unmarshaled via `drawioConnectionJSON` (unknown JSON keys ignored). Numeric keys (`nodespacing`/`levelspacing`/`edgespacing`/`padding`) `strconv.Atoi`-validated on **every** occurrence — a malformed superseded value still errors (intentional asymmetry, req 2.5/4.2).
+- Absent directives → zero values, never `DefaultDrawIOHeader()` (Decision 11; absent-vs-0 for ints is accepted ambiguity).
+- Quote-parity scan: seeded at the **header line start** (so multi-line quoted column names work — continuation lines aren't record boundaries); toggles on odd `"` count per physical line; only boundary lines after the header are tested for trailing directives. Runs over the whole section before csv, so `ErrDrawIOTrailingDirective` beats field-count errors anywhere (multi-block detection, Decision 9).
+- Parity-vs-csv quote-model disagreement (bare quote mid-field, e.g. `x"q,b`): parity scan thinks following lines are quoted → trailing directive not flagged → csv bare-quote `ParseError` fires instead. Pinned by `TestParseDrawIOCSV_ParityVsCSVQuoteDisagreement`.
+- Sentinels: `ErrDrawIONoColumnHeader` (4.4), `ErrDrawIOTrailingDirective` (4.5), `ErrDrawIODuplicateColumn` (4.6), `ErrDrawIODirective` (4.1/4.2 — connect JSON + non-integer numerics). All wrapped via `fmt.Errorf("%w: line %d: ...")`. CSV structural errors pass through as `*csv.ParseError` with `Line`/`StartLine` shifted by `headerIdx` (`adjustDrawIOCSVError`) so they're file-relative, not section-relative.
+- `TrimLeadingSpace` stays false; `FieldsPerRecord` default enforces field counts; blank lines skipped by csv (and the pre-pass); empty cells become `""`, every column present in every record; zero data rows → `Records` is empty non-nil.
+- goconst gotcha: directive keys used in both the key set and switch need consts (`drawioKeyLabel` etc.) or lint fails.
 
 ## Column-order plumbing
 

--- a/specs/drawio-csv-reader/decision_log.md
+++ b/specs/drawio-csv-reader/decision_log.md
@@ -1,0 +1,447 @@
+# Decision Log: draw.io CSV Reader
+
+## Decision 1: Use the full spec workflow
+
+**Date**: 2026-06-11
+**Status**: accepted
+
+### Context
+
+T-1539 asks for a v2 equivalent of v1's `GetHeaderAndContentsFromFile`. Scope assessment estimated 200-300 LOC across 3+ files, with open API-shape questions and round-trip edge cases (unescaped connect JSON, zero-value vs absent directives).
+
+### Decision
+
+Run the full spec workflow (requirements, design, tasks) rather than a smolspec.
+
+### Rationale
+
+The estimate exceeds the 80 LOC smolspec threshold by a wide margin, and the round-trip fidelity questions warrant explicit design decisions.
+
+### Alternatives Considered
+
+- **Smolspec**: Lightweight single document - Rejected because the implementation size and design questions exceed smolspec criteria.
+
+### Consequences
+
+**Positive:**
+- Round-trip edge cases get explicit requirements and design coverage.
+
+**Negative:**
+- More process overhead for a moderately sized feature.
+
+---
+
+## Decision 2: API returns header and records, not a content object
+
+**Date**: 2026-06-11
+**Status**: superseded by Decision 6
+
+### Context
+
+The parser could return `(DrawIOHeader, []Record, error)`, a `*DrawIOContent`, or both. The driving use case (awstools `tgw overview --append`) reads an existing file, merges in new records, and re-renders.
+
+### Decision
+
+The public API returns the parsed `DrawIOHeader` and `[]Record` directly (user-approved choice).
+
+### Rationale
+
+The merge workflow needs the raw header and records anyway; a `*DrawIOContent` wrapper would immediately be unpacked via `GetHeader()`/`GetRecords()`. Callers that want a content object can call `NewDrawIOContent` with the returned values.
+
+### Alternatives Considered
+
+- ***DrawIOContent return**: Ready-made content object - Rejected because the merge flow still has to unpack it, adding a step without value.
+- **Both forms**: Core function plus convenience constructor - Rejected to keep the API surface minimal; `NewDrawIOContent` already serves as the constructor.
+
+### Consequences
+
+**Positive:**
+- Direct fit for the read-merge-rewrite workflow.
+- Smaller API surface.
+
+**Negative:**
+- Callers wanting a `*DrawIOContent` must compose two calls.
+
+---
+
+## Decision 3: Tolerant parsing of unknown directives
+
+**Date**: 2026-06-11
+**Status**: accepted
+
+### Context
+
+draw.io supports more header directives than `DrawIOHeader` represents (`# stylename:`, `# vars:`, `# labels:`, etc.), and files may be hand-edited or written by v1.
+
+### Decision
+
+The parser guarantees round-trip fidelity only for v2 renderer output; unrecognized but well-formed directives are silently ignored (user-approved choice).
+
+### Rationale
+
+Tolerance keeps hand-edited and v1-written files usable on a best-effort basis without expanding `DrawIOHeader` to the full draw.io directive set, which the driving use case does not need.
+
+### Alternatives Considered
+
+- **Strict v2-only parsing**: Error on unknown directives - Rejected because it breaks on hand-edited and v1-written files for no benefit.
+- **Full draw.io directive set**: Parse everything drawio.com supports - Rejected as scope expansion requiring `DrawIOHeader` struct changes without a current need.
+
+### Consequences
+
+**Positive:**
+- Robust against hand-edits and forward-compatible with new directives.
+
+**Negative:**
+- Ignored directives are dropped on re-render; a hand-added `# vars:` line would be lost in the append cycle.
+
+---
+
+## Decision 4: Error on malformed input
+
+**Date**: 2026-06-11
+**Status**: accepted
+
+### Context
+
+Malformed connect JSON, bad numeric directive values, or inconsistent CSV rows could be skipped (best-effort) or reported as errors. In the append workflow, silently dropped rows mean silent diagram data loss on the next write.
+
+### Decision
+
+Return errors with line/directive context for malformed connect JSON, non-integer numeric directives, malformed CSV, and missing column header row (user-approved choice). Unlike v1, never panic or `log.Fatal`.
+
+### Rationale
+
+The append workflow rewrites the file from parsed data; anything unparseable that is skipped would be permanently lost. Failing loudly protects the data.
+
+### Alternatives Considered
+
+- **Best-effort parsing**: Skip unparseable parts - Rejected because silent data loss in a read-modify-write cycle is destructive.
+
+### Consequences
+
+**Positive:**
+- No silent data loss; v2 error-handling conventions (returned errors) are followed.
+
+**Negative:**
+- A corrupted line blocks the whole file until fixed manually.
+
+---
+
+## Decision 5: Fix the renderer's connect JSON escaping as part of this feature
+
+**Date**: 2026-06-11
+**Status**: accepted
+
+### Context
+
+`writeDrawIOHeader` builds `# connect:` JSON with `fmt.Sprintf` and no string escaping. A connection style or label containing a double quote produces invalid JSON, which the new parser (and draw.io itself) cannot read, breaking round-trip requirement [3.1](requirements.md#3.1).
+
+### Decision
+
+Include a writer-side fix so `# connect:` values are always valid JSON (requirement [3.5](requirements.md#3.5)).
+
+### Rationale
+
+Round-trip stability is the core promise of this feature; it cannot hold if the writer can emit unparseable output. The fix is small and benefits draw.io import correctness independently of the parser.
+
+### Alternatives Considered
+
+- **Document as known limitation**: Leave writer untouched - Rejected because quotes in styles/labels are plausible and would corrupt the append cycle.
+- **Lenient JSON-ish parsing in the reader**: Accept the broken output - Rejected as fragile and divergent from what draw.io itself accepts.
+
+### Consequences
+
+**Positive:**
+- Round-trip holds for all representable header values; draw.io import compatibility improves.
+
+**Negative:**
+- Touches existing renderer code, so existing renderer tests may need byte-level expectations updated if formatting changes.
+
+---
+
+## Decision 6: Parser returns a result struct with explicit column order
+
+**Date**: 2026-06-11
+**Status**: accepted
+
+### Context
+
+Both the design-critic and peer-review-validator reviews found that the Decision 2 shape `(DrawIOHeader, []Record, error)` cannot carry column names: records are maps, so column order is lost, an empty-data file loses its column header row entirely, and the writer's `extractColumnNames` alphabetizes columns on every render. Round-trip requirement [3.1](requirements.md#3.1) is unachievable with that shape.
+
+### Decision
+
+The parser returns `(*ParsedDrawIO, error)` where `ParsedDrawIO` holds `Header DrawIOHeader`, `Columns []string` (file order), and `Records []Record` (file order). The writer gains support for an explicit column order that takes precedence over alphabetized auto-detection (user-approved choice, revising Decision 2).
+
+### Rationale
+
+Explicit columns are the only way to preserve order and round-trip empty-data files. A result struct keeps the signature narrow and extensible, and column-order preservation matches the library's headline key-order-preservation principle.
+
+### Alternatives Considered
+
+- **Four return values** `(DrawIOHeader, []string, []Record, error)`: Same information - Rejected as an awkwardly wide Go signature.
+- **Keep 2-value shape with carve-outs**: Document the losses - Rejected because it permanently breaks round-trip for non-alphabetical files.
+
+### Consequences
+
+**Positive:**
+- Round-trip holds including empty-data files and non-alphabetical column orders.
+
+**Negative:**
+- Requires a writer-side change (`DrawIOContent` explicit column order) in addition to the parser.
+
+---
+
+## Decision 7: Round-trip invariant is idempotency, not universal byte-identity
+
+**Date**: 2026-06-11
+**Status**: accepted
+
+### Context
+
+The peer review showed universal byte-identity is falsifiable: `encoding/csv` normalizes `\r\n` to `\n` inside quoted fields, and `fmt.Sprint` value formatting makes the first render of programmatically built content unstable. The append workflow only needs stability from the first re-render onward.
+
+### Decision
+
+Requirement [3.1](requirements.md#3.1) demands parse→render idempotency (`render(parse(f'))` == `f'`); byte-identity with the original file ([3.2](requirements.md#3.2)) is guaranteed only for renderer-produced files free of carriage returns in field values.
+
+### Rationale
+
+Idempotency is exactly what the read-merge-rewrite cycle needs and is achievable; absolute byte-identity is hostage to CSV normalization rules outside our control.
+
+### Alternatives Considered
+
+- **Universal byte-identity**: Stronger claim - Rejected because the first property-based test would falsify it (CRLF normalization).
+- **No formal invariant**: Just "round-trips" informally - Rejected as untestable.
+
+### Consequences
+
+**Positive:**
+- A precise, testable property that holds for all inputs.
+
+**Negative:**
+- Files containing CRLF in field values are normalized on the first rewrite.
+
+---
+
+## Decision 8: Comments recognized only before the column header row; writer quotes leading-# fields
+
+**Date**: 2026-06-11
+**Status**: accepted
+
+### Context
+
+The writer only quotes fields containing `,`, `"`, or newlines, so a data value starting with `#` is written unquoted and a CSV reader in comment mode (v1's approach) silently drops the row — silent data loss in the append cycle. Separately, rejecting trailing directive lines ([4.5](requirements.md#4.5)) requires recognizing directive patterns after the data section, which conflicts with treating every `#` line as data.
+
+### Decision
+
+The parser does not use CSV comment mode: it splits the directive block from the data section in a pre-pass, so leading-`#` data survives. After the column header row, only unquoted lines matching a recognized directive pattern are rejected (multi-block detection); all other `#` lines are data. The writer additionally quotes fields beginning with `#` so its own output is never ambiguous.
+
+### Rationale
+
+Reader-side handling fixes the data-loss hazard for existing files; writer-side quoting removes the residual ambiguity (a data value that happens to look like a directive) from all future output. The writer also quotes a row consisting of a single empty field, since an unquoted one renders as a blank line that CSV readers silently skip. Together these make requirement [3.2](requirements.md#3.2) hold for output of the modified renderer.
+
+### Alternatives Considered
+
+- **CSV comment mode (`Comment='#'`)**: v1's approach - Rejected because it silently drops data rows starting with `#`.
+- **Writer-side quoting only**: Leaves existing files exposed - Rejected as incomplete; old files still parse wrong.
+- **Reader-side only**: Validator's preference - Rejected because multi-block detection (Decision 9) needs directive-pattern recognition after the header row, and unquoted directive-lookalike data would then false-positive; quoting at the writer eliminates that for self-produced files.
+
+### Consequences
+
+**Positive:**
+- No silent row loss; multi-block files are detectable.
+
+**Negative:**
+- A hand-written unquoted data row that exactly matches a directive pattern (e.g. first cell `# label: x`) errors instead of parsing as data. This fails loudly, not silently, and cannot occur in renderer-produced files.
+
+---
+
+## Decision 9: Reject trailing directive lines (multi-diagram files) with an error
+
+**Date**: 2026-06-11
+**Status**: accepted
+
+### Context
+
+A v2 document with multiple `DrawIOContent`s renders as concatenated header + table blocks. A parser that silently read only the first block would, in the append cycle, rewrite the file and delete the other diagrams.
+
+### Decision
+
+Directive-pattern lines after the column header row produce an error distinguishable from malformed-CSV errors ([4.5](requirements.md#4.5)). Multi-diagram parsing stays out of scope.
+
+### Rationale
+
+"Out of scope" must not mean "undefined": the failure mode is silent destruction of user data, which Decision 4 already rules out.
+
+### Alternatives Considered
+
+- **Parse first block, ignore rest**: Simple - Rejected as silent data loss.
+- **Support multi-block parsing**: Return multiple results - Rejected as scope expansion without a current need.
+
+### Consequences
+
+**Positive:**
+- The append workflow cannot silently destroy multi-diagram files whose later blocks emit directive lines (which every non-zero-value header does).
+
+**Negative:**
+- Legitimate multi-diagram files cannot be read at all until such support is added.
+- A second block with a fully zero-value header emits no directives and is not detectable; this residual hole is documented in the requirements' Out of Scope section. Closing it would require the writer to always emit a directive, breaking byte compatibility with existing files.
+
+---
+
+## Decision 10: Pin the connect-JSON wire format
+
+**Date**: 2026-06-11
+**Status**: accepted
+
+### Context
+
+`DrawIOConnection` has no json struct tags. A naive `json.Marshal` in the Decision 5 writer fix would emit capitalized keys (`From`, `To`, ...), changing output bytes and breaking draw.io import, while `json.Unmarshal` would silently accept either casing.
+
+### Decision
+
+The wire format is pinned ([3.5](requirements.md#3.5)): keys `from`, `to`, `invert`, `label`, `style` in that order, all always present (`invert` never omitted), JSON string escaping applied. The parser unmarshals into the same tagged struct and ignores unknown keys ([2.2](requirements.md#2.2)).
+
+### Rationale
+
+The format must match what existing files contain and what draw.io accepts; leaving it to the implementation invites accidental byte and compatibility breaks.
+
+### Alternatives Considered
+
+- **Leave format to implementation**: Less spec text - Rejected; the default `json.Marshal` output would be wrong.
+- **Keep hand-rolled Sprintf with manual escaping**: Minimal diff - Viable but rejected in favor of tagged-struct marshaling, which cannot miss an escape case.
+
+### Consequences
+
+**Positive:**
+- Existing files, new output, and draw.io all agree on one format.
+
+**Negative:**
+- The pinned format must be implemented carefully; see Decision 14 for why json tags on the public struct were rejected.
+
+---
+
+## Decision 11: Absent directives map to zero values, not DefaultDrawIOHeader defaults
+
+**Date**: 2026-06-11
+**Status**: accepted
+
+### Context
+
+`DefaultDrawIOHeader()` sets Layout=auto, NodeSpacing=40, etc. A reader could seed those defaults for directives missing from the file. The writer also only emits numeric directives when > 0, so "absent" and "explicit 0" are indistinguishable in `DrawIOHeader`'s int fields.
+
+### Decision
+
+Absent directives yield the field's zero value ([2.3](requirements.md#2.3)). The absent-vs-zero ambiguity for numeric fields is accepted: draw.io treats 0 and absent identically, and re-rendering suppresses both.
+
+### Rationale
+
+Seeding defaults would make re-rendered output differ from the parsed file (e.g. a file without `# layout:` would gain one), breaking idempotency. Zero values reproduce exactly what was read.
+
+### Alternatives Considered
+
+- **Seed DefaultDrawIOHeader values**: Matches constructor expectations - Rejected because it breaks round-trip idempotency for files lacking those directives.
+- **Pointer/sentinel fields for absent-vs-zero**: Precise - Rejected as an API change to `DrawIOHeader` without a practical need.
+
+### Consequences
+
+**Positive:**
+- Round-trip idempotency holds; parser output reflects the file, nothing more.
+
+**Negative:**
+- Callers building new content from parsed headers of sparse files get zero values where they might expect draw.io defaults.
+
+---
+
+## Decision 12: Column order passed via variadic functional options
+
+**Date**: 2026-06-12
+**Status**: accepted
+
+### Context
+
+The writer needs an explicit column order on `DrawIOContent` (Decision 6). The order must flow through both `NewDrawIOContent` and `Builder.DrawIO` without breaking existing callers.
+
+### Decision
+
+Add `opts ...DrawIOOption` to `NewDrawIOContent` and `Builder.DrawIO`, with `WithDrawIOColumns(columns ...string)` as the first option (user-approved choice).
+
+### Rationale
+
+Variadic options are backward compatible (no existing caller passes options) and match the library's established functional-options idiom (`WithKeys`, `WithSchema`).
+
+### Alternatives Considered
+
+- **Separate constructors** (`NewDrawIOContentWithColumns`, `Builder.DrawIOWithColumns`): No signature changes - Rejected because it doubles the API surface for one parameter.
+
+### Consequences
+
+**Positive:**
+- Zero migration for existing callers; extensible for future options.
+
+**Negative:**
+- One more option type in the public API.
+
+---
+
+## Decision 13: NewDrawIOContentFromTable preserves schema column order
+
+**Date**: 2026-06-12
+**Status**: accepted
+
+### Context
+
+`NewDrawIOContentFromTable` copies a table's records but not its schema order, so the renderer alphabetizes columns — at odds with the library's key-order-preservation principle. The new columns field makes preserving order trivial.
+
+### Decision
+
+`NewDrawIOContentFromTable` sets the columns field from `table.schema.GetFieldNames()` (user-approved choice).
+
+### Rationale
+
+Consistency with the library's headline guarantee; one line of code now that the field exists.
+
+### Alternatives Considered
+
+- **Leave alphabetized**: No behavior change for existing users - Rejected; the inconsistency is a latent bug, and the change only affects column order in draw.io CSV output, not data.
+
+### Consequences
+
+**Positive:**
+- Table-sourced draw.io output respects user-specified key order.
+
+**Negative:**
+- Existing users of this constructor see column order change from alphabetical to schema order (behavior change, though aligned with documented library principles).
+
+---
+
+## Decision 14: Connect JSON via a private mirror struct, not json tags on DrawIOConnection
+
+**Date**: 2026-06-12
+**Status**: accepted
+
+### Context
+
+The design review found that tagging the public `DrawIOConnection` struct would change more than the CSV wire format: `renderDrawIOContentJSON` (json_yaml_renderer.go) marshals the full `DrawIOHeader`, so JSON-format document output would flip connection keys from `From/To/Invert/Label/Style` to lowercase — a visible behavior change in an unrelated renderer.
+
+### Decision
+
+`DrawIOConnection` stays untagged. The drawio CSV writer and parser marshal/unmarshal through a private `drawioConnectionJSON` mirror struct carrying the json tags.
+
+### Rationale
+
+Decision 10 pins the CSV wire format only; it does not require tags on the public type. The mirror struct confines the format to the one place it applies and leaves every other renderer's output untouched.
+
+### Alternatives Considered
+
+- **Tag the public struct**: Simpler, makes JSON renderer output consistent with YAML's lowercase keys - Rejected because silently changing JSON-format output is a side effect outside this feature's scope.
+
+### Consequences
+
+**Positive:**
+- No behavior change outside the drawio CSV format; a JSON-renderer regression test guards this.
+
+**Negative:**
+- A five-field struct is duplicated privately and must be kept in sync with `DrawIOConnection`.
+
+---

--- a/specs/drawio-csv-reader/design.md
+++ b/specs/drawio-csv-reader/design.md
@@ -1,0 +1,148 @@
+# Design: draw.io CSV Reader
+
+## Overview
+
+Add `ParseDrawIOCSV`/`ParseDrawIOFile` to the v2 `output` package, parsing draw.io CSV (as written by `drawioRenderer`) into header directives, column order, and records. Three small writer changes make round-trip idempotency ([3.1](requirements.md#3.1)) and re-render byte-identity ([3.2](requirements.md#3.2)) hold: explicit column order, pinned connect JSON, and two extra quoting rules.
+
+## Architecture
+
+New file `v2/drawio_reader.go` (tests in `v2/drawio_reader_test.go`), package `output` — the parser needs `DrawIOHeader`/`Record`, so a subpackage would invert the dependency direction for no gain.
+
+Writer changes are confined to `v2/graph_renderers.go` (`renderDrawIOContent`, `writeDrawIOHeader`, `writeCSVRow`) and `v2/graph_content.go` (`DrawIOContent` columns field, `DrawIOConnection` json tags, constructors). Builder integration is the existing `Builder.DrawIO` call site at `v2/document.go:232`.
+
+### Parsing pipeline
+
+```
+input bytes
+  → strip optional UTF-8 BOM                                  [1.6]
+  → line scan: consume directive/comment/blank lines until
+    first non-comment line = column header row                [1.5, 2.x, 4.4]
+  → quote-parity scan of remaining data section: at each
+    logical record boundary, an unquoted line matching
+    "# <recognized-key>: " → trailing-directive error         [4.5]
+  → csv.Reader (no Comment mode, FieldsPerRecord enforced)
+    over column header row + data section                     [1.5, 3.4, 4.3]
+  → duplicate-column check, record materialization (""-fill)  [1.3, 4.6]
+```
+
+Non-obvious points:
+
+- **No `Comment='#'` on `csv.Reader`** (Decision 8): comment stripping happens only in the pre-pass, so data rows starting with `#` survive ([1.5](requirements.md#1.5)).
+- **Quote-parity scan**: quoted CSV fields may contain newlines, so the trailing-directive check cannot naively split on `\n`. The scan tracks whether each physical line starts inside an open quoted field; only lines at a record boundary are tested against the directive pattern. This pass runs before `csv.Reader` so [4.5](requirements.md#4.5) takes precedence over field-count errors on the same line.
+- **Directive grammar** ([2.1](requirements.md#2.1)): exact prefix `# ` + key + `: `, key case-sensitive, value = rest of line verbatim (no trimming). Lines not matching this with a recognized key are ignored in the pre-pass ([2.4](requirements.md#2.4)).
+- **Line splitting in the pre-pass**: `\r\n` is stripped, a lone `\r` is kept — matching `encoding/csv` semantics so directives and data normalize identically on CRLF files.
+- **Multi-line column header row**: a quoted column name may contain `\n`, so the header *record* can span physical lines; the quote-parity scan seeds its state at the start of the header line, not the line after it, so header continuation lines are never tested as record boundaries.
+- **Whole-section scan precedence (deliberate)**: the parity scan runs over the entire data section before `csv.Reader`, so a trailing directive anywhere is reported before any field-count error — stronger than the per-line precedence [4.5](requirements.md#4.5) requires. The scan's quote model (parity counting) and csv's (quotes special only at field start) can disagree on malformed hand-written input, shifting *which* error is reported; both paths fail loudly.
+- **Blank lines**: `encoding/csv` skips them unconditionally; this is the documented [1.6](requirements.md#1.6) behavior, made loss-free for new files by the writer's single-empty-field quoting rule.
+- **`csv.Reader` defaults stay as-is**: `TrimLeadingSpace` remains false (values round-trip verbatim, [2.1](requirements.md#2.1) no-trimming applies to data too); only `FieldsPerRecord` enforcement is relied upon.
+- **Known best-effort mis-parse**: a pre-feature file whose column header row starts with an unquoted `#` (column named `#x`) is consumed by the pre-pass as a comment, promoting the first data row to column header. Accepted: the modified writer quotes such fields ([3.6](requirements.md#3.6)), and old files are best-effort per Out of Scope.
+
+### Directive mapping
+
+Recognized keys map 1:1 onto `DrawIOHeader` fields (the 18 keys from [2.1](requirements.md#2.1)). String directives assign verbatim; `nodespacing`/`levelspacing`/`edgespacing`/`padding` go through `strconv.Atoi` (error → [4.2](requirements.md#4.2), checked on every occurrence even when superseded — intentional asymmetry with last-wins [2.5](requirements.md#2.5)); each `# connect:` value is unmarshaled via the private mirror struct (unknown keys ignored by default unmarshal semantics per [2.2](requirements.md#2.2); any unmarshal failure → [4.1](requirements.md#4.1)). Last-wins applies to scalar directives only: `connect` is append-all, exempt from [2.5](requirements.md#2.5), with every occurrence validated. No `DefaultDrawIOHeader()` seeding (Decision 11).
+
+### Writer changes
+
+| Change | Where | Behavior |
+|---|---|---|
+| Explicit column order | `DrawIOContent.columns` (new field); `renderDrawIOContent` uses it when non-empty, falls back to `extractColumnNames` | Parsed files re-render in file order incl. zero-record column header row ([3.3](requirements.md#3.3)) |
+| Connect JSON | `writeDrawIOHeader`: replace Sprintf with `json.Encoder` + `SetEscapeHTML(false)` encoding a private mirror struct | Valid JSON, keys `from,to,invert,label,style`, `invert` always present, `&<>` verbatim ([3.5](requirements.md#3.5)). Byte-identical to current output for values without `"`/`\`/control chars/invalid UTF-8 (json replaces invalid sequences with U+FFFD; Sprintf passed them through) |
+| Quoting rules | `writeCSVRow`: also quote when field starts with `#`, or row is a single empty field | No comment-mistakable or blank-line-mistakable data rows ([3.6](requirements.md#3.6)) |
+
+`json.Encoder.Encode` appends `\n`, which serves as the directive line terminator (`# connect: ` prefix written first).
+
+### Parity audit (column-order pattern extension)
+
+| Call site | Needs explicit columns? | Rationale |
+|---|---|---|
+| `renderDrawIOContent` (graph_renderers.go:639) | Yes | Core change; only caller of `extractColumnNames` |
+| `renderTableAsDrawIO` (graph_renderers.go:698) | No | Already uses `table.schema.GetFieldNames()` order |
+| `renderGraphAsDrawIO` (graph_renderers.go:665) | No | Fixed 4-column layout |
+| `NewDrawIOContent` (graph_content.go:436) | Yes | Gains `opts ...DrawIOOption`; `WithDrawIOColumns` sets the field |
+| `NewDrawIOContentFromTable` (graph_content.go:448) | Yes | Sets columns from `table.schema.GetFieldNames()` (user-approved; fixes alphabetization for table-sourced content). Nil-table path leaves columns nil |
+| `Builder.DrawIO` (document.go:232) | Yes | Gains `opts ...DrawIOOption`, forwards to `NewDrawIOContent` |
+| `DrawIOContent.Clone` (graph_content.go:518) | Yes | Must `slices.Clone` the columns slice |
+| `renderDrawIOContentJSON`/`...YAML` (json_yaml_renderer.go) | No (deliberate) | They marshal `GetHeader()`/`GetRecords()` only; columns stay a CSV-format concern. The private mirror struct (below) keeps their `DrawIOConnection` key casing unchanged |
+
+Both variadic additions are backward compatible (no existing caller passes options).
+
+## Components and Interfaces
+
+```go
+// drawio_reader.go
+
+// ParsedDrawIO holds the result of parsing a draw.io CSV file.
+type ParsedDrawIO struct {
+    Header  DrawIOHeader // zero-valued fields for absent directives
+    Columns []string     // column header row, file order
+    Records []Record     // file order; every column present, "" for empty cells
+}
+
+func ParseDrawIOCSV(r io.Reader) (*ParsedDrawIO, error)
+func ParseDrawIOFile(path string) (*ParsedDrawIO, error) // os.Open + ParseDrawIOCSV, wrapped errors
+
+// graph_content.go additions
+type DrawIOOption func(*DrawIOContent)
+func WithDrawIOColumns(columns ...string) DrawIOOption
+func NewDrawIOContent(title string, records []Record, header DrawIOHeader, opts ...DrawIOOption) *DrawIOContent
+func (d *DrawIOContent) GetColumns() []string // copy, may be nil
+
+// document.go
+func (b *Builder) DrawIO(title string, records []Record, header DrawIOHeader, opts ...DrawIOOption) *Builder
+```
+
+Behavioral contracts:
+
+- `ParseDrawIOCSV` reads the entire input; `Records` values are always `string` (typed as `any` via `Record`).
+- Round-trip contract: for `f' = render(parse(f))`, `render(parse(f')) == f'` byte-for-byte; `f' == f` when `f` was produced by the modified renderer and contains no CR in field values.
+- `WithDrawIOColumns` does not validate against record keys; keys absent from columns are simply not rendered (matches existing renderer behavior of skipping unknown keys), keys missing in a record render as `""`.
+- Parser and renderer remain stateless; no locking added.
+
+## Data Models
+
+`DrawIOConnection` stays untagged: adding json tags would change `renderDrawIOContentJSON` output (json_yaml_renderer.go marshals the header, so connection keys would flip from `From/To/...` to lowercase in JSON-format documents). The CSV wire format (Decision 10) is pinned instead via a private mirror struct used by both the writer (marshal) and parser (unmarshal):
+
+```go
+// drawio_reader.go (unexported)
+type drawioConnectionJSON struct {
+    From   string `json:"from"`
+    To     string `json:"to"`
+    Invert bool   `json:"invert"` // no omitempty: "invert":false is load-bearing for byte identity (3.5)
+    Label  string `json:"label"`
+    Style  string `json:"style"`
+}
+```
+
+`DrawIOContent` gains `columns []string`, cloned in `Clone()` and exposed via `GetColumns()`.
+
+## Error Handling
+
+New sentinel errors in `drawio_reader.go`, all wrapped with `fmt.Errorf("%w: ...")` to carry line/directive context while staying `errors.Is`-matchable:
+
+| Sentinel | Requirement | Trigger |
+|---|---|---|
+| `ErrDrawIONoColumnHeader` | [4.4](requirements.md#4.4) | Empty input or comments/blank lines only |
+| `ErrDrawIOTrailingDirective` | [4.5](requirements.md#4.5) | Recognized directive pattern after column header row |
+| `ErrDrawIODuplicateColumn` | [4.6](requirements.md#4.6) | Duplicate name in column header row |
+| `ErrDrawIODirective` | [4.1](requirements.md#4.1), [4.2](requirements.md#4.2) | Connect unmarshal failure or non-integer numeric directive (message names the directive) |
+
+CSV structural errors ([4.3](requirements.md#4.3)) pass through as `*csv.ParseError`, which already carries line numbers; `ParseDrawIOFile` wraps `os.Open` errors. Sentinels (not one struct type with a kind field) because callers like awstools only need `errors.Is` discrimination; nothing programmatic reads the context fields. No panics anywhere on the parse path ([4.7](requirements.md#4.7)).
+
+## Testing Strategy
+
+`drawio_reader_test.go`, map-based table tests per project convention:
+
+- **Directive parsing**: each of the 18 keys; unknown directives/non-directive comments ignored; duplicate last-wins; malformed-superseded-numeric still errors; connect order preservation; connect with unknown JSON keys; zero-value header for directive-less file.
+- **Data section**: leading-`#` data rows parse as data; quoted fields with commas/quotes/newlines; BOM; blank lines; empty-cell `""`-fill; zero data rows.
+- **Errors**: one test per sentinel, asserting `errors.Is` and message content (line/directive); trailing-directive precedence over field-count mismatch on the same line; an error-returning `io.Reader` (mid-stream, non-EOF) surfaces as a returned error ([4.7](requirements.md#4.7)); a parity-scan-vs-csv quote-model disagreement case pinning which error fires.
+- **API surface**: `ParseDrawIOFile` happy path and wrapped `os.Open` error; `GetColumns` returns a defensive copy; multi-line quoted column name in the header row.
+- **Writer changes** (in existing drawio test files): connect JSON byte-compatibility with the previous Sprintf output for escape-free values; a connect value containing `&<>` rendered verbatim (proves `SetEscapeHTML(false)` is wired, not just defaulted); new quoting rules; explicit column order incl. zero-record header row; record keys outside the column list are not rendered (pins the documented silent-drop contract of `WithDrawIOColumns`); `NewDrawIOContentFromTable` schema-order regression; `Clone` copies columns; JSON-renderer regression asserting `DrawIOConnection` key casing in JSON-format output is unchanged (guards the mirror-struct decision).
+
+Property-based tests (`pgregory.net/rapid`, new test-only dependency) — the round-trip requirements are universal guarantees and example tests cannot cover the quoting/escaping interaction space:
+
+- **Idempotency** ([3.1](requirements.md#3.1)): arbitrary `DrawIOHeader` (printable strings incl. `"`,`\`,`,`,`#`, newlines in record values), columns, records → render → parse → render → parse → render; second and third renders byte-equal.
+- **Byte-identity** ([3.2](requirements.md#3.2)): same generators restricted to CR-free values; first re-render equals first render.
+- **No-panic property** ([4.7](requirements.md#4.7)): arbitrary byte slices into `ParseDrawIOCSV`, plus a directive-biased generator emitting `# connect: <arbitrary-json-ish>` and `# padding: <arbitrary-token>` lines so the unmarshal/Atoi paths are actually reached; asserts error-or-success, never panic.
+- Generator constraints (these encode documented carve-outs, not bugs): no `\n`/`\r` in header string fields (Out of Scope), unique column names (else `ErrDrawIODuplicateColumn` correctly fires), record keys ⊆ columns (keys outside the column list are intentionally not rendered).
+
+One example-based golden round-trip with a realistic awstools-style file (connections, identity, parent, layout none + left/top) as an anchor against generator blind spots.

--- a/specs/drawio-csv-reader/implementation.md
+++ b/specs/drawio-csv-reader/implementation.md
@@ -1,0 +1,212 @@
+# Implementation Explanation: draw.io CSV Reader
+
+Three-level explanation of the drawio-csv-reader feature as implemented on branch
+`T-1539/drawio-csv-reader` (spec: this directory). Generated as part of the
+pre-push review.
+
+## Beginner Level
+
+### What Changed / What This Does
+
+The go-output library could already *write* draw.io CSV files — a special text
+format that the diagrams.net (draw.io) application can import to draw
+architecture diagrams. A draw.io CSV file has two parts: a block of
+configuration lines at the top that all start with `#` (called directives, e.g.
+`# label: %Name%` tells draw.io what text to put on each box), followed by a
+normal CSV table whose rows become the boxes in the diagram.
+
+What the library could *not* do was read such a file back in. This change adds
+that: `ParseDrawIOFile("diagram.csv")` (or `ParseDrawIOCSV` for any input
+stream) reads a file and gives you back three things — the configuration
+(header), the column names in their original order, and the data rows.
+
+A few small changes were also made to the *writing* side so that a file you
+read in and write out again comes back exactly the same, byte for byte.
+
+### Why It Matters
+
+Tools built on this library (like awstools) want to merge new data into an
+existing diagram file: read the file, add rows, write it back. Without a
+parser, that workflow was impossible — you could only ever generate a diagram
+from scratch. With it, you can append to a diagram across multiple runs (for
+example, collecting AWS network data from several accounts into one picture).
+
+The "comes back exactly the same" property matters because it means appending
+rows never silently corrupts or reorders the rest of the file.
+
+### Key Concepts
+
+- **CSV (comma-separated values)**: a plain-text table; each line is a row,
+  values separated by commas. Values containing commas or quotes are wrapped in
+  double quotes, like `"Production VPC, primary"`.
+- **Directive**: a configuration line at the top of the file, format
+  `# key: value`. Think of it as the diagram's settings panel saved as text.
+- **Round-trip**: read a file in and write it back out. A *lossless* round-trip
+  reproduces the original exactly — like photocopying a photocopy and getting
+  an identical page.
+- **Sentinel error**: a named, exported error value (like
+  `ErrDrawIODuplicateColumn`) that calling code can check for with
+  `errors.Is`, instead of having to match error message text.
+
+## Intermediate Level
+
+### Changes Overview
+
+- **`v2/drawio_reader.go` (new)**: `ParseDrawIOCSV(io.Reader)` /
+  `ParseDrawIOFile(path)` returning `*ParsedDrawIO{Header, Columns, Records}`;
+  four sentinel errors; the 18 directive-key constants; the private
+  `drawioConnectionJSON` mirror struct shared with the writer; the
+  `writeDrawIODirective` grammar helper.
+- **`v2/graph_content.go`**: `DrawIOContent` gains a `columns []string` field,
+  a `DrawIOOption` functional-options type with `WithDrawIOColumns(...)`, a
+  `GetColumns()` defensive-copy accessor, and column cloning in `Clone()`.
+  `NewDrawIOContentFromTable` now captures the table schema's field order.
+- **`v2/graph_renderers.go`**: the renderer prefers the explicit column order
+  over alphabetized auto-detection; `# connect:` lines are emitted with
+  `json.Encoder` (`SetEscapeHTML(false)`) instead of `fmt.Sprintf`; CSV fields
+  starting with `#` and single-empty-field rows are now quoted.
+- **`v2/document.go`**: `Builder.DrawIO` gains variadic `opts ...DrawIOOption`
+  (backward compatible).
+- **Tests**: ~77 parser table-test cases, exact-output writer tests, four
+  property-based tests (`pgregory.net/rapid`, test-only dependency), and a
+  golden awstools-style round-trip file.
+
+### Implementation Approach
+
+The parser is a staged pipeline over the whole input:
+
+1. **BOM strip** — tolerate a UTF-8 byte order mark.
+2. **Directive pre-pass** — consume `#`-prefixed and blank lines until the
+   first data line (the column header row). Directives use an exact
+   case-sensitive `# key: ` grammar with verbatim untrimmed values; unknown
+   keys and free-form comments are ignored; scalar keys are last-wins while
+   `# connect:` appends; numeric values are validated on every occurrence.
+3. **Quote-parity scan** — before CSV parsing, scan the data section for
+   directive lines appearing *after* the header row (a second diagram block),
+   tracking quote parity so that lines inside multi-line quoted fields are
+   never misclassified. Running this before `csv.Reader` makes the
+   trailing-directive error take precedence over field-count errors.
+4. **`csv.Reader`** — with `Comment` mode *off* (so data rows starting with
+   `#` survive; comment handling already happened), `FieldsPerRecord`
+   enforcement, and `TrimLeadingSpace` false (values round-trip verbatim).
+5. **Materialization** — duplicate-column check, then one `Record` per row
+   with every column present (`""` for empty cells).
+
+On the writer side, three changes close the round-trip gaps: explicit column
+order (parsed files re-render in file order instead of alphabetically),
+connect JSON pinned to exact key order and escaping via a shared mirror
+struct, and quoting rules that prevent data from being mistaken for comments
+or blank lines.
+
+### Trade-offs
+
+- **Sentinel errors over a structured error type**: callers only need
+  `errors.Is` discrimination; nothing reads context fields programmatically,
+  so sentinels wrapped with `fmt.Errorf("%w: ...")` are the simplest adequate
+  shape (Decision in design.md Error Handling).
+- **Private mirror struct over tagging `DrawIOConnection`**: adding json tags
+  to the public struct would have changed the JSON/YAML document renderers'
+  output (key casing). The mirror confines the wire format to the CSV
+  writer/parser (Decision 14), guarded by a key-casing regression test.
+- **Whole-input read over streaming**: the quote-parity pre-scan requires the
+  data section before CSV parsing. Draw.io CSV files are small (KBs), so
+  simplicity wins.
+- **Tolerant directive parsing over strict**: unknown directives are ignored
+  rather than errors, so files from newer draw.io versions or hand edits
+  still parse (requirement 2.4); malformed values of *recognized* keys fail
+  loudly (4.1/4.2).
+
+## Expert Level
+
+### Technical Deep Dive
+
+The subtle correctness work is concentrated in three places:
+
+- **Quote-parity scan semantics.** Quoted CSV fields may contain newlines, so
+  "is this physical line a record boundary?" requires tracking whether the
+  line starts inside an open quoted field. The scan counts quote characters
+  per line (escaped `""` contributes even parity, so it cannot flip state) and
+  seeds its state at the *header* line, making multi-line quoted column names
+  safe. The scan's parity model and encoding/csv's quote model (quotes special
+  only at field start) can disagree on malformed input; the design accepts
+  that the *choice* of error shifts — both paths fail loudly — and
+  `TestParseDrawIOCSV_ParityVsCSVQuoteDisagreement` pins which one fires.
+- **Byte-identity of connect JSON.** The old `fmt.Sprintf` emission could not
+  escape quotes/backslashes (producing invalid JSON), but its output for
+  escape-free values is the compatibility target. `json.Encoder` with
+  `SetEscapeHTML(false)` reproduces it byte-for-byte: field order follows the
+  mirror struct declaration, `invert` carries no `omitempty` (the
+  `"invert":false` token is load-bearing for requirement 3.5), and `Encode`'s
+  trailing newline is the line terminator. Known deviation: invalid UTF-8 in
+  values becomes U+FFFD where Sprintf passed it through (documented in
+  design.md).
+- **CRLF normalization.** The pre-pass line splitter strips `\r` only before
+  `\n`, matching encoding/csv, so directives and data normalize identically.
+  Consequence: two column names differing only by `\r` vs nothing collide
+  after normalization — the round-trip property generators key uniqueness on
+  the normalized name. `csv.ParseError` line numbers are shifted from
+  data-section to whole-file coordinates before being returned.
+
+The round-trip guarantees are property-tested (rapid, 3 properties + a
+no-panic fuzz with a directive-biased generator reaching the
+`json.Unmarshal`/`strconv.Atoi` paths) with an example-based golden file as an
+anchor against generator blind spots. Idempotency (3.1) holds universally;
+byte-identity (3.2) holds for CR-free renderer-produced files, with two
+documented carve-outs (CR values; leading U+FEFF column name in a
+directive-less file, which BOM tolerance consumes).
+
+### Architecture Impact
+
+- The parser lives in package `output` (not a subpackage) because it needs
+  `DrawIOHeader`/`Record`; a subpackage would invert the dependency direction.
+- The directive grammar now has a single definition: the `drawioKey*`
+  constants and `writeDrawIODirective` are shared by `writeDrawIOHeader` and
+  `matchDrawIODirective`, so adding a directive cannot silently desynchronize
+  writer and parser (and the byte-identity property would catch any residual
+  drift).
+- `NewDrawIOContentFromTable` capturing schema order is a deliberate behavior
+  change (Decision 13): table-sourced draw.io content now renders in schema
+  order rather than alphabetized — aligned with the library's core key-order-
+  preservation principle.
+- Sentinel errors introduce the `var Err...` convention to v2, which
+  otherwise uses structured error types; acceptable because parser callers
+  need kind discrimination, not field access.
+
+### Potential Issues
+
+- **Pre-feature files**: output written by the *old* renderer may contain
+  unquoted leading-`#` data fields or bare blank lines for single-empty-cell
+  rows; these mis-parse (consumed as comment / skipped as blank). Documented
+  as out of scope — old files are best-effort.
+- **Multiple diagram blocks** are detected only if the second block emits at
+  least one directive line; a second block with a fully zero-value header is
+  indistinguishable from data and will be parsed as rows (out of scope, by
+  design).
+- **`extractColumnNames` fallback alphabetizes**: content without explicit
+  columns still renders alphabetized (pre-existing behavior, kept for
+  backward compatibility). Callers wanting order stability must pass
+  `WithDrawIOColumns`.
+- **`renderTableAsDrawIO` duplication**: the table-content render arm still
+  re-implements row emission; it could now delegate through
+  `NewDrawIOContentFromTable` + `renderDrawIOContent`. Left for a future
+  cleanup (noted in the pre-push review).
+
+## Completeness Assessment
+
+**Fully implemented**: all 24 acceptance criteria across requirements
+sections 1–4, each with a behavioral test (verified requirement-by-requirement
+in the pre-push review); all 10 spec tasks complete; all 3 writer changes from
+the design's parity audit; the four sentinel errors; property-based round-trip
+verification with golden anchor; public API documented in v2/docs/API.md and
+the v1 migration mapping in v2/docs/MIGRATION.md.
+
+**Partially implemented**: none.
+
+**Missing / deferred (deliberate)**: directives `DrawIOHeader` cannot
+represent (`# stylename:`, `# vars:`, ...) are ignored, not parsed;
+multi-block files are rejected, not supported; v1 `drawio` package untouched.
+All recorded in the spec's Out of Scope list.
+
+**Divergences discovered during explanation**: none beyond the documented
+carve-outs; the U+FEFF byte-identity edge was promoted from agent notes into
+the spec's Out of Scope list during the pre-push review.

--- a/specs/drawio-csv-reader/requirements.md
+++ b/specs/drawio-csv-reader/requirements.md
@@ -1,0 +1,70 @@
+# Requirements: draw.io CSV Reader
+
+## Introduction
+
+The v2 library can write draw.io CSV output (via `DrawIOContent` and the drawio renderer) but cannot read such a file back in. This feature adds a parser that reads a draw.io CSV file produced by the v2 drawio renderer and returns the `DrawIOHeader` configuration, the column names, and the data records. It replaces v1's `GetHeaderAndContentsFromFile` and unblocks read-merge-rewrite workflows such as the awstools `tgw overview --append` multi-account merge (Transit ticket T-1539).
+
+## Out of Scope
+
+- Parsing draw.io header directives that `DrawIOHeader` does not represent (e.g. `# stylename:`, `# styles:`, `# vars:`, `# labels:`); such directives are ignored, not errors.
+- Files containing multiple diagram blocks (multiple header + table sections concatenated); the parser detects and rejects them rather than supporting them. Detection relies on the second block emitting at least one directive line; a block with a fully zero-value header is not detectable.
+- Fidelity guarantees for files not produced by the v2 drawio renderer (hand-written or v1-written files parse on a best-effort basis under the tolerance rules below).
+- Recovering records that pre-feature renderer output stored as bare blank lines (a single-column table row with an empty cell); CSV parsing cannot distinguish these from blank separator lines, so they are lost on read.
+- Header directive values containing line breaks; the draw.io CSV header format cannot represent them, and the writer's behavior for such values is unchanged by this feature.
+- Parsing draw.io XML (`.drawio`) files.
+- Semantic validation of parsed values (e.g. whether `%Name%` placeholders match actual columns).
+- Changes to the v1 `drawio` package.
+
+## Requirements
+
+### 1. Parse draw.io CSV into header, columns, and records
+
+**User Story:** As a developer migrating from v1, I want to read an existing draw.io CSV file into its header configuration, column order, and data records, so that I can merge new data and re-render the diagram.
+
+**Acceptance Criteria:**
+
+1. <a name="1.1"></a>WHEN given input produced by the v2 drawio renderer, the system SHALL return the `DrawIOHeader` represented by the file's header directives, the column names in file order, and the data rows as `[]Record` in file order.
+2. <a name="1.2"></a>The system SHALL accept input from an `io.Reader` and SHALL provide a convenience function that reads from a file path.
+3. <a name="1.3"></a>Each returned record SHALL contain an entry for every column name; WHEN a CSV cell is empty, the record value SHALL be the empty string `""`.
+4. <a name="1.4"></a>WHEN the input contains a column header row but no data rows, the system SHALL return the column names and zero records without error.
+5. <a name="1.5"></a>WHEN a row after the column header row begins with `#` but does not match a recognized directive pattern (see [4.5](#4.5)), the system SHALL parse it as data, not as a comment.
+6. <a name="1.6"></a>The system SHALL skip blank lines and SHALL tolerate a leading UTF-8 byte order mark.
+
+### 2. Header directive parsing
+
+**User Story:** As a developer, I want header directives parsed back into `DrawIOHeader` fields, so that re-rendering preserves the diagram configuration.
+
+**Acceptance Criteria:**
+
+1. <a name="2.1"></a>The system SHALL recognize directive lines of the exact form `# key: value` (key matched case-sensitively, value taken verbatim to the end of the line) and SHALL populate the corresponding `DrawIOHeader` field for every directive the v2 renderer emits: `label`, `style`, `identity`, `parent`, `parentstyle`, `namespace`, `connect`, `height`, `width`, `ignore`, `nodespacing`, `levelspacing`, `edgespacing`, `padding`, `link`, `left`, `top`, `layout`.
+2. <a name="2.2"></a>WHEN one or more `# connect:` directives are present, the system SHALL parse each value into a `DrawIOConnection`, ignoring unknown JSON keys, and SHALL preserve their file order in `DrawIOHeader.Connections`.
+3. <a name="2.3"></a>WHEN a directive is absent from the input, the corresponding `DrawIOHeader` field SHALL be its zero value; the system SHALL NOT substitute `DefaultDrawIOHeader()` values.
+4. <a name="2.4"></a>WHEN a comment line contains an unrecognized directive key or no `key: value` structure, the system SHALL ignore that line.
+5. <a name="2.5"></a>WHEN a recognized directive other than `connect` appears more than once, the last occurrence SHALL win; malformed occurrences still error per [4.2](#4.2) (intentional asymmetry: valid superseded values are dropped, malformed ones fail loudly).
+
+### 3. Round-trip stability
+
+**User Story:** As a developer using the append workflow, I want write→read→write to be stable, so that repeated append runs do not alter or corrupt the diagram file.
+
+**Acceptance Criteria:**
+
+1. <a name="3.1"></a>WHEN a file produced by the v2 drawio renderer is parsed and the returned header, columns, and records are rendered again, parsing and re-rendering that output SHALL reproduce it byte-for-byte (parse→render is idempotent from the first re-render onward).
+2. <a name="3.2"></a>WHEN a file produced by the v2 drawio renderer (as modified by this feature) contains no carriage-return characters in field values, the first re-render SHALL already be byte-identical to the original file; files written by the renderer before this feature are covered by [3.1](#3.1) only.
+3. <a name="3.3"></a>WHEN re-rendering parsed content, the system SHALL write columns in the parsed file order, including the column header row when there are zero records.
+4. <a name="3.4"></a>The system SHALL correctly parse quoted CSV fields containing commas, double quotes, and newlines as written by the renderer.
+5. <a name="3.5"></a>The renderer SHALL emit each `# connect:` value as valid JSON with exactly the keys `from`, `to`, `invert`, `label`, `style` in that order, all keys always present, string values escaped per JSON rules (including double quotes and backslashes), and no HTML escaping (`&`, `<`, `>` written verbatim).
+6. <a name="3.6"></a>WHEN a data field value begins with `#`, or a row consists of a single empty field, the renderer SHALL quote the field so the line cannot be mistaken for a comment, directive, or blank line.
+
+### 4. Error handling
+
+**User Story:** As a developer, I want malformed input to fail with a clear error, so that the append workflow stops loudly instead of silently losing diagram data.
+
+**Acceptance Criteria:**
+
+1. <a name="4.1"></a>WHEN a `# connect:` directive value cannot be parsed into a `DrawIOConnection`, the system SHALL return an error identifying the offending directive.
+2. <a name="4.2"></a>WHEN a recognized numeric directive (`nodespacing`, `levelspacing`, `edgespacing`, `padding`) has a non-integer value in any occurrence — including one superseded per [2.5](#2.5) — the system SHALL return an error identifying the directive.
+3. <a name="4.3"></a>WHEN the CSV data section is malformed (e.g. a row's field count differs from the column header row), the system SHALL return an error including line context.
+4. <a name="4.4"></a>WHEN the input contains no column header row (empty input or comments only), the system SHALL return an error.
+5. <a name="4.5"></a>WHEN an unquoted line after the column header row matches a recognized directive pattern (`# key: value` with a key from [2.1](#2.1), e.g. the start of a second diagram block), the system SHALL return an error distinguishable from a malformed-CSV error; this check SHALL take precedence over [4.3](#4.3) for the same line.
+6. <a name="4.6"></a>WHEN the column header row contains duplicate column names, the system SHALL return an error.
+7. <a name="4.7"></a>The system SHALL report all failures via returned errors and SHALL NOT panic or terminate the process on malformed input or I/O failure.

--- a/specs/drawio-csv-reader/requirements.md
+++ b/specs/drawio-csv-reader/requirements.md
@@ -11,6 +11,7 @@ The v2 library can write draw.io CSV output (via `DrawIOContent` and the drawio 
 - Fidelity guarantees for files not produced by the v2 drawio renderer (hand-written or v1-written files parse on a best-effort basis under the tolerance rules below).
 - Recovering records that pre-feature renderer output stored as bare blank lines (a single-column table row with an empty cell); CSV parsing cannot distinguish these from blank separator lines, so they are lost on read.
 - Header directive values containing line breaks; the draw.io CSV header format cannot represent them, and the writer's behavior for such values is unchanged by this feature.
+- Byte identity ([3.2](#3.2)) for a directive-less file whose first column name starts with U+FEFF: BOM tolerance ([1.6](#1.6)) strips that prefix on re-parse, so the leading U+FEFF is lost. Idempotency ([3.1](#3.1)) still holds.
 - Parsing draw.io XML (`.drawio`) files.
 - Semantic validation of parsed values (e.g. whether `%Name%` placeholders match actual columns).
 - Changes to the v1 `drawio` package.

--- a/specs/drawio-csv-reader/tasks.md
+++ b/specs/drawio-csv-reader/tasks.md
@@ -8,7 +8,7 @@ references:
 
 ## Writer changes
 
-- [ ] 1. Write failing tests for DrawIOContent column-order plumbing <!-- id:ih3bs6v -->
+- [x] 1. Write failing tests for DrawIOContent column-order plumbing <!-- id:ih3bs6v -->
   - Test WithDrawIOColumns option sets column order on NewDrawIOContent and Builder.DrawIO (forwarding)
   - Test GetColumns returns a defensive copy (mutating the result does not affect content)
   - Test Clone deep-copies the columns slice
@@ -17,7 +17,7 @@ references:
   - Stream: 1
   - Requirements: [3.3](requirements.md#3.3)
 
-- [ ] 2. Implement columns field, DrawIOOption, and constructor/builder plumbing <!-- id:ih3bs6w -->
+- [x] 2. Implement columns field, DrawIOOption, and constructor/builder plumbing <!-- id:ih3bs6w -->
   - v2/graph_content.go: columns []string on DrawIOContent; variadic opts on NewDrawIOContent and NewDrawIOContentFromTable; slices.Clone in Clone(); GetColumns accessor
   - v2/document.go:232: Builder.DrawIO gains opts ...DrawIOOption and forwards them
   - Backward compatible: no existing caller passes options (verified in design parity audit)
@@ -25,7 +25,7 @@ references:
   - Stream: 1
   - Requirements: [3.3](requirements.md#3.3)
 
-- [ ] 3. Write failing tests for drawio renderer output changes <!-- id:ih3bs6x -->
+- [x] 3. Write failing tests for drawio renderer output changes <!-- id:ih3bs6x -->
   - Explicit column order used by renderDrawIOContent; column header row written even with zero records
   - Record keys outside the column list are not rendered (pins WithDrawIOColumns silent-drop contract)
   - Connect JSON: byte-identical to old Sprintf output for escape-free values; quotes/backslashes escaped per JSON; ampersand/angle-brackets verbatim (proves SetEscapeHTML(false)); invert:false always present
@@ -35,7 +35,7 @@ references:
   - Stream: 1
   - Requirements: [3.3](requirements.md#3.3), [3.5](requirements.md#3.5), [3.6](requirements.md#3.6)
 
-- [ ] 4. Implement renderer changes: explicit columns, connect JSON encoder, quoting rules <!-- id:ih3bs6y -->
+- [x] 4. Implement renderer changes: explicit columns, connect JSON encoder, quoting rules <!-- id:ih3bs6y -->
   - v2/graph_renderers.go renderDrawIOContent: use GetColumns() when non-empty; fall back to extractColumnNames
   - writeDrawIOHeader: emit connect via drawioConnectionJSON mirror struct (json tags from/to/invert/label/style; no omitempty on Invert) with json.Encoder + SetEscapeHTML(false); Encode trailing newline is the line terminator
   - writeCSVRow: also quote fields starting with # and a single empty sole field

--- a/specs/drawio-csv-reader/tasks.md
+++ b/specs/drawio-csv-reader/tasks.md
@@ -79,7 +79,7 @@ references:
 
 ## Round-trip and validation
 
-- [ ] 9. Add property-based round-trip tests and golden example <!-- id:ih3bs73 -->
+- [x] 9. Add property-based round-trip tests and golden example <!-- id:ih3bs73 -->
   - Add pgregory.net/rapid as test-only dependency (go.mod via make mod-tidy)
   - Idempotency property (3.1): render-parse-render-parse-render; second and third renders byte-equal
   - Byte-identity property (3.2): CR-free generated content; first re-render equals first render
@@ -91,7 +91,7 @@ references:
   - Stream: 1
   - Requirements: [3.1](requirements.md#3.1), [3.2](requirements.md#3.2), [4.7](requirements.md#4.7)
 
-- [ ] 10. Run full validation pipeline and fix findings <!-- id:ih3bs74 -->
+- [x] 10. Run full validation pipeline and fix findings <!-- id:ih3bs74 -->
   - make check (fmt + lint + tests) and make modernize; fix all findings
   - Verify existing drawio and JSON/YAML renderer tests still pass unchanged (byte-compat and key-casing guards)
   - Blocked-by: ih3bs73 (Add property-based round-trip tests and golden example)

--- a/specs/drawio-csv-reader/tasks.md
+++ b/specs/drawio-csv-reader/tasks.md
@@ -1,0 +1,98 @@
+---
+references:
+    - specs/drawio-csv-reader/requirements.md
+    - specs/drawio-csv-reader/design.md
+    - specs/drawio-csv-reader/decision_log.md
+---
+# draw.io CSV Reader
+
+## Writer changes
+
+- [ ] 1. Write failing tests for DrawIOContent column-order plumbing <!-- id:ih3bs6v -->
+  - Test WithDrawIOColumns option sets column order on NewDrawIOContent and Builder.DrawIO (forwarding)
+  - Test GetColumns returns a defensive copy (mutating the result does not affect content)
+  - Test Clone deep-copies the columns slice
+  - Test NewDrawIOContentFromTable captures table.schema.GetFieldNames() order; nil table leaves columns nil (Decision 13)
+  - Define DrawIOOption type / WithDrawIOColumns / GetColumns stubs so the package compiles (types exempt from TDD); assertions must fail before task 2
+  - Stream: 1
+  - Requirements: [3.3](requirements.md#3.3)
+
+- [ ] 2. Implement columns field, DrawIOOption, and constructor/builder plumbing <!-- id:ih3bs6w -->
+  - v2/graph_content.go: columns []string on DrawIOContent; variadic opts on NewDrawIOContent and NewDrawIOContentFromTable; slices.Clone in Clone(); GetColumns accessor
+  - v2/document.go:232: Builder.DrawIO gains opts ...DrawIOOption and forwards them
+  - Backward compatible: no existing caller passes options (verified in design parity audit)
+  - Blocked-by: ih3bs6v (Write failing tests for DrawIOContent column-order plumbing)
+  - Stream: 1
+  - Requirements: [3.3](requirements.md#3.3)
+
+- [ ] 3. Write failing tests for drawio renderer output changes <!-- id:ih3bs6x -->
+  - Explicit column order used by renderDrawIOContent; column header row written even with zero records
+  - Record keys outside the column list are not rendered (pins WithDrawIOColumns silent-drop contract)
+  - Connect JSON: byte-identical to old Sprintf output for escape-free values; quotes/backslashes escaped per JSON; ampersand/angle-brackets verbatim (proves SetEscapeHTML(false)); invert:false always present
+  - Quoting: leading-# field quoted; single-empty-field row rendered as a quoted empty string not a blank line
+  - JSON-renderer regression: DrawIOConnection key casing in JSON document output unchanged (guards Decision 14 mirror struct)
+  - Blocked-by: ih3bs6w (Implement columns field, DrawIOOption, and constructor/builder plumbing)
+  - Stream: 1
+  - Requirements: [3.3](requirements.md#3.3), [3.5](requirements.md#3.5), [3.6](requirements.md#3.6)
+
+- [ ] 4. Implement renderer changes: explicit columns, connect JSON encoder, quoting rules <!-- id:ih3bs6y -->
+  - v2/graph_renderers.go renderDrawIOContent: use GetColumns() when non-empty; fall back to extractColumnNames
+  - writeDrawIOHeader: emit connect via drawioConnectionJSON mirror struct (json tags from/to/invert/label/style; no omitempty on Invert) with json.Encoder + SetEscapeHTML(false); Encode trailing newline is the line terminator
+  - writeCSVRow: also quote fields starting with # and a single empty sole field
+  - Place drawioConnectionJSON in the new v2/drawio_reader.go per design (created here; parser added later)
+  - Blocked-by: ih3bs6x (Write failing tests for drawio renderer output changes)
+  - Stream: 1
+  - Requirements: [3.3](requirements.md#3.3), [3.5](requirements.md#3.5), [3.6](requirements.md#3.6)
+
+## Parser
+
+- [ ] 5. Define parser API surface and write failing core parser tests <!-- id:ih3bs6z -->
+  - v2/drawio_reader.go: ParsedDrawIO struct; ParseDrawIOCSV/ParseDrawIOFile stubs; sentinel error vars (types/wiring exempt from TDD)
+  - v2/drawio_reader_test.go map-based table tests: all 18 directive keys map to DrawIOHeader fields; grammar is case-sensitive exact-prefix with verbatim untrimmed values; CRLF handling (\r\n stripped / lone \r kept)
+  - Tolerance: unknown directives and non-directive comments ignored; scalar duplicates last-wins; connect append-all preserving order with unknown JSON keys ignored
+  - Zero-value header when directives absent (never DefaultDrawIOHeader); BOM tolerated; blank lines skipped; empty cells materialize as empty string for every column; records and columns in file order; zero-data-rows returns columns + empty records
+  - Stream: 1
+  - Requirements: [1.1](requirements.md#1.1), [1.2](requirements.md#1.2), [1.3](requirements.md#1.3), [1.4](requirements.md#1.4), [1.6](requirements.md#1.6), [2.1](requirements.md#2.1), [2.2](requirements.md#2.2), [2.3](requirements.md#2.3), [2.4](requirements.md#2.4), [2.5](requirements.md#2.5)
+
+- [ ] 6. Implement ParseDrawIOCSV/ParseDrawIOFile core pipeline <!-- id:ih3bs70 -->
+  - Pipeline per design: BOM strip, directive pre-pass, quote-parity scan seeded at the column header line, csv.Reader with no Comment mode and FieldsPerRecord enforcement, empty-string fill
+  - Connect unmarshal via drawioConnectionJSON (from task 4)
+  - TrimLeadingSpace stays false
+  - Blocked-by: ih3bs6y (Implement renderer changes: explicit columns, connect JSON encoder, quoting rules), ih3bs6z (Define parser API surface and write failing core parser tests)
+  - Stream: 1
+  - Requirements: [1.1](requirements.md#1.1), [1.2](requirements.md#1.2), [1.3](requirements.md#1.3), [1.4](requirements.md#1.4), [1.6](requirements.md#1.6), [2.1](requirements.md#2.1), [2.2](requirements.md#2.2), [2.3](requirements.md#2.3), [2.4](requirements.md#2.4), [2.5](requirements.md#2.5)
+
+- [ ] 7. Write failing error-handling and edge-case parser tests <!-- id:ih3bs71 -->
+  - Per-sentinel tests asserting errors.Is plus directive/line context: connect unparseable (4.1); non-integer numeric incl. superseded occurrence (4.2); field-count mismatch with line context (4.3); empty/comment-only input (4.4); trailing directive after data incl. precedence over field-count on the same line (4.5); duplicate column names (4.6)
+  - Edge cases: leading-# data row parses as data (1.5); quoted fields with commas/quotes/newlines (3.4); multi-line quoted column header name; parity-scan-vs-csv quote-model disagreement case pinning which error fires
+  - 4.7: error-returning io.Reader (mid-stream non-EOF) surfaces as error; ParseDrawIOFile wraps os.Open errors; nothing panics
+  - Blocked-by: ih3bs70 (Implement ParseDrawIOCSV/ParseDrawIOFile core pipeline)
+  - Stream: 1
+  - Requirements: [1.5](requirements.md#1.5), [3.4](requirements.md#3.4), [4.1](requirements.md#4.1), [4.2](requirements.md#4.2), [4.3](requirements.md#4.3), [4.4](requirements.md#4.4), [4.5](requirements.md#4.5), [4.6](requirements.md#4.6), [4.7](requirements.md#4.7)
+
+- [ ] 8. Implement parser error handling and edge cases <!-- id:ih3bs72 -->
+  - Sentinels: ErrDrawIONoColumnHeader, ErrDrawIOTrailingDirective, ErrDrawIODuplicateColumn, ErrDrawIODirective (per design Error Handling table)
+  - Whole-section parity scan runs before csv parsing so 4.5 wins over 4.3
+  - Blocked-by: ih3bs71 (Write failing error-handling and edge-case parser tests)
+  - Stream: 1
+  - Requirements: [1.5](requirements.md#1.5), [3.4](requirements.md#3.4), [4.1](requirements.md#4.1), [4.2](requirements.md#4.2), [4.3](requirements.md#4.3), [4.4](requirements.md#4.4), [4.5](requirements.md#4.5), [4.6](requirements.md#4.6), [4.7](requirements.md#4.7)
+
+## Round-trip and validation
+
+- [ ] 9. Add property-based round-trip tests and golden example <!-- id:ih3bs73 -->
+  - Add pgregory.net/rapid as test-only dependency (go.mod via make mod-tidy)
+  - Idempotency property (3.1): render-parse-render-parse-render; second and third renders byte-equal
+  - Byte-identity property (3.2): CR-free generated content; first re-render equals first render
+  - No-panic property (4.7): arbitrary bytes plus directive-biased generator emitting connect/padding lines so unmarshal/Atoi paths are reached
+  - Generator constraints encode documented carve-outs: no newline/CR in header string fields; unique column names; record keys subset of columns
+  - Golden example: awstools-style file with connections, identity, parent, layout none + left/top
+  - Fix any implementation bugs the properties surface
+  - Blocked-by: ih3bs72 (Implement parser error handling and edge cases)
+  - Stream: 1
+  - Requirements: [3.1](requirements.md#3.1), [3.2](requirements.md#3.2), [4.7](requirements.md#4.7)
+
+- [ ] 10. Run full validation pipeline and fix findings <!-- id:ih3bs74 -->
+  - make check (fmt + lint + tests) and make modernize; fix all findings
+  - Verify existing drawio and JSON/YAML renderer tests still pass unchanged (byte-compat and key-casing guards)
+  - Blocked-by: ih3bs73 (Add property-based round-trip tests and golden example)
+  - Stream: 1

--- a/specs/drawio-csv-reader/tasks.md
+++ b/specs/drawio-csv-reader/tasks.md
@@ -46,7 +46,7 @@ references:
 
 ## Parser
 
-- [ ] 5. Define parser API surface and write failing core parser tests <!-- id:ih3bs6z -->
+- [x] 5. Define parser API surface and write failing core parser tests <!-- id:ih3bs6z -->
   - v2/drawio_reader.go: ParsedDrawIO struct; ParseDrawIOCSV/ParseDrawIOFile stubs; sentinel error vars (types/wiring exempt from TDD)
   - v2/drawio_reader_test.go map-based table tests: all 18 directive keys map to DrawIOHeader fields; grammar is case-sensitive exact-prefix with verbatim untrimmed values; CRLF handling (\r\n stripped / lone \r kept)
   - Tolerance: unknown directives and non-directive comments ignored; scalar duplicates last-wins; connect append-all preserving order with unknown JSON keys ignored
@@ -54,7 +54,7 @@ references:
   - Stream: 1
   - Requirements: [1.1](requirements.md#1.1), [1.2](requirements.md#1.2), [1.3](requirements.md#1.3), [1.4](requirements.md#1.4), [1.6](requirements.md#1.6), [2.1](requirements.md#2.1), [2.2](requirements.md#2.2), [2.3](requirements.md#2.3), [2.4](requirements.md#2.4), [2.5](requirements.md#2.5)
 
-- [ ] 6. Implement ParseDrawIOCSV/ParseDrawIOFile core pipeline <!-- id:ih3bs70 -->
+- [x] 6. Implement ParseDrawIOCSV/ParseDrawIOFile core pipeline <!-- id:ih3bs70 -->
   - Pipeline per design: BOM strip, directive pre-pass, quote-parity scan seeded at the column header line, csv.Reader with no Comment mode and FieldsPerRecord enforcement, empty-string fill
   - Connect unmarshal via drawioConnectionJSON (from task 4)
   - TrimLeadingSpace stays false
@@ -62,7 +62,7 @@ references:
   - Stream: 1
   - Requirements: [1.1](requirements.md#1.1), [1.2](requirements.md#1.2), [1.3](requirements.md#1.3), [1.4](requirements.md#1.4), [1.6](requirements.md#1.6), [2.1](requirements.md#2.1), [2.2](requirements.md#2.2), [2.3](requirements.md#2.3), [2.4](requirements.md#2.4), [2.5](requirements.md#2.5)
 
-- [ ] 7. Write failing error-handling and edge-case parser tests <!-- id:ih3bs71 -->
+- [x] 7. Write failing error-handling and edge-case parser tests <!-- id:ih3bs71 -->
   - Per-sentinel tests asserting errors.Is plus directive/line context: connect unparseable (4.1); non-integer numeric incl. superseded occurrence (4.2); field-count mismatch with line context (4.3); empty/comment-only input (4.4); trailing directive after data incl. precedence over field-count on the same line (4.5); duplicate column names (4.6)
   - Edge cases: leading-# data row parses as data (1.5); quoted fields with commas/quotes/newlines (3.4); multi-line quoted column header name; parity-scan-vs-csv quote-model disagreement case pinning which error fires
   - 4.7: error-returning io.Reader (mid-stream non-EOF) surfaces as error; ParseDrawIOFile wraps os.Open errors; nothing panics
@@ -70,7 +70,7 @@ references:
   - Stream: 1
   - Requirements: [1.5](requirements.md#1.5), [3.4](requirements.md#3.4), [4.1](requirements.md#4.1), [4.2](requirements.md#4.2), [4.3](requirements.md#4.3), [4.4](requirements.md#4.4), [4.5](requirements.md#4.5), [4.6](requirements.md#4.6), [4.7](requirements.md#4.7)
 
-- [ ] 8. Implement parser error handling and edge cases <!-- id:ih3bs72 -->
+- [x] 8. Implement parser error handling and edge cases <!-- id:ih3bs72 -->
   - Sentinels: ErrDrawIONoColumnHeader, ErrDrawIOTrailingDirective, ErrDrawIODuplicateColumn, ErrDrawIODirective (per design Error Handling table)
   - Whole-section parity scan runs before csv parsing so 4.5 wins over 4.3
   - Blocked-by: ih3bs71 (Write failing error-handling and edge-case parser tests)

--- a/v2/docs/API.md
+++ b/v2/docs/API.md
@@ -419,8 +419,69 @@ func (b *Builder) GanttChart(title string, tasks []GanttTask) *Builder
 // PieChart adds a pie chart with slices
 func (b *Builder) PieChart(title string, slices []PieSlice, showData bool) *Builder
 
-// DrawIO adds Draw.io diagram content
-func (b *Builder) DrawIO(title string, records []Record, header DrawIOHeader) *Builder
+// DrawIO adds Draw.io diagram content. Options configure the content, e.g.
+// WithDrawIOColumns sets an explicit CSV column order.
+func (b *Builder) DrawIO(title string, records []Record, header DrawIOHeader, opts ...DrawIOOption) *Builder
+```
+
+#### Draw.io CSV Parsing
+
+Parse draw.io CSV files (as written by the Draw.io renderer) back into header
+directives, column order, and records — for example to append rows to an
+existing diagram file:
+
+```go
+// ParsedDrawIO holds the result of parsing a draw.io CSV file
+type ParsedDrawIO struct {
+    Header  DrawIOHeader // zero-valued fields for absent directives
+    Columns []string     // column header row, file order
+    Records []Record     // file order; every column present, "" for empty cells
+}
+
+// ParseDrawIOCSV parses draw.io CSV from a reader
+func ParseDrawIOCSV(r io.Reader) (*ParsedDrawIO, error)
+
+// ParseDrawIOFile opens path and parses it with ParseDrawIOCSV
+func ParseDrawIOFile(path string) (*ParsedDrawIO, error)
+
+// DrawIOOption configures DrawIOContent during construction
+type DrawIOOption func(*DrawIOContent)
+
+// WithDrawIOColumns sets an explicit column order for draw.io CSV rendering.
+// Record keys absent from columns are not rendered; columns missing from a
+// record render as the empty string.
+func WithDrawIOColumns(columns ...string) DrawIOOption
+
+// GetColumns returns a copy of the explicit column order, or nil when unset
+func (d *DrawIOContent) GetColumns() []string
+```
+
+Parse errors are discriminable with `errors.Is`:
+
+```go
+var (
+    ErrDrawIONoColumnHeader    // no column header row (empty or comments-only input)
+    ErrDrawIOTrailingDirective // directive after the column header row (second diagram block)
+    ErrDrawIODuplicateColumn   // duplicate name in the column header row
+    ErrDrawIODirective         // invalid directive value (connect JSON or non-integer numeric)
+)
+```
+
+Round-trip example:
+
+```go
+parsed, err := output.ParseDrawIOFile("diagram.csv")
+if err != nil {
+    return err
+}
+parsed.Records = append(parsed.Records, output.Record{"Name": "new-node"})
+
+doc := output.New().
+    DrawIO("diagram", parsed.Records, parsed.Header,
+        output.WithDrawIOColumns(parsed.Columns...)).
+    Build()
+// Rendering with output.DrawIO() reproduces the file with the new row,
+// preserving directive order, column order, and quoting.
 ```
 
 ### Schema System
@@ -2604,7 +2665,7 @@ The v2 API is designed for extensibility:
 | `Graph(title, edges)` | Add graph diagram | `Graph("Flow", edges)` |
 | `GanttChart(title, tasks)` | Add Gantt chart | `GanttChart("Timeline", tasks)` |
 | `PieChart(title, slices, show)` | Add pie chart | `PieChart("Stats", slices, true)` |
-| `DrawIO(title, records, header)` | Add Draw.io diagram | `DrawIO("Architecture", records, header)` |
+| `DrawIO(title, records, header, opts...)` | Add Draw.io diagram | `DrawIO("Architecture", records, header)` |
 | `SetMetadata(key, value)` | Set metadata | `SetMetadata("author", "AI Agent")` |
 | `HasErrors()` | Check for errors | `if builder.HasErrors() {...}` |
 | `Errors()` | Get all errors | `for _, err := range builder.Errors()` |

--- a/v2/docs/MIGRATION.md
+++ b/v2/docs/MIGRATION.md
@@ -558,14 +558,36 @@ drawio.SetHeaderValues(drawio.Header{
 
 // v2
 doc := output.New().
-    DrawIO("Architecture", data,
-        output.WithDrawIOLayout("horizontalflow"),
-        output.WithDrawIOLabel("%Name%"),
-        output.WithDrawIOStyle("%Image%"),
-    ).
+    DrawIO("Architecture", data, output.DrawIOHeader{
+        Label:  "%Name%",
+        Style:  "%Image%",
+        Layout: "horizontalflow",
+    }).
     Build()
 
 out := output.NewOutput(output.WithFormat(output.DrawIO))
+```
+
+#### Draw.io CSV Parsing
+
+v1's `drawio.GetHeaderAndContentsFromFile` is replaced by `output.ParseDrawIOFile`
+(or `output.ParseDrawIOCSV` for an `io.Reader`):
+
+```go
+// v1
+header, contents, err := drawio.GetHeaderAndContentsFromFile("diagram.csv")
+
+// v2
+parsed, err := output.ParseDrawIOFile("diagram.csv")
+// parsed.Header  - DrawIOHeader with the file's directives
+// parsed.Columns - column order as it appears in the file
+// parsed.Records - data rows in file order
+
+// Re-render (round-trip) with the parsed column order preserved:
+doc := output.New().
+    DrawIO("diagram", parsed.Records, parsed.Header,
+        output.WithDrawIOColumns(parsed.Columns...)).
+    Build()
 ```
 
 #### AWS Icons for Draw.io

--- a/v2/document.go
+++ b/v2/document.go
@@ -229,8 +229,8 @@ func (b *Builder) PieChart(title string, slices []PieSlice, showData bool) *Buil
 }
 
 // DrawIO adds Draw.io diagram content with CSV configuration
-func (b *Builder) DrawIO(title string, records []Record, header DrawIOHeader) *Builder {
-	drawioContent := NewDrawIOContent(title, records, header)
+func (b *Builder) DrawIO(title string, records []Record, header DrawIOHeader, opts ...DrawIOOption) *Builder {
+	drawioContent := NewDrawIOContent(title, records, header, opts...)
 	return b.AddContent(drawioContent)
 }
 

--- a/v2/drawio_columns_test.go
+++ b/v2/drawio_columns_test.go
@@ -1,0 +1,117 @@
+package output
+
+import (
+	"slices"
+	"testing"
+)
+
+// TestWithDrawIOColumns_NewDrawIOContent verifies that the WithDrawIOColumns
+// option sets an explicit column order on content built via NewDrawIOContent.
+func TestWithDrawIOColumns_NewDrawIOContent(t *testing.T) {
+	records := []Record{
+		{"Beta": "1", "Alpha": "2"},
+	}
+
+	content := NewDrawIOContent("ordered", records, DrawIOHeader{}, WithDrawIOColumns("Beta", "Alpha"))
+
+	got := content.GetColumns()
+	want := []string{"Beta", "Alpha"}
+	if !slices.Equal(got, want) {
+		t.Errorf("GetColumns() = %v, want %v", got, want)
+	}
+}
+
+// TestWithDrawIOColumns_BuilderDrawIO verifies that Builder.DrawIO forwards
+// DrawIOOption values to the underlying NewDrawIOContent call.
+func TestWithDrawIOColumns_BuilderDrawIO(t *testing.T) {
+	doc := New().
+		DrawIO("forwarded", []Record{{"Beta": "1", "Alpha": "2"}}, DrawIOHeader{}, WithDrawIOColumns("Beta", "Alpha")).
+		Build()
+
+	contents := doc.GetContents()
+	if len(contents) != 1 {
+		t.Fatalf("len(GetContents()) = %d, want 1", len(contents))
+	}
+
+	drawioContent, ok := contents[0].(*DrawIOContent)
+	if !ok {
+		t.Fatalf("content type = %T, want *DrawIOContent", contents[0])
+	}
+
+	got := drawioContent.GetColumns()
+	want := []string{"Beta", "Alpha"}
+	if !slices.Equal(got, want) {
+		t.Errorf("GetColumns() = %v, want %v", got, want)
+	}
+}
+
+// TestDrawIOContent_GetColumnsDefensiveCopy verifies that mutating the slice
+// returned by GetColumns does not affect the content's internal state.
+func TestDrawIOContent_GetColumnsDefensiveCopy(t *testing.T) {
+	content := NewDrawIOContent("copy", nil, DrawIOHeader{}, WithDrawIOColumns("Beta", "Alpha"))
+
+	got := content.GetColumns()
+	if len(got) != 2 {
+		t.Fatalf("GetColumns() returned %d columns, want 2", len(got))
+	}
+
+	got[0] = "mutated"
+
+	want := []string{"Beta", "Alpha"}
+	if again := content.GetColumns(); !slices.Equal(again, want) {
+		t.Errorf("after mutating returned slice, GetColumns() = %v, want %v", again, want)
+	}
+}
+
+// TestDrawIOContent_CloneCopiesColumns verifies that Clone deep-copies the
+// columns slice so the clone and the original do not share backing storage.
+func TestDrawIOContent_CloneCopiesColumns(t *testing.T) {
+	content := NewDrawIOContent("clone", nil, DrawIOHeader{}, WithDrawIOColumns("Beta", "Alpha"))
+
+	clone, ok := content.Clone().(*DrawIOContent)
+	if !ok {
+		t.Fatalf("Clone() type = %T, want *DrawIOContent", content.Clone())
+	}
+
+	want := []string{"Beta", "Alpha"}
+	if !slices.Equal(clone.columns, want) {
+		t.Fatalf("clone columns = %v, want %v", clone.columns, want)
+	}
+
+	clone.columns[0] = "mutated"
+
+	if !slices.Equal(content.columns, want) {
+		t.Errorf("mutating clone columns changed original: got %v, want %v", content.columns, want)
+	}
+}
+
+// TestNewDrawIOContentFromTable_CapturesSchemaOrder verifies that the
+// from-table constructor records the table schema's field order (Decision 13)
+// instead of leaving columns empty for the renderer to alphabetize.
+func TestNewDrawIOContentFromTable_CapturesSchemaOrder(t *testing.T) {
+	records := []Record{
+		{"Name": "Server1", "Type": "Web"},
+	}
+	table, err := NewTableContent("table", records, WithKeys("Type", "Name"))
+	if err != nil {
+		t.Fatalf("NewTableContent failed: %v", err)
+	}
+
+	content := NewDrawIOContentFromTable(table, DrawIOHeader{})
+
+	got := content.GetColumns()
+	want := []string{"Type", "Name"}
+	if !slices.Equal(got, want) {
+		t.Errorf("GetColumns() = %v, want %v", got, want)
+	}
+}
+
+// TestNewDrawIOContentFromTable_NilTableNilColumns verifies the nil-table
+// path leaves the columns slice nil (Decision 13).
+func TestNewDrawIOContentFromTable_NilTableNilColumns(t *testing.T) {
+	content := NewDrawIOContentFromTable(nil, DrawIOHeader{})
+
+	if got := content.GetColumns(); got != nil {
+		t.Errorf("GetColumns() = %v, want nil", got)
+	}
+}

--- a/v2/drawio_csv_test.go
+++ b/v2/drawio_csv_test.go
@@ -275,6 +275,186 @@ func TestDrawIOBuilder_Integration(t *testing.T) {
 	}
 }
 
+func TestDrawIORenderer_ExplicitColumnOrder(t *testing.T) {
+	tests := map[string]struct {
+		content *DrawIOContent
+		want    string
+	}{
+		"explicit columns override alphabetical order": {
+			content: NewDrawIOContent("ordered", []Record{
+				{"Alpha": "1", "Beta": "2"},
+			}, DrawIOHeader{}, WithDrawIOColumns("Beta", "Alpha")),
+			want: "Beta,Alpha\n2,1\n",
+		},
+		"column header row written with zero records": {
+			content: NewDrawIOContent("empty", nil, DrawIOHeader{}, WithDrawIOColumns("Beta", "Alpha")),
+			want:    "Beta,Alpha\n",
+		},
+		"record keys outside column list are dropped": {
+			content: NewDrawIOContent("dropped", []Record{
+				{"Alpha": "1", "Hidden": "secret"},
+			}, DrawIOHeader{}, WithDrawIOColumns("Alpha")),
+			want: "Alpha\n1\n",
+		},
+		"columns missing from a record render empty": {
+			content: NewDrawIOContent("missing", []Record{
+				{"Beta": "2"},
+			}, DrawIOHeader{}, WithDrawIOColumns("Beta", "Alpha")),
+			want: "Beta,Alpha\n2,\n",
+		},
+		"no explicit columns falls back to alphabetical": {
+			content: NewDrawIOContent("fallback", []Record{
+				{"Beta": "2", "Alpha": "1"},
+			}, DrawIOHeader{}),
+			want: "Alpha,Beta\n1,2\n",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			doc := New().AddContent(tt.content).Build()
+			renderer := &drawioRenderer{}
+
+			result, err := renderer.Render(context.Background(), doc)
+			if err != nil {
+				t.Fatalf("Render() error = %v", err)
+			}
+
+			if got := string(result); got != tt.want {
+				t.Errorf("Render() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDrawIORenderer_ConnectJSON(t *testing.T) {
+	tests := map[string]struct {
+		conn DrawIOConnection
+		want string
+	}{
+		// Byte-identical to the previous Sprintf-based output for values
+		// that need no escaping.
+		"escape-free values byte-compatible with previous output": {
+			conn: DrawIOConnection{From: "Service", To: "Backend", Label: "Port", Style: DrawIODefaultConnectionStyle},
+			want: `# connect: {"from":"Service","to":"Backend","invert":false,"label":"Port","style":"curved=1;endArrow=blockThin;endFill=1;fontSize=11;"}` + "\n",
+		},
+		"quotes and backslashes escaped per JSON": {
+			conn: DrawIOConnection{From: `a"b`, To: `c\d`},
+			want: `# connect: {"from":"a\"b","to":"c\\d","invert":false,"label":"","style":""}` + "\n",
+		},
+		// Proves SetEscapeHTML(false) is wired: the default encoder would
+		// emit &, <, and > instead.
+		"ampersand and angle brackets verbatim": {
+			conn: DrawIOConnection{From: "a&b", To: "c<d>e"},
+			want: `# connect: {"from":"a&b","to":"c<d>e","invert":false,"label":"","style":""}` + "\n",
+		},
+		"invert true rendered": {
+			conn: DrawIOConnection{From: "x", To: "y", Invert: true},
+			want: `# connect: {"from":"x","to":"y","invert":true,"label":"","style":""}` + "\n",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			content := NewDrawIOContent("connect", nil, DrawIOHeader{
+				Connections: []DrawIOConnection{tt.conn},
+			}, WithDrawIOColumns("Name"))
+			doc := New().AddContent(content).Build()
+			renderer := &drawioRenderer{}
+
+			result, err := renderer.Render(context.Background(), doc)
+			if err != nil {
+				t.Fatalf("Render() error = %v", err)
+			}
+
+			want := tt.want + "Name\n"
+			if got := string(result); got != want {
+				t.Errorf("Render() = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestDrawIORenderer_QuotingRules(t *testing.T) {
+	tests := map[string]struct {
+		content *DrawIOContent
+		want    string
+	}{
+		"field starting with hash is quoted": {
+			content: NewDrawIOContent("hash", []Record{
+				{"Name": "# label: x"},
+			}, DrawIOHeader{}, WithDrawIOColumns("Name")),
+			want: "Name\n\"# label: x\"\n",
+		},
+		"single empty sole field quoted instead of blank line": {
+			content: NewDrawIOContent("empty", []Record{
+				{"Name": ""},
+			}, DrawIOHeader{}, WithDrawIOColumns("Name")),
+			want: "Name\n\"\"\n",
+		},
+		"empty field among multiple fields stays unquoted": {
+			content: NewDrawIOContent("multi", []Record{
+				{"Alpha": "", "Beta": "x"},
+			}, DrawIOHeader{}, WithDrawIOColumns("Alpha", "Beta")),
+			want: "Alpha,Beta\n,x\n",
+		},
+		"hash in the middle of a field stays unquoted": {
+			content: NewDrawIOContent("mid", []Record{
+				{"Name": "a#b"},
+			}, DrawIOHeader{}, WithDrawIOColumns("Name")),
+			want: "Name\na#b\n",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			doc := New().AddContent(tt.content).Build()
+			renderer := &drawioRenderer{}
+
+			result, err := renderer.Render(context.Background(), doc)
+			if err != nil {
+				t.Fatalf("Render() error = %v", err)
+			}
+
+			if got := string(result); got != tt.want {
+				t.Errorf("Render() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestJSONRenderer_DrawIOConnectionKeyCasing guards Decision 14: the drawio
+// CSV wire format uses a private mirror struct, so DrawIOConnection stays
+// untagged and JSON document output keeps its exported-field key casing.
+func TestJSONRenderer_DrawIOConnectionKeyCasing(t *testing.T) {
+	content := NewDrawIOContent("casing", []Record{
+		{"Name": "Server1"},
+	}, DrawIOHeader{
+		Connections: []DrawIOConnection{
+			{From: "Service", To: "Backend", Label: "Port", Style: "curved=1;"},
+		},
+	})
+	doc := New().AddContent(content).Build()
+	renderer := &jsonRenderer{}
+
+	result, err := renderer.Render(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	output := string(result)
+	for _, expected := range []string{`"From": "Service"`, `"To": "Backend"`, `"Invert": false`, `"Label": "Port"`, `"Style": "curved=1;"`} {
+		if !strings.Contains(output, expected) {
+			t.Errorf("JSON output should contain %q, got:\n%s", expected, output)
+		}
+	}
+	for _, unexpected := range []string{`"from"`, `"to"`, `"invert"`, `"label"`, `"style"`} {
+		if strings.Contains(output, unexpected) {
+			t.Errorf("JSON output should not contain lowercase key %q, got:\n%s", unexpected, output)
+		}
+	}
+}
+
 func TestDefaultDrawIOHeader(t *testing.T) {
 	header := DefaultDrawIOHeader()
 

--- a/v2/drawio_reader.go
+++ b/v2/drawio_reader.go
@@ -1,6 +1,7 @@
 package output
 
 import (
+	"bytes"
 	"encoding/csv"
 	"encoding/json"
 	"errors"
@@ -41,36 +42,60 @@ type ParsedDrawIO struct {
 // drawioUTF8BOM is the UTF-8 byte order mark tolerated at the start of input.
 const drawioUTF8BOM = "\xef\xbb\xbf"
 
-// Directive keys referenced from more than one place in the parser.
+// Directive keys of the draw.io CSV wire format, shared by the writer
+// (writeDrawIOHeader) and the parser so both sides stay in sync.
 const (
 	drawioKeyLabel        = "label"
+	drawioKeyStyle        = "style"
+	drawioKeyIdentity     = "identity"
+	drawioKeyParent       = "parent"
+	drawioKeyParentStyle  = "parentstyle"
+	drawioKeyNamespace    = "namespace"
+	drawioKeyConnect      = "connect"
+	drawioKeyHeight       = "height"
+	drawioKeyWidth        = "width"
+	drawioKeyIgnore       = "ignore"
 	drawioKeyNodeSpacing  = "nodespacing"
 	drawioKeyLevelSpacing = "levelspacing"
 	drawioKeyEdgeSpacing  = "edgespacing"
 	drawioKeyPadding      = "padding"
+	drawioKeyLink         = "link"
+	drawioKeyLeft         = "left"
+	drawioKeyTop          = "top"
+	drawioKeyLayout       = "layout"
 )
 
 // drawioDirectiveKeys is the set of directive keys the v2 renderer emits,
 // matched case-sensitively (requirement 2.1).
 var drawioDirectiveKeys = map[string]bool{
 	drawioKeyLabel:        true,
-	"style":               true,
-	"identity":            true,
-	"parent":              true,
-	"parentstyle":         true,
-	"namespace":           true,
-	"connect":             true,
-	"height":              true,
-	"width":               true,
-	"ignore":              true,
+	drawioKeyStyle:        true,
+	drawioKeyIdentity:     true,
+	drawioKeyParent:       true,
+	drawioKeyParentStyle:  true,
+	drawioKeyNamespace:    true,
+	drawioKeyConnect:      true,
+	drawioKeyHeight:       true,
+	drawioKeyWidth:        true,
+	drawioKeyIgnore:       true,
 	drawioKeyNodeSpacing:  true,
 	drawioKeyLevelSpacing: true,
 	drawioKeyEdgeSpacing:  true,
 	drawioKeyPadding:      true,
-	"link":                true,
-	"left":                true,
-	"top":                 true,
-	"layout":              true,
+	drawioKeyLink:         true,
+	drawioKeyLeft:         true,
+	drawioKeyTop:          true,
+	drawioKeyLayout:       true,
+}
+
+// writeDrawIODirective writes one directive line in the exact grammar the
+// parser recognizes: "# " + key + ": " + value + "\n".
+func writeDrawIODirective(buf *bytes.Buffer, key, value string) {
+	buf.WriteString("# ")
+	buf.WriteString(key)
+	buf.WriteString(": ")
+	buf.WriteString(value)
+	buf.WriteByte('\n')
 }
 
 // ParseDrawIOCSV parses draw.io CSV (as written by the drawio renderer) from
@@ -226,27 +251,27 @@ func applyDrawIODirective(h *DrawIOHeader, line string, lineNum int) error {
 	switch key {
 	case drawioKeyLabel:
 		h.Label = value
-	case "style":
+	case drawioKeyStyle:
 		h.Style = value
-	case "identity":
+	case drawioKeyIdentity:
 		h.Identity = value
-	case "parent":
+	case drawioKeyParent:
 		h.Parent = value
-	case "parentstyle":
+	case drawioKeyParentStyle:
 		h.ParentStyle = value
-	case "namespace":
+	case drawioKeyNamespace:
 		h.Namespace = value
-	case "connect":
+	case drawioKeyConnect:
 		var conn drawioConnectionJSON
 		if err := json.Unmarshal([]byte(value), &conn); err != nil {
 			return fmt.Errorf("%w: line %d: connect: %v", ErrDrawIODirective, lineNum, err)
 		}
 		h.Connections = append(h.Connections, DrawIOConnection(conn))
-	case "height":
+	case drawioKeyHeight:
 		h.Height = value
-	case "width":
+	case drawioKeyWidth:
 		h.Width = value
-	case "ignore":
+	case drawioKeyIgnore:
 		h.Ignore = value
 	case drawioKeyNodeSpacing, drawioKeyLevelSpacing, drawioKeyEdgeSpacing, drawioKeyPadding:
 		n, err := strconv.Atoi(value)
@@ -263,13 +288,13 @@ func applyDrawIODirective(h *DrawIOHeader, line string, lineNum int) error {
 		case drawioKeyPadding:
 			h.Padding = n
 		}
-	case "link":
+	case drawioKeyLink:
 		h.Link = value
-	case "left":
+	case drawioKeyLeft:
 		h.Left = value
-	case "top":
+	case drawioKeyTop:
 		h.Top = value
-	case "layout":
+	case drawioKeyLayout:
 		h.Layout = value
 	}
 	return nil

--- a/v2/drawio_reader.go
+++ b/v2/drawio_reader.go
@@ -1,5 +1,280 @@
 package output
 
+import (
+	"encoding/csv"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Sentinel errors returned by ParseDrawIOCSV/ParseDrawIOFile. All are wrapped
+// with additional line/directive context via fmt.Errorf("%w: ...") so callers
+// can discriminate with errors.Is while messages stay informative.
+var (
+	// ErrDrawIONoColumnHeader indicates the input contains no column header
+	// row (empty input, or comments and blank lines only). Requirement 4.4.
+	ErrDrawIONoColumnHeader = errors.New("drawio csv: no column header row")
+	// ErrDrawIOTrailingDirective indicates a recognized directive line was
+	// found after the column header row, e.g. the start of a second diagram
+	// block. Requirement 4.5.
+	ErrDrawIOTrailingDirective = errors.New("drawio csv: directive after column header row")
+	// ErrDrawIODuplicateColumn indicates the column header row contains a
+	// duplicate column name. Requirement 4.6.
+	ErrDrawIODuplicateColumn = errors.New("drawio csv: duplicate column name")
+	// ErrDrawIODirective indicates a recognized directive has an invalid
+	// value: unparseable connect JSON or a non-integer numeric value.
+	// Requirements 4.1 and 4.2.
+	ErrDrawIODirective = errors.New("drawio csv: invalid directive")
+)
+
+// ParsedDrawIO holds the result of parsing a draw.io CSV file.
+type ParsedDrawIO struct {
+	Header  DrawIOHeader // zero-valued fields for absent directives
+	Columns []string     // column header row, file order
+	Records []Record     // file order; every column present, "" for empty cells
+}
+
+// drawioUTF8BOM is the UTF-8 byte order mark tolerated at the start of input.
+const drawioUTF8BOM = "\xef\xbb\xbf"
+
+// Directive keys referenced from more than one place in the parser.
+const (
+	drawioKeyLabel        = "label"
+	drawioKeyNodeSpacing  = "nodespacing"
+	drawioKeyLevelSpacing = "levelspacing"
+	drawioKeyEdgeSpacing  = "edgespacing"
+	drawioKeyPadding      = "padding"
+)
+
+// drawioDirectiveKeys is the set of directive keys the v2 renderer emits,
+// matched case-sensitively (requirement 2.1).
+var drawioDirectiveKeys = map[string]bool{
+	drawioKeyLabel:        true,
+	"style":               true,
+	"identity":            true,
+	"parent":              true,
+	"parentstyle":         true,
+	"namespace":           true,
+	"connect":             true,
+	"height":              true,
+	"width":               true,
+	"ignore":              true,
+	drawioKeyNodeSpacing:  true,
+	drawioKeyLevelSpacing: true,
+	drawioKeyEdgeSpacing:  true,
+	drawioKeyPadding:      true,
+	"link":                true,
+	"left":                true,
+	"top":                 true,
+	"layout":              true,
+}
+
+// ParseDrawIOCSV parses draw.io CSV (as written by the drawio renderer) from
+// r into its header directives, column order, and data records. Absent
+// directives leave the corresponding DrawIOHeader field zero-valued; the
+// DefaultDrawIOHeader values are never substituted.
+func ParseDrawIOCSV(r io.Reader) (*ParsedDrawIO, error) {
+	data, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("drawio csv: reading input: %w", err)
+	}
+
+	// Strip an optional UTF-8 byte order mark (requirement 1.6).
+	text := strings.TrimPrefix(string(data), drawioUTF8BOM)
+	lines := splitDrawIOLines(text)
+
+	// Directive pre-pass: consume directive/comment/blank lines until the
+	// first non-comment, non-blank line, which is the column header row.
+	header := DrawIOHeader{}
+	headerIdx := -1
+	for i, line := range lines {
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "#") {
+			if err := applyDrawIODirective(&header, line, i+1); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		headerIdx = i
+		break
+	}
+	if headerIdx == -1 {
+		return nil, fmt.Errorf("%w: input contains only directives, comments, or blank lines", ErrDrawIONoColumnHeader)
+	}
+
+	// Quote-parity scan of the data section: detect recognized directive
+	// lines after the column header row (a second diagram block) before csv
+	// parsing, so this error takes precedence over field-count errors. The
+	// state is seeded at the start of the header line so continuation lines
+	// of a multi-line quoted column header are never tested as boundaries.
+	inQuote := false
+	for i := headerIdx; i < len(lines); i++ {
+		line := lines[i]
+		if i > headerIdx && !inQuote {
+			if key, _, ok := matchDrawIODirective(line); ok {
+				return nil, fmt.Errorf("%w: line %d: %q (multiple diagram blocks are not supported)", ErrDrawIOTrailingDirective, i+1, key)
+			}
+		}
+		if strings.Count(line, `"`)%2 == 1 {
+			inQuote = !inQuote
+		}
+	}
+
+	// CSV parse of column header row + data section. No Comment mode (data
+	// rows starting with '#' survive), FieldsPerRecord enforcement via the
+	// first record, TrimLeadingSpace stays false (values verbatim).
+	reader := csv.NewReader(strings.NewReader(strings.Join(lines[headerIdx:], "\n")))
+	columns, err := reader.Read()
+	if err != nil {
+		return nil, adjustDrawIOCSVError(err, headerIdx)
+	}
+
+	seen := make(map[string]bool, len(columns))
+	for _, col := range columns {
+		if seen[col] {
+			return nil, fmt.Errorf("%w: %q", ErrDrawIODuplicateColumn, col)
+		}
+		seen[col] = true
+	}
+
+	records := make([]Record, 0)
+	for {
+		row, err := reader.Read()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, adjustDrawIOCSVError(err, headerIdx)
+		}
+		record := make(Record, len(columns))
+		for j, col := range columns {
+			record[col] = row[j]
+		}
+		records = append(records, record)
+	}
+
+	return &ParsedDrawIO{Header: header, Columns: columns, Records: records}, nil
+}
+
+// ParseDrawIOFile opens path and parses it with ParseDrawIOCSV.
+func ParseDrawIOFile(path string) (*ParsedDrawIO, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("drawio csv: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+	return ParseDrawIOCSV(f)
+}
+
+// adjustDrawIOCSVError shifts a *csv.ParseError's line numbers from
+// data-section coordinates (the csv.Reader only sees the input from the
+// column header row onward) to whole-file coordinates so the reported line
+// context matches the file (requirement 4.3). Non-ParseError errors pass
+// through unchanged.
+func adjustDrawIOCSVError(err error, headerIdx int) error {
+	var pe *csv.ParseError
+	if errors.As(err, &pe) {
+		pe.Line += headerIdx
+		pe.StartLine += headerIdx
+	}
+	return err
+}
+
+// splitDrawIOLines splits input into physical lines on '\n', stripping a
+// preceding '\r' (CRLF) while keeping lone '\r' characters — matching
+// encoding/csv semantics so directives and data normalize identically on
+// CRLF files.
+func splitDrawIOLines(s string) []string {
+	lines := strings.Split(s, "\n")
+	for i, line := range lines {
+		lines[i] = strings.TrimSuffix(line, "\r")
+	}
+	return lines
+}
+
+// matchDrawIODirective reports whether line matches the directive grammar:
+// the exact prefix "# " + recognized key + ": ", with the value taken
+// verbatim (untrimmed) to the end of the line. Keys are case-sensitive.
+func matchDrawIODirective(line string) (key, value string, ok bool) {
+	rest, found := strings.CutPrefix(line, "# ")
+	if !found {
+		return "", "", false
+	}
+	key, value, found = strings.Cut(rest, ": ")
+	if !found || !drawioDirectiveKeys[key] {
+		return "", "", false
+	}
+	return key, value, true
+}
+
+// applyDrawIODirective applies a single comment line from the header block to
+// h. Lines that do not match a recognized directive are ignored (requirement
+// 2.4). Scalar directives are last-wins; connect is append-all (requirements
+// 2.2, 2.5). Numeric and connect values are validated on every occurrence,
+// even when later superseded (requirements 4.1, 4.2).
+func applyDrawIODirective(h *DrawIOHeader, line string, lineNum int) error {
+	key, value, ok := matchDrawIODirective(line)
+	if !ok {
+		return nil
+	}
+	switch key {
+	case drawioKeyLabel:
+		h.Label = value
+	case "style":
+		h.Style = value
+	case "identity":
+		h.Identity = value
+	case "parent":
+		h.Parent = value
+	case "parentstyle":
+		h.ParentStyle = value
+	case "namespace":
+		h.Namespace = value
+	case "connect":
+		var conn drawioConnectionJSON
+		if err := json.Unmarshal([]byte(value), &conn); err != nil {
+			return fmt.Errorf("%w: line %d: connect: %v", ErrDrawIODirective, lineNum, err)
+		}
+		h.Connections = append(h.Connections, DrawIOConnection(conn))
+	case "height":
+		h.Height = value
+	case "width":
+		h.Width = value
+	case "ignore":
+		h.Ignore = value
+	case drawioKeyNodeSpacing, drawioKeyLevelSpacing, drawioKeyEdgeSpacing, drawioKeyPadding:
+		n, err := strconv.Atoi(value)
+		if err != nil {
+			return fmt.Errorf("%w: line %d: %s: %q is not an integer", ErrDrawIODirective, lineNum, key, value)
+		}
+		switch key {
+		case drawioKeyNodeSpacing:
+			h.NodeSpacing = n
+		case drawioKeyLevelSpacing:
+			h.LevelSpacing = n
+		case drawioKeyEdgeSpacing:
+			h.EdgeSpacing = n
+		case drawioKeyPadding:
+			h.Padding = n
+		}
+	case "link":
+		h.Link = value
+	case "left":
+		h.Left = value
+	case "top":
+		h.Top = value
+	case "layout":
+		h.Layout = value
+	}
+	return nil
+}
+
 // drawioConnectionJSON pins the draw.io CSV wire format for `# connect:`
 // directive values (Decision 14): keys from/to/invert/label/style in that
 // order, all always present. The public DrawIOConnection stays untagged so

--- a/v2/drawio_reader.go
+++ b/v2/drawio_reader.go
@@ -1,0 +1,15 @@
+package output
+
+// drawioConnectionJSON pins the draw.io CSV wire format for `# connect:`
+// directive values (Decision 14): keys from/to/invert/label/style in that
+// order, all always present. The public DrawIOConnection stays untagged so
+// JSON/YAML document renderers keep their exported-field key casing; this
+// private mirror confines the wire format to the drawio CSV writer and
+// parser.
+type drawioConnectionJSON struct {
+	From   string `json:"from"`
+	To     string `json:"to"`
+	Invert bool   `json:"invert"` // no omitempty: "invert":false is load-bearing for byte identity (requirement 3.5)
+	Label  string `json:"label"`
+	Style  string `json:"style"`
+}

--- a/v2/drawio_reader_test.go
+++ b/v2/drawio_reader_test.go
@@ -1,0 +1,656 @@
+package output
+
+import (
+	"encoding/csv"
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// mustParseDrawIO parses input and fails the test on error.
+func mustParseDrawIO(t *testing.T, input string) *ParsedDrawIO {
+	t.Helper()
+	got, err := ParseDrawIOCSV(strings.NewReader(input))
+	if err != nil {
+		t.Fatalf("ParseDrawIOCSV() error = %v, want nil", err)
+	}
+	if got == nil {
+		t.Fatal("ParseDrawIOCSV() = nil, want non-nil result")
+	}
+	return got
+}
+
+// TestParseDrawIOCSV_DirectiveKeys verifies every directive key the v2
+// renderer emits maps onto its DrawIOHeader field (requirement 2.1, 2.2).
+func TestParseDrawIOCSV_DirectiveKeys(t *testing.T) {
+	tests := map[string]struct {
+		directives string
+		want       DrawIOHeader
+	}{
+		"label": {
+			directives: "# label: %Name%\n",
+			want:       DrawIOHeader{Label: "%Name%"},
+		},
+		"style": {
+			directives: "# style: %Image%\n",
+			want:       DrawIOHeader{Style: "%Image%"},
+		},
+		"identity": {
+			directives: "# identity: ID\n",
+			want:       DrawIOHeader{Identity: "ID"},
+		},
+		"parent": {
+			directives: "# parent: Parent\n",
+			want:       DrawIOHeader{Parent: "Parent"},
+		},
+		"parentstyle": {
+			directives: "# parentstyle: rounded=1\n",
+			want:       DrawIOHeader{ParentStyle: "rounded=1"},
+		},
+		"namespace": {
+			directives: "# namespace: csvimport-\n",
+			want:       DrawIOHeader{Namespace: "csvimport-"},
+		},
+		"connect": {
+			directives: "# connect: {\"from\":\"From\",\"to\":\"Name\",\"invert\":true,\"label\":\"Uses\",\"style\":\"curved=1\"}\n",
+			want: DrawIOHeader{Connections: []DrawIOConnection{
+				{From: "From", To: "Name", Invert: true, Label: "Uses", Style: "curved=1"},
+			}},
+		},
+		"height": {
+			directives: "# height: auto\n",
+			want:       DrawIOHeader{Height: "auto"},
+		},
+		"width": {
+			directives: "# width: 80\n",
+			want:       DrawIOHeader{Width: "80"},
+		},
+		"ignore": {
+			directives: "# ignore: Image\n",
+			want:       DrawIOHeader{Ignore: "Image"},
+		},
+		"nodespacing": {
+			directives: "# nodespacing: 40\n",
+			want:       DrawIOHeader{NodeSpacing: 40},
+		},
+		"levelspacing": {
+			directives: "# levelspacing: 100\n",
+			want:       DrawIOHeader{LevelSpacing: 100},
+		},
+		"edgespacing": {
+			directives: "# edgespacing: 40\n",
+			want:       DrawIOHeader{EdgeSpacing: 40},
+		},
+		"padding": {
+			directives: "# padding: 15\n",
+			want:       DrawIOHeader{Padding: 15},
+		},
+		"link": {
+			directives: "# link: URL\n",
+			want:       DrawIOHeader{Link: "URL"},
+		},
+		"left": {
+			directives: "# left: X\n",
+			want:       DrawIOHeader{Left: "X"},
+		},
+		"top": {
+			directives: "# top: Y\n",
+			want:       DrawIOHeader{Top: "Y"},
+		},
+		"layout": {
+			directives: "# layout: horizontalflow\n",
+			want:       DrawIOHeader{Layout: "horizontalflow"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := mustParseDrawIO(t, tc.directives+"Name\nalpha\n")
+			if !reflect.DeepEqual(got.Header, tc.want) {
+				t.Errorf("Header = %+v, want %+v", got.Header, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseDrawIOCSV_DirectiveGrammar verifies the directive grammar is a
+// case-sensitive exact prefix `# key: ` with the value taken verbatim,
+// untrimmed, to the end of the line (requirements 2.1, 2.4).
+func TestParseDrawIOCSV_DirectiveGrammar(t *testing.T) {
+	tests := map[string]struct {
+		directives string
+		want       DrawIOHeader
+	}{
+		"key is case-sensitive capitalized ignored": {
+			directives: "# Label: x\n",
+			want:       DrawIOHeader{},
+		},
+		"key is case-sensitive uppercase ignored": {
+			directives: "# LABEL: x\n",
+			want:       DrawIOHeader{},
+		},
+		"no space after hash ignored": {
+			directives: "#label: x\n",
+			want:       DrawIOHeader{},
+		},
+		"two spaces after hash ignored": {
+			directives: "#  label: x\n",
+			want:       DrawIOHeader{},
+		},
+		"no space after colon ignored": {
+			directives: "# label:x\n",
+			want:       DrawIOHeader{},
+		},
+		"value keeps leading whitespace verbatim": {
+			directives: "# label:  padded\n",
+			want:       DrawIOHeader{Label: " padded"},
+		},
+		"value keeps trailing whitespace verbatim": {
+			directives: "# label: padded \n",
+			want:       DrawIOHeader{Label: "padded "},
+		},
+		"value may contain colon-space": {
+			directives: "# label: a: b\n",
+			want:       DrawIOHeader{Label: "a: b"},
+		},
+		"value taken to end of line": {
+			directives: "# style: shape=image;html=1\n",
+			want:       DrawIOHeader{Style: "shape=image;html=1"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := mustParseDrawIO(t, tc.directives+"Name\nalpha\n")
+			if !reflect.DeepEqual(got.Header, tc.want) {
+				t.Errorf("Header = %+v, want %+v", got.Header, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseDrawIOCSV_CRLF verifies \r\n line endings are stripped while a
+// lone \r is kept, matching encoding/csv semantics (design parsing pipeline).
+func TestParseDrawIOCSV_CRLF(t *testing.T) {
+	tests := map[string]struct {
+		input       string
+		wantHeader  DrawIOHeader
+		wantColumns []string
+		wantRecords []Record
+	}{
+		"crlf line endings stripped from directives and data": {
+			input:       "# label: %Name%\r\nName\r\nalpha\r\n",
+			wantHeader:  DrawIOHeader{Label: "%Name%"},
+			wantColumns: []string{"Name"},
+			wantRecords: []Record{{"Name": "alpha"}},
+		},
+		"lone carriage return kept in directive value": {
+			input:       "# label: a\rb\nName\nalpha\n",
+			wantHeader:  DrawIOHeader{Label: "a\rb"},
+			wantColumns: []string{"Name"},
+			wantRecords: []Record{{"Name": "alpha"}},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := mustParseDrawIO(t, tc.input)
+			if !reflect.DeepEqual(got.Header, tc.wantHeader) {
+				t.Errorf("Header = %+v, want %+v", got.Header, tc.wantHeader)
+			}
+			if !reflect.DeepEqual(got.Columns, tc.wantColumns) {
+				t.Errorf("Columns = %v, want %v", got.Columns, tc.wantColumns)
+			}
+			if !reflect.DeepEqual(got.Records, tc.wantRecords) {
+				t.Errorf("Records = %v, want %v", got.Records, tc.wantRecords)
+			}
+		})
+	}
+}
+
+// TestParseDrawIOCSV_Tolerance verifies unknown directives and non-directive
+// comments are ignored, scalar duplicates are last-wins, and connect is
+// append-all (requirements 2.2, 2.4, 2.5).
+func TestParseDrawIOCSV_Tolerance(t *testing.T) {
+	tests := map[string]struct {
+		directives string
+		want       DrawIOHeader
+	}{
+		"unknown directive key ignored": {
+			directives: "# stylename: foo\n",
+			want:       DrawIOHeader{},
+		},
+		"unrepresented drawio directive ignored": {
+			directives: "# vars: {\"x\":1}\n",
+			want:       DrawIOHeader{},
+		},
+		"comment without key-value structure ignored": {
+			directives: "# just a free-form comment\n",
+			want:       DrawIOHeader{},
+		},
+		"bare hash ignored": {
+			directives: "#\n",
+			want:       DrawIOHeader{},
+		},
+		"double hash ignored": {
+			directives: "## label: x\n",
+			want:       DrawIOHeader{},
+		},
+		"scalar duplicate last wins": {
+			directives: "# label: first\n# label: second\n",
+			want:       DrawIOHeader{Label: "second"},
+		},
+		"numeric duplicate last wins": {
+			directives: "# padding: 1\n# padding: 2\n",
+			want:       DrawIOHeader{Padding: 2},
+		},
+		"connect append-all preserves file order": {
+			directives: "# connect: {\"from\":\"A\",\"to\":\"B\",\"invert\":false,\"label\":\"first\",\"style\":\"s1\"}\n" +
+				"# connect: {\"from\":\"C\",\"to\":\"D\",\"invert\":true,\"label\":\"second\",\"style\":\"s2\"}\n",
+			want: DrawIOHeader{Connections: []DrawIOConnection{
+				{From: "A", To: "B", Invert: false, Label: "first", Style: "s1"},
+				{From: "C", To: "D", Invert: true, Label: "second", Style: "s2"},
+			}},
+		},
+		"connect ignores unknown json keys": {
+			directives: "# connect: {\"from\":\"A\",\"to\":\"B\",\"invert\":false,\"label\":\"L\",\"style\":\"S\",\"extra\":\"ignored\"}\n",
+			want: DrawIOHeader{Connections: []DrawIOConnection{
+				{From: "A", To: "B", Invert: false, Label: "L", Style: "S"},
+			}},
+		},
+		"connect omitted json keys zero-valued": {
+			directives: "# connect: {\"from\":\"A\",\"to\":\"B\"}\n",
+			want: DrawIOHeader{Connections: []DrawIOConnection{
+				{From: "A", To: "B"},
+			}},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := mustParseDrawIO(t, tc.directives+"Name\nalpha\n")
+			if !reflect.DeepEqual(got.Header, tc.want) {
+				t.Errorf("Header = %+v, want %+v", got.Header, tc.want)
+			}
+		})
+	}
+}
+
+// TestParseDrawIOCSV_DataSection verifies BOM tolerance, blank-line skipping,
+// empty-cell fill, file-order preservation, zero-value headers, and the
+// zero-data-rows case (requirements 1.1, 1.3, 1.4, 1.6, 2.3).
+func TestParseDrawIOCSV_DataSection(t *testing.T) {
+	tests := map[string]struct {
+		input       string
+		wantHeader  DrawIOHeader
+		wantColumns []string
+		wantRecords []Record
+	}{
+		"zero-value header when directives absent": {
+			input:       "Name,Image\nalpha,a.png\n",
+			wantHeader:  DrawIOHeader{},
+			wantColumns: []string{"Name", "Image"},
+			wantRecords: []Record{{"Name": "alpha", "Image": "a.png"}},
+		},
+		"utf8 bom tolerated before directives": {
+			input:       "\ufeff# label: %Name%\nName\nalpha\n",
+			wantHeader:  DrawIOHeader{Label: "%Name%"},
+			wantColumns: []string{"Name"},
+			wantRecords: []Record{{"Name": "alpha"}},
+		},
+		"utf8 bom tolerated before column header": {
+			input:       "\ufeffName\nalpha\n",
+			wantHeader:  DrawIOHeader{},
+			wantColumns: []string{"Name"},
+			wantRecords: []Record{{"Name": "alpha"}},
+		},
+		"blank lines skipped everywhere": {
+			input:       "\n# label: x\n\nName\n\nalpha\n\nbeta\n\n",
+			wantHeader:  DrawIOHeader{Label: "x"},
+			wantColumns: []string{"Name"},
+			wantRecords: []Record{{"Name": "alpha"}, {"Name": "beta"}},
+		},
+		"empty cells materialize as empty string": {
+			input:       "A,B,C\n1,,3\n,,\n",
+			wantHeader:  DrawIOHeader{},
+			wantColumns: []string{"A", "B", "C"},
+			wantRecords: []Record{
+				{"A": "1", "B": "", "C": "3"},
+				{"A": "", "B": "", "C": ""},
+			},
+		},
+		"columns and records preserved in file order": {
+			input:       "Zebra,Alpha,Mango\nz1,a1,m1\nz2,a2,m2\nz3,a3,m3\n",
+			wantHeader:  DrawIOHeader{},
+			wantColumns: []string{"Zebra", "Alpha", "Mango"},
+			wantRecords: []Record{
+				{"Zebra": "z1", "Alpha": "a1", "Mango": "m1"},
+				{"Zebra": "z2", "Alpha": "a2", "Mango": "m2"},
+				{"Zebra": "z3", "Alpha": "a3", "Mango": "m3"},
+			},
+		},
+		"zero data rows returns columns and no records": {
+			input:       "# label: %Name%\nName,Image\n",
+			wantHeader:  DrawIOHeader{Label: "%Name%"},
+			wantColumns: []string{"Name", "Image"},
+			wantRecords: []Record{},
+		},
+		"no trailing newline on final data row": {
+			input:       "Name\nalpha",
+			wantHeader:  DrawIOHeader{},
+			wantColumns: []string{"Name"},
+			wantRecords: []Record{{"Name": "alpha"}},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := mustParseDrawIO(t, tc.input)
+			if !reflect.DeepEqual(got.Header, tc.wantHeader) {
+				t.Errorf("Header = %+v, want %+v", got.Header, tc.wantHeader)
+			}
+			if !reflect.DeepEqual(got.Columns, tc.wantColumns) {
+				t.Errorf("Columns = %v, want %v", got.Columns, tc.wantColumns)
+			}
+			if len(got.Records) != len(tc.wantRecords) {
+				t.Fatalf("len(Records) = %d, want %d", len(got.Records), len(tc.wantRecords))
+			}
+			for i, want := range tc.wantRecords {
+				if !reflect.DeepEqual(got.Records[i], want) {
+					t.Errorf("Records[%d] = %v, want %v", i, got.Records[i], want)
+				}
+			}
+		})
+	}
+}
+
+// TestParseDrawIOCSV_DirectiveErrors verifies malformed recognized directives
+// fail with ErrDrawIODirective carrying line and directive context, validated
+// on every occurrence even when superseded (requirements 4.1, 4.2, 2.5).
+func TestParseDrawIOCSV_DirectiveErrors(t *testing.T) {
+	tests := map[string]struct {
+		input        string
+		wantContains []string
+	}{
+		"connect value not json": {
+			input:        "# connect: notjson\nName\nalpha\n",
+			wantContains: []string{"line 1", "connect"},
+		},
+		"connect value wrong json type": {
+			input:        "# connect: {\"from\":1}\nName\nalpha\n",
+			wantContains: []string{"line 1", "connect"},
+		},
+		"connect malformed even when another connect is valid": {
+			input: "# connect: {\"from\":\"A\",\"to\":\"B\",\"invert\":false,\"label\":\"L\",\"style\":\"S\"}\n" +
+				"# connect: {broken\nName\nalpha\n",
+			wantContains: []string{"line 2", "connect"},
+		},
+		"nodespacing non-integer": {
+			input:        "# nodespacing: wide\nName\nalpha\n",
+			wantContains: []string{"line 1", "nodespacing"},
+		},
+		"levelspacing non-integer": {
+			input:        "# levelspacing: 10.5\nName\nalpha\n",
+			wantContains: []string{"line 1", "levelspacing"},
+		},
+		"edgespacing non-integer": {
+			input:        "# edgespacing: \nName\nalpha\n",
+			wantContains: []string{"line 1", "edgespacing"},
+		},
+		"padding non-integer": {
+			input:        "# padding: 5px\nName\nalpha\n",
+			wantContains: []string{"line 1", "padding"},
+		},
+		"padding value not trimmed before validation": {
+			input:        "# padding:  5\nName\nalpha\n",
+			wantContains: []string{"line 1", "padding"},
+		},
+		"superseded malformed numeric still errors": {
+			input:        "# padding: nope\n# padding: 5\nName\nalpha\n",
+			wantContains: []string{"line 1", "padding"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := ParseDrawIOCSV(strings.NewReader(tc.input))
+			if !errors.Is(err, ErrDrawIODirective) {
+				t.Fatalf("ParseDrawIOCSV() error = %v, want errors.Is ErrDrawIODirective", err)
+			}
+			for _, want := range tc.wantContains {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error %q does not contain %q", err.Error(), want)
+				}
+			}
+		})
+	}
+}
+
+// TestParseDrawIOCSV_NoColumnHeader verifies empty or comment/blank-only
+// input fails with ErrDrawIONoColumnHeader (requirement 4.4).
+func TestParseDrawIOCSV_NoColumnHeader(t *testing.T) {
+	tests := map[string]string{
+		"empty input":         "",
+		"blank lines only":    "\n\n\n",
+		"comments only":       "# label: x\n# style: y\n",
+		"comments and blanks": "\n# label: x\n\n# free comment\n\n",
+		"bom only":            "\ufeff",
+	}
+
+	for name, input := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := ParseDrawIOCSV(strings.NewReader(input))
+			if !errors.Is(err, ErrDrawIONoColumnHeader) {
+				t.Fatalf("ParseDrawIOCSV() error = %v, want errors.Is ErrDrawIONoColumnHeader", err)
+			}
+		})
+	}
+}
+
+// TestParseDrawIOCSV_TrailingDirective verifies recognized directive lines
+// after the column header row fail with ErrDrawIOTrailingDirective, taking
+// precedence over field-count errors (requirement 4.5, Decision 9).
+func TestParseDrawIOCSV_TrailingDirective(t *testing.T) {
+	tests := map[string]struct {
+		input        string
+		wantContains []string
+	}{
+		"directive after data rows": {
+			input:        "Name\nalpha\n# label: x\n",
+			wantContains: []string{"line 3", "label"},
+		},
+		"second diagram block detected": {
+			input:        "# label: a\nName\nalpha\n# label: b\nName\nbeta\n",
+			wantContains: []string{"line 4", "label"},
+		},
+		"precedence over field-count mismatch on same line": {
+			input:        "A,B\n1,2\n# layout: auto\n",
+			wantContains: []string{"line 3", "layout"},
+		},
+		"whole-section precedence over earlier field-count mismatch": {
+			input:        "A,B\n1,2,3\n# layout: auto\n",
+			wantContains: []string{"line 3", "layout"},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := ParseDrawIOCSV(strings.NewReader(tc.input))
+			if !errors.Is(err, ErrDrawIOTrailingDirective) {
+				t.Fatalf("ParseDrawIOCSV() error = %v, want errors.Is ErrDrawIOTrailingDirective", err)
+			}
+			for _, want := range tc.wantContains {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error %q does not contain %q", err.Error(), want)
+				}
+			}
+		})
+	}
+}
+
+// TestParseDrawIOCSV_DuplicateColumns verifies duplicate column header names
+// fail with ErrDrawIODuplicateColumn (requirement 4.6).
+func TestParseDrawIOCSV_DuplicateColumns(t *testing.T) {
+	_, err := ParseDrawIOCSV(strings.NewReader("A,B,A\n1,2,3\n"))
+	if !errors.Is(err, ErrDrawIODuplicateColumn) {
+		t.Fatalf("ParseDrawIOCSV() error = %v, want errors.Is ErrDrawIODuplicateColumn", err)
+	}
+	if !strings.Contains(err.Error(), `"A"`) {
+		t.Errorf("error %q does not name the duplicate column", err.Error())
+	}
+}
+
+// TestParseDrawIOCSV_FieldCountMismatch verifies malformed CSV passes through
+// as a *csv.ParseError whose line numbers refer to the whole file, not just
+// the data section (requirement 4.3).
+func TestParseDrawIOCSV_FieldCountMismatch(t *testing.T) {
+	_, err := ParseDrawIOCSV(strings.NewReader("# label: x\nA,B\n1,2,3\n"))
+	if err == nil {
+		t.Fatal("ParseDrawIOCSV() error = nil, want field-count error")
+	}
+	var pe *csv.ParseError
+	if !errors.As(err, &pe) {
+		t.Fatalf("ParseDrawIOCSV() error = %v, want errors.As *csv.ParseError", err)
+	}
+	if pe.Line != 3 {
+		t.Errorf("ParseError.Line = %d, want 3 (file line of the bad row)", pe.Line)
+	}
+	if !strings.Contains(err.Error(), "line 3") {
+		t.Errorf("error %q does not contain file line context %q", err.Error(), "line 3")
+	}
+}
+
+// TestParseDrawIOCSV_DataEdgeCases verifies leading-# data rows parse as data
+// (requirement 1.5) and quoted fields with commas, quotes, and newlines parse
+// correctly, including multi-line quoted column header names (requirement 3.4).
+func TestParseDrawIOCSV_DataEdgeCases(t *testing.T) {
+	tests := map[string]struct {
+		input       string
+		wantColumns []string
+		wantRecords []Record
+	}{
+		"leading hash data row parses as data": {
+			input:       "Name\n#alpha\n",
+			wantColumns: []string{"Name"},
+			wantRecords: []Record{{"Name": "#alpha"}},
+		},
+		"unrecognized directive-like data row parses as data": {
+			input:       "Name\n# vars: x\n",
+			wantColumns: []string{"Name"},
+			wantRecords: []Record{{"Name": "# vars: x"}},
+		},
+		"quoted directive lookalike parses as data": {
+			input:       "Name\n\"# label: x\"\n",
+			wantColumns: []string{"Name"},
+			wantRecords: []Record{{"Name": "# label: x"}},
+		},
+		"quoted fields with commas quotes and newlines": {
+			input:       "Name,Desc\n\"a,b\",\"say \"\"hi\"\"\nsecond line\"\n",
+			wantColumns: []string{"Name", "Desc"},
+			wantRecords: []Record{{"Name": "a,b", "Desc": "say \"hi\"\nsecond line"}},
+		},
+		"multi-line quoted column header name": {
+			input:       "\"Na\nme\",X\n1,2\n",
+			wantColumns: []string{"Na\nme", "X"},
+			wantRecords: []Record{{"Na\nme": "1", "X": "2"}},
+		},
+		"directive lookalike inside multi-line quoted field is data": {
+			input:       "Name\n\"start\n# label: x\nend\"\n",
+			wantColumns: []string{"Name"},
+			wantRecords: []Record{{"Name": "start\n# label: x\nend"}},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := mustParseDrawIO(t, tc.input)
+			if !reflect.DeepEqual(got.Columns, tc.wantColumns) {
+				t.Errorf("Columns = %v, want %v", got.Columns, tc.wantColumns)
+			}
+			if !reflect.DeepEqual(got.Records, tc.wantRecords) {
+				t.Errorf("Records = %v, want %v", got.Records, tc.wantRecords)
+			}
+		})
+	}
+}
+
+// TestParseDrawIOCSV_ParityVsCSVQuoteDisagreement pins which error fires when
+// the parity scan's quote model (parity counting) and csv's (quotes special
+// only at field start) disagree on malformed input: a bare quote mid-field
+// makes the parity scan treat following lines as quoted, so the trailing
+// directive is not flagged and csv's bare-quote ParseError surfaces instead.
+// Both paths fail loudly (design: whole-section scan precedence note).
+func TestParseDrawIOCSV_ParityVsCSVQuoteDisagreement(t *testing.T) {
+	input := "A,B\nx\"q,b\n# label: z\n"
+	_, err := ParseDrawIOCSV(strings.NewReader(input))
+	if err == nil {
+		t.Fatal("ParseDrawIOCSV() error = nil, want bare-quote csv error")
+	}
+	if errors.Is(err, ErrDrawIOTrailingDirective) {
+		t.Fatalf("ParseDrawIOCSV() error = %v, want csv error, not ErrDrawIOTrailingDirective", err)
+	}
+	var pe *csv.ParseError
+	if !errors.As(err, &pe) {
+		t.Fatalf("ParseDrawIOCSV() error = %v, want errors.As *csv.ParseError", err)
+	}
+}
+
+// errDrawIOReader returns its payload, then a non-EOF error mid-stream.
+type errDrawIOReader struct {
+	data string
+	err  error
+	done bool
+}
+
+func (r *errDrawIOReader) Read(p []byte) (int, error) {
+	if !r.done {
+		r.done = true
+		return copy(p, r.data), nil
+	}
+	return 0, r.err
+}
+
+// TestParseDrawIOCSV_ReaderError verifies a mid-stream non-EOF read failure
+// surfaces as a returned error, never a panic (requirement 4.7).
+func TestParseDrawIOCSV_ReaderError(t *testing.T) {
+	wantErr := errors.New("disk exploded")
+	_, err := ParseDrawIOCSV(&errDrawIOReader{data: "Name\nal", err: wantErr})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("ParseDrawIOCSV() error = %v, want errors.Is the reader error", err)
+	}
+}
+
+// TestParseDrawIOFile verifies the file convenience wrapper: happy path and
+// wrapped os.Open errors (requirements 1.2, 4.7).
+func TestParseDrawIOFile(t *testing.T) {
+	t.Run("happy path", func(t *testing.T) {
+		path := filepath.Join(t.TempDir(), "diagram.csv")
+		content := "# label: %Name%\nName,Image\nalpha,a.png\n"
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatalf("writing fixture: %v", err)
+		}
+		got, err := ParseDrawIOFile(path)
+		if err != nil {
+			t.Fatalf("ParseDrawIOFile() error = %v, want nil", err)
+		}
+		want := &ParsedDrawIO{
+			Header:  DrawIOHeader{Label: "%Name%"},
+			Columns: []string{"Name", "Image"},
+			Records: []Record{{"Name": "alpha", "Image": "a.png"}},
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("ParseDrawIOFile() = %+v, want %+v", got, want)
+		}
+	})
+
+	t.Run("missing file wraps os.Open error", func(t *testing.T) {
+		_, err := ParseDrawIOFile(filepath.Join(t.TempDir(), "nope.csv"))
+		if !errors.Is(err, fs.ErrNotExist) {
+			t.Fatalf("ParseDrawIOFile() error = %v, want errors.Is fs.ErrNotExist", err)
+		}
+	})
+}

--- a/v2/drawio_roundtrip_test.go
+++ b/v2/drawio_roundtrip_test.go
@@ -1,0 +1,334 @@
+package output
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"unicode"
+
+	"pgregory.net/rapid"
+)
+
+// This file holds the property-based round-trip tests for the draw.io CSV
+// writer/parser pair (requirements 3.1, 3.2, 4.7) plus an example-based
+// golden round-trip as an anchor against generator blind spots.
+//
+// Generator constraints encode documented carve-outs, not bugs:
+//   - no '\n' or '\r' in header (directive) string fields: the draw.io CSV
+//     header format cannot represent line breaks in directive values
+//     (requirements Out of Scope)
+//   - unique column names: duplicates correctly fail with
+//     ErrDrawIODuplicateColumn (requirement 4.6)
+//   - record keys are a subset of the columns: keys outside the column list
+//     are intentionally not rendered (WithDrawIOColumns silent-drop contract)
+//   - column names must stay distinct after CRLF normalization: parsing
+//     normalizes "\r\n" to "\n" inside quoted fields (Decision 7), so two
+//     columns differing only by CR would collide on re-parse
+
+// drawioRoundTripTB is the subset of testing.T/rapid.T the round-trip
+// helpers need.
+type drawioRoundTripTB interface {
+	Helper()
+	Fatalf(format string, args ...any)
+}
+
+// renderDrawIORoundTrip renders header/columns/records through the drawio
+// renderer using the round-trip contract from the design: a document built
+// with NewDrawIOContent and WithDrawIOColumns(parsed.Columns...).
+func renderDrawIORoundTrip(t drawioRoundTripTB, header DrawIOHeader, columns []string, records []Record) []byte {
+	t.Helper()
+	doc := New().
+		AddContent(NewDrawIOContent("round-trip", records, header, WithDrawIOColumns(columns...))).
+		Build()
+	out, err := (&drawioRenderer{}).Render(context.Background(), doc)
+	if err != nil {
+		t.Fatalf("Render() error = %v, want nil", err)
+	}
+	return out
+}
+
+// parseDrawIORoundTrip parses rendered output, failing the test on error:
+// renderer-produced output must always parse back (requirement 3.1).
+func parseDrawIORoundTrip(t drawioRoundTripTB, data []byte, stage string) *ParsedDrawIO {
+	t.Helper()
+	parsed, err := ParseDrawIOCSV(bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("ParseDrawIOCSV() %s parse error = %v, want nil\ninput:\n%s", stage, err, data)
+	}
+	return parsed
+}
+
+// drawioStringGen generates printable strings biased toward the characters
+// the round-trip requirements call out: quotes, backslashes, commas, '#',
+// directive punctuation, and HTML-escape candidates. extra adds runes (e.g.
+// '\n' or '\r' for record values) beyond the printable base set.
+func drawioStringGen(extra ...rune) *rapid.Generator[string] {
+	runes := append([]rune{'"', '\\', ',', '#', ':', ' ', '%', '&', '<', '>'}, extra...)
+	return rapid.StringOf(rapid.RuneFrom(runes, unicode.L, unicode.N, unicode.P, unicode.S))
+}
+
+// drawioHeaderGen generates an arbitrary DrawIOHeader. String fields stay
+// free of line breaks (documented carve-out); numeric fields include zero
+// and negative values, which the writer suppresses in both renders.
+func drawioHeaderGen() *rapid.Generator[DrawIOHeader] {
+	return rapid.Custom(func(t *rapid.T) DrawIOHeader {
+		str := drawioStringGen()
+		num := rapid.IntRange(-2, 200)
+		h := DrawIOHeader{
+			Label:        str.Draw(t, "label"),
+			Style:        str.Draw(t, "style"),
+			Ignore:       str.Draw(t, "ignore"),
+			Link:         str.Draw(t, "link"),
+			Layout:       rapid.OneOf(rapid.SampledFrom([]string{"", DrawIOLayoutNone, DrawIOLayoutAuto, DrawIOLayoutHorizontalFlow}), str).Draw(t, "layout"),
+			NodeSpacing:  num.Draw(t, "nodespacing"),
+			LevelSpacing: num.Draw(t, "levelspacing"),
+			EdgeSpacing:  num.Draw(t, "edgespacing"),
+			Padding:      num.Draw(t, "padding"),
+			Parent:       str.Draw(t, "parent"),
+			ParentStyle:  str.Draw(t, "parentstyle"),
+			Height:       str.Draw(t, "height"),
+			Width:        str.Draw(t, "width"),
+			Left:         str.Draw(t, "left"),
+			Top:          str.Draw(t, "top"),
+			Identity:     str.Draw(t, "identity"),
+			Namespace:    str.Draw(t, "namespace"),
+		}
+		for i := range rapid.IntRange(0, 3).Draw(t, "connectionCount") {
+			h.Connections = append(h.Connections, DrawIOConnection{
+				From:   str.Draw(t, fmt.Sprintf("conn%d.from", i)),
+				To:     str.Draw(t, fmt.Sprintf("conn%d.to", i)),
+				Invert: rapid.Bool().Draw(t, fmt.Sprintf("conn%d.invert", i)),
+				Label:  str.Draw(t, fmt.Sprintf("conn%d.label", i)),
+				Style:  str.Draw(t, fmt.Sprintf("conn%d.style", i)),
+			})
+		}
+		return h
+	})
+}
+
+// drawioColumnsGen generates 1..4 column names, unique after CRLF
+// normalization. allowCR includes '\r' for the idempotency property; the
+// byte-identity property (requirement 3.2) is restricted to CR-free values.
+func drawioColumnsGen(allowCR bool) *rapid.Generator[[]string] {
+	extra := []rune{'\n'}
+	if allowCR {
+		extra = append(extra, '\r')
+	}
+	return rapid.SliceOfNDistinct(drawioStringGen(extra...), 1, 4, func(s string) string {
+		return strings.ReplaceAll(s, "\r\n", "\n")
+	})
+}
+
+// drawioRecordsGen generates 0..4 records whose keys are a subset of
+// columns and whose values are strings (the only value type the parser can
+// produce, so the only one the round-trip contract covers).
+func drawioRecordsGen(t *rapid.T, columns []string, allowCR bool) []Record {
+	extra := []rune{'\n'}
+	if allowCR {
+		extra = append(extra, '\r')
+	}
+	valueGen := drawioStringGen(extra...)
+	count := rapid.IntRange(0, 4).Draw(t, "recordCount")
+	records := make([]Record, 0, count)
+	for i := range count {
+		record := make(Record)
+		for j, col := range columns {
+			if rapid.Bool().Draw(t, fmt.Sprintf("record%d.has%d", i, j)) {
+				record[col] = valueGen.Draw(t, fmt.Sprintf("record%d.value%d", i, j))
+			}
+		}
+		records = append(records, record)
+	}
+	return records
+}
+
+// TestPropertyDrawIORoundTripIdempotency verifies requirement 3.1: for any
+// renderable header/columns/records, render → parse → render → parse →
+// render produces byte-equal output from the first re-render onward.
+func TestPropertyDrawIORoundTripIdempotency(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		header := drawioHeaderGen().Draw(rt, "header")
+		columns := drawioColumnsGen(true).Draw(rt, "columns")
+		records := drawioRecordsGen(rt, columns, true)
+
+		first := renderDrawIORoundTrip(rt, header, columns, records)
+		parsed1 := parseDrawIORoundTrip(rt, first, "first")
+		second := renderDrawIORoundTrip(rt, parsed1.Header, parsed1.Columns, parsed1.Records)
+		parsed2 := parseDrawIORoundTrip(rt, second, "second")
+		third := renderDrawIORoundTrip(rt, parsed2.Header, parsed2.Columns, parsed2.Records)
+
+		if !bytes.Equal(second, third) {
+			rt.Fatalf("round-trip not idempotent\nsecond render:\n%q\nthird render:\n%q", second, third)
+		}
+	})
+}
+
+// TestPropertyDrawIORoundTripByteIdentity verifies requirement 3.2: for
+// CR-free values, the first re-render is already byte-identical to the
+// renderer's original output.
+func TestPropertyDrawIORoundTripByteIdentity(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		header := drawioHeaderGen().Draw(rt, "header")
+		columns := drawioColumnsGen(false).Draw(rt, "columns")
+		records := drawioRecordsGen(rt, columns, false)
+
+		first := renderDrawIORoundTrip(rt, header, columns, records)
+		parsed := parseDrawIORoundTrip(rt, first, "first")
+		second := renderDrawIORoundTrip(rt, parsed.Header, parsed.Columns, parsed.Records)
+
+		if !bytes.Equal(first, second) {
+			rt.Fatalf("re-render not byte-identical\nfirst render:\n%q\nsecond render:\n%q", first, second)
+		}
+	})
+}
+
+// TestPropertyParseDrawIOCSVNoPanic verifies requirement 4.7 for arbitrary
+// byte input: the parser returns a result or an error, and never panics.
+func TestPropertyParseDrawIOCSVNoPanic(t *testing.T) {
+	rapid.Check(t, func(rt *rapid.T) {
+		data := rapid.SliceOf(rapid.Byte()).Draw(rt, "data")
+		parsed, err := ParseDrawIOCSV(bytes.NewReader(data))
+		if (parsed == nil) == (err == nil) {
+			rt.Fatalf("ParseDrawIOCSV() = (%v, %v), want exactly one of result and error non-nil", parsed, err)
+		}
+	})
+}
+
+// TestPropertyParseDrawIODirectivesNoPanic verifies requirement 4.7 on the
+// directive-handling paths: a generator biased toward `# connect:` and
+// `# padding:` lines makes sure the JSON unmarshal and Atoi branches are
+// actually exercised with malformed values, asserting error-or-success.
+func TestPropertyParseDrawIODirectivesNoPanic(t *testing.T) {
+	connectValueGen := rapid.OneOf(
+		rapid.SampledFrom([]string{
+			`{"from":"a","to":"b","invert":false,"label":"l","style":"s"}`,
+			`{"from": 5}`,
+			`{"invert":"yes"}`,
+			`{"from":"a"`,
+			`"unterminated`,
+			`{`, `}`, `[]`, `[1,2]`, `null`, `true`, `NaN`, ``,
+		}),
+		rapid.String(),
+	)
+	paddingValueGen := rapid.OneOf(
+		rapid.SampledFrom([]string{
+			"42", "-7", "0", "", " 42", "42 ", "4.5", "1e3", "0x10", "x",
+			"999999999999999999999999999999",
+		}),
+		rapid.String(),
+	)
+
+	rapid.Check(t, func(rt *rapid.T) {
+		var sb strings.Builder
+		lineCount := rapid.IntRange(1, 8).Draw(rt, "lineCount")
+		for i := range lineCount {
+			switch rapid.IntRange(0, 2).Draw(rt, fmt.Sprintf("kind%d", i)) {
+			case 0:
+				sb.WriteString("# connect: " + connectValueGen.Draw(rt, fmt.Sprintf("connect%d", i)) + "\n")
+			case 1:
+				sb.WriteString("# padding: " + paddingValueGen.Draw(rt, fmt.Sprintf("padding%d", i)) + "\n")
+			default:
+				sb.WriteString(rapid.String().Draw(rt, fmt.Sprintf("line%d", i)) + "\n")
+			}
+		}
+		if rapid.Bool().Draw(rt, "appendData") {
+			sb.WriteString("a,b\n1,2\n")
+		}
+
+		parsed, err := ParseDrawIOCSV(strings.NewReader(sb.String()))
+		if (parsed == nil) == (err == nil) {
+			rt.Fatalf("ParseDrawIOCSV() = (%v, %v), want exactly one of result and error non-nil\ninput:\n%q", parsed, err, sb.String())
+		}
+	})
+}
+
+// drawioGoldenFile is a realistic awstools-style draw.io CSV file
+// (connections, identity, parent, layout none with left/top), with directive
+// lines in the renderer's emission order so byte identity (requirement 3.2)
+// can be asserted against the first re-render.
+const drawioGoldenFile = `# label: %Name%
+# style: %Image%
+# identity: ID
+# parent: Parent
+# parentstyle: swimlane;whiteSpace=wrap;html=1;childLayout=stackLayout;horizontal=1;horizontalStack=0;resizeParent=1;resizeLast=0;collapsible=1;
+# namespace: awstools-
+# connect: {"from":"DrawSource","to":"ID","invert":false,"label":"Connection","style":"curved=1;endArrow=blockThin;endFill=1;fontSize=11;"}
+# connect: {"from":"DrawTarget","to":"ID","invert":true,"label":"","style":"dashed=1;endArrow=blockThin;endFill=1;fontSize=11;"}
+# height: 78
+# width: 78
+# ignore: ID,Image,DrawSource,DrawTarget,Connection,X,Y
+# nodespacing: 40
+# levelspacing: 100
+# edgespacing: 40
+# link: Link
+# left: X
+# top: Y
+# layout: none
+ID,Name,Image,Parent,DrawSource,DrawTarget,Connection,Link,X,Y
+tgw-123,Transit Gateway,aws.network.transit_gateway,,,,,https://example.com/tgw-123,40,40
+vpc-1,"Production VPC, primary",aws.network.vpc,tgw-123,tgw-123,,attached,https://example.com/vpc-1,120,40
+vpc-2,Development VPC,aws.network.vpc,tgw-123,tgw-123,vpc-1,peered,,200,120
+`
+
+// TestDrawIORoundTripGoldenFile is the example-based anchor for the
+// round-trip properties: parse the golden file, verify the interesting
+// fields, then assert first-re-render byte identity (3.2) and second/third
+// render idempotency (3.1).
+func TestDrawIORoundTripGoldenFile(t *testing.T) {
+	parsed, err := ParseDrawIOCSV(strings.NewReader(drawioGoldenFile))
+	if err != nil {
+		t.Fatalf("ParseDrawIOCSV() error = %v, want nil", err)
+	}
+
+	if parsed.Header.Identity != "ID" {
+		t.Errorf("Header.Identity = %q, want %q", parsed.Header.Identity, "ID")
+	}
+	if parsed.Header.Parent != "Parent" {
+		t.Errorf("Header.Parent = %q, want %q", parsed.Header.Parent, "Parent")
+	}
+	if parsed.Header.Layout != DrawIOLayoutNone {
+		t.Errorf("Header.Layout = %q, want %q", parsed.Header.Layout, DrawIOLayoutNone)
+	}
+	if parsed.Header.Left != "X" || parsed.Header.Top != "Y" {
+		t.Errorf("Header.Left/Top = %q/%q, want X/Y", parsed.Header.Left, parsed.Header.Top)
+	}
+	if len(parsed.Header.Connections) != 2 {
+		t.Fatalf("len(Header.Connections) = %d, want 2", len(parsed.Header.Connections))
+	}
+	if got := parsed.Header.Connections[0]; got.From != "DrawSource" || got.Invert {
+		t.Errorf("Connections[0] = %+v, want From=DrawSource Invert=false", got)
+	}
+	if got := parsed.Header.Connections[1]; got.From != "DrawTarget" || !got.Invert {
+		t.Errorf("Connections[1] = %+v, want From=DrawTarget Invert=true", got)
+	}
+
+	wantColumns := []string{"ID", "Name", "Image", "Parent", "DrawSource", "DrawTarget", "Connection", "Link", "X", "Y"}
+	if fmt.Sprint(parsed.Columns) != fmt.Sprint(wantColumns) {
+		t.Errorf("Columns = %v, want %v", parsed.Columns, wantColumns)
+	}
+	if len(parsed.Records) != 3 {
+		t.Fatalf("len(Records) = %d, want 3", len(parsed.Records))
+	}
+	if got := parsed.Records[1]["Name"]; got != "Production VPC, primary" {
+		t.Errorf("Records[1][Name] = %q, want %q", got, "Production VPC, primary")
+	}
+	if got := parsed.Records[0]["DrawSource"]; got != "" {
+		t.Errorf("Records[0][DrawSource] = %q, want empty string", got)
+	}
+
+	// Byte identity (3.2): the golden file is CR-free renderer-shaped
+	// output, so the first re-render must reproduce it exactly.
+	first := renderDrawIORoundTrip(t, parsed.Header, parsed.Columns, parsed.Records)
+	if string(first) != drawioGoldenFile {
+		t.Errorf("first re-render differs from golden file\ngot:\n%s\nwant:\n%s", first, drawioGoldenFile)
+	}
+
+	// Idempotency (3.1): subsequent parse/render cycles are stable.
+	reparsed := parseDrawIORoundTrip(t, first, "golden re-render")
+	second := renderDrawIORoundTrip(t, reparsed.Header, reparsed.Columns, reparsed.Records)
+	if !bytes.Equal(first, second) {
+		t.Errorf("second render differs from first\nfirst:\n%s\nsecond:\n%s", first, second)
+	}
+}

--- a/v2/examples/collapsible_csv_export/go.sum
+++ b/v2/examples/collapsible_csv_export/go.sum
@@ -54,3 +54,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+pgregory.net/rapid v1.3.0 h1:vBvO0VSqti75J1jjYqpgPNBLKMd1+gxa9fYo7vk/Exc=
+pgregory.net/rapid v1.3.0/go.mod h1:dPlE4OBBxgXPqkP79flB6sJL1dx5azpI7HQ9MY9Z7uk=

--- a/v2/examples/collapsible_github_pr/go.sum
+++ b/v2/examples/collapsible_github_pr/go.sum
@@ -54,3 +54,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+pgregory.net/rapid v1.3.0 h1:vBvO0VSqti75J1jjYqpgPNBLKMd1+gxa9fYo7vk/Exc=
+pgregory.net/rapid v1.3.0/go.mod h1:dPlE4OBBxgXPqkP79flB6sJL1dx5azpI7HQ9MY9Z7uk=

--- a/v2/examples/collapsible_terminal_analysis/go.sum
+++ b/v2/examples/collapsible_terminal_analysis/go.sum
@@ -54,3 +54,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+pgregory.net/rapid v1.3.0 h1:vBvO0VSqti75J1jjYqpgPNBLKMd1+gxa9fYo7vk/Exc=
+pgregory.net/rapid v1.3.0/go.mod h1:dPlE4OBBxgXPqkP79flB6sJL1dx5azpI7HQ9MY9Z7uk=

--- a/v2/examples/migration_example/go.sum
+++ b/v2/examples/migration_example/go.sum
@@ -54,3 +54,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+pgregory.net/rapid v1.3.0 h1:vBvO0VSqti75J1jjYqpgPNBLKMd1+gxa9fYo7vk/Exc=
+pgregory.net/rapid v1.3.0/go.mod h1:dPlE4OBBxgXPqkP79flB6sJL1dx5azpI7HQ9MY9Z7uk=

--- a/v2/examples/pipeline_transformation/go.sum
+++ b/v2/examples/pipeline_transformation/go.sum
@@ -54,3 +54,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+pgregory.net/rapid v1.3.0 h1:vBvO0VSqti75J1jjYqpgPNBLKMd1+gxa9fYo7vk/Exc=
+pgregory.net/rapid v1.3.0/go.mod h1:dPlE4OBBxgXPqkP79flB6sJL1dx5azpI7HQ9MY9Z7uk=

--- a/v2/examples/transformations/go.sum
+++ b/v2/examples/transformations/go.sum
@@ -54,3 +54,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+pgregory.net/rapid v1.3.0 h1:vBvO0VSqti75J1jjYqpgPNBLKMd1+gxa9fYo7vk/Exc=
+pgregory.net/rapid v1.3.0/go.mod h1:dPlE4OBBxgXPqkP79flB6sJL1dx5azpI7HQ9MY9Z7uk=

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/jedib0t/go-pretty/v6 v6.4.9
 	github.com/mattn/go-isatty v0.0.20
 	gopkg.in/yaml.v3 v3.0.1
+	pgregory.net/rapid v1.3.0
 )
 
 require (

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -54,3 +54,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+pgregory.net/rapid v1.3.0 h1:vBvO0VSqti75J1jjYqpgPNBLKMd1+gxa9fYo7vk/Exc=
+pgregory.net/rapid v1.3.0/go.mod h1:dPlE4OBBxgXPqkP79flB6sJL1dx5azpI7HQ9MY9Z7uk=

--- a/v2/graph_content.go
+++ b/v2/graph_content.go
@@ -438,7 +438,8 @@ type DrawIOOption func(*DrawIOContent)
 
 // WithDrawIOColumns sets an explicit column order for draw.io CSV rendering.
 // Record keys absent from columns are not rendered; columns missing from a
-// record render as the empty string.
+// record render as the empty string. Calling it with no columns is equivalent
+// to not setting an order: the renderer falls back to auto-detection.
 func WithDrawIOColumns(columns ...string) DrawIOOption {
 	return func(d *DrawIOContent) {
 		d.columns = slices.Clone(columns)

--- a/v2/graph_content.go
+++ b/v2/graph_content.go
@@ -399,6 +399,7 @@ type DrawIOContent struct {
 	title   string
 	header  DrawIOHeader
 	records []Record
+	columns []string // explicit column order; nil means auto-detect
 }
 
 // DrawIOHeader configures Draw.io CSV import behavior (v1 compatibility)
@@ -432,33 +433,49 @@ type DrawIOConnection struct {
 	Style  string // Connection style (curved, straight, etc.)
 }
 
+// DrawIOOption configures a DrawIOContent during construction.
+type DrawIOOption func(*DrawIOContent)
+
+// WithDrawIOColumns sets an explicit column order for draw.io CSV rendering.
+// Record keys absent from columns are not rendered; columns missing from a
+// record render as the empty string.
+func WithDrawIOColumns(columns ...string) DrawIOOption {
+	return func(d *DrawIOContent) {
+		d.columns = slices.Clone(columns)
+	}
+}
+
 // NewDrawIOContent creates a new Draw.io content
-func NewDrawIOContent(title string, records []Record, header DrawIOHeader) *DrawIOContent {
-	return &DrawIOContent{
+func NewDrawIOContent(title string, records []Record, header DrawIOHeader, opts ...DrawIOOption) *DrawIOContent {
+	content := &DrawIOContent{
 		id:      GenerateID(),
 		title:   title,
 		header:  header,
 		records: cloneRecords(records),
 	}
+	for _, opt := range opts {
+		opt(content)
+	}
+	return content
 }
 
 // NewDrawIOContentFromTable creates Draw.io content from table data.
 // A nil table yields safe, empty content rather than a panic, since this
 // constructor returns no error to report the invalid input.
-func NewDrawIOContentFromTable(table *TableContent, header DrawIOHeader) *DrawIOContent {
-	if table == nil {
-		return &DrawIOContent{
-			id:     GenerateID(),
-			header: header,
-		}
+func NewDrawIOContentFromTable(table *TableContent, header DrawIOHeader, opts ...DrawIOOption) *DrawIOContent {
+	content := &DrawIOContent{
+		id:     GenerateID(),
+		header: header,
 	}
-
-	return &DrawIOContent{
-		id:      GenerateID(),
-		title:   table.title,
-		header:  header,
-		records: cloneRecords(table.records),
+	if table != nil {
+		content.title = table.title
+		content.records = cloneRecords(table.records)
+		content.columns = table.schema.GetFieldNames()
 	}
+	for _, opt := range opts {
+		opt(content)
+	}
+	return content
 }
 
 // Type returns the content type
@@ -485,6 +502,12 @@ func (d *DrawIOContent) GetHeader() DrawIOHeader {
 // mutate the content's internal state.
 func (d *DrawIOContent) GetRecords() []Record {
 	return cloneRecords(d.records)
+}
+
+// GetColumns returns a copy of the explicit column order, or nil when no
+// explicit order has been set.
+func (d *DrawIOContent) GetColumns() []string {
+	return slices.Clone(d.columns)
 }
 
 // AppendText implements encoding.TextAppender
@@ -527,6 +550,7 @@ func (d *DrawIOContent) Clone() Content {
 		title:   d.title,
 		header:  newHeader,
 		records: cloneRecords(d.records),
+		columns: slices.Clone(d.columns),
 	}
 }
 

--- a/v2/graph_content_mutation_test.go
+++ b/v2/graph_content_mutation_test.go
@@ -308,7 +308,7 @@ func TestGraphContent_GetNodesStableOrder(t *testing.T) {
 	// First-seen order across (From, To) pairs, deduplicated.
 	want := []string{"Start", "Process", "Review", "Deploy", "End", "Rollback"}
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		got := g.GetNodes()
 		if !slices.Equal(got, want) {
 			t.Fatalf("GetNodes() returned unstable/unexpected order on iteration %d:\ngot:  %v\nwant: %v", i, got, want)

--- a/v2/graph_renderers.go
+++ b/v2/graph_renderers.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"sort"
+	"strconv"
 	"strings"
 )
 
@@ -736,94 +737,98 @@ func (d *drawioRenderer) renderTableAsDrawIO(buf *bytes.Buffer, table *TableCont
 	}
 }
 
-// writeDrawIOHeader writes the Draw.io CSV header comments
+// writeDrawIOHeader writes the Draw.io CSV header comments. All lines go
+// through writeDrawIODirective and the drawioKey* constants so the writer and
+// the parser share one definition of the directive grammar.
 func (d *drawioRenderer) writeDrawIOHeader(buf *bytes.Buffer, header DrawIOHeader) {
 	// Label
 	if header.Label != "" {
-		fmt.Fprintf(buf, "# label: %s\n", header.Label)
+		writeDrawIODirective(buf, drawioKeyLabel, header.Label)
 	}
 
 	// Style
 	if header.Style != "" {
-		fmt.Fprintf(buf, "# style: %s\n", header.Style)
+		writeDrawIODirective(buf, drawioKeyStyle, header.Style)
 	}
 
 	// Identity
 	if header.Identity != "" {
-		fmt.Fprintf(buf, "# identity: %s\n", header.Identity)
+		writeDrawIODirective(buf, drawioKeyIdentity, header.Identity)
 	}
 
 	// Parent
 	if header.Parent != "" {
-		fmt.Fprintf(buf, "# parent: %s\n", header.Parent)
+		writeDrawIODirective(buf, drawioKeyParent, header.Parent)
 		if header.ParentStyle != "" {
-			fmt.Fprintf(buf, "# parentstyle: %s\n", header.ParentStyle)
+			writeDrawIODirective(buf, drawioKeyParentStyle, header.ParentStyle)
 		}
 	}
 
 	// Namespace
 	if header.Namespace != "" {
-		fmt.Fprintf(buf, "# namespace: %s\n", header.Namespace)
+		writeDrawIODirective(buf, drawioKeyNamespace, header.Namespace)
 	}
 
 	// Connections: encode through the drawioConnectionJSON mirror struct so
 	// values are escaped per JSON rules while &, <, and > stay verbatim
 	// (requirement 3.5). Encode's trailing newline terminates the line.
-	enc := json.NewEncoder(buf)
-	enc.SetEscapeHTML(false)
-	for _, conn := range header.Connections {
-		buf.WriteString("# connect: ")
-		// Encoding a struct of strings and a bool cannot fail.
-		_ = enc.Encode(drawioConnectionJSON(conn))
+	if len(header.Connections) > 0 {
+		enc := json.NewEncoder(buf)
+		enc.SetEscapeHTML(false)
+		for _, conn := range header.Connections {
+			buf.WriteString("# " + drawioKeyConnect + ": ")
+			// Encoding a struct of strings and a bool cannot fail.
+			_ = enc.Encode(drawioConnectionJSON(conn))
+		}
 	}
 
 	// Dimensions
 	if header.Height != "" {
-		fmt.Fprintf(buf, "# height: %s\n", header.Height)
+		writeDrawIODirective(buf, drawioKeyHeight, header.Height)
 	}
 	if header.Width != "" {
-		fmt.Fprintf(buf, "# width: %s\n", header.Width)
+		writeDrawIODirective(buf, drawioKeyWidth, header.Width)
 	}
 
 	// Ignore
 	if header.Ignore != "" {
-		fmt.Fprintf(buf, "# ignore: %s\n", header.Ignore)
+		writeDrawIODirective(buf, drawioKeyIgnore, header.Ignore)
 	}
 
 	// Spacing
 	if header.NodeSpacing > 0 {
-		fmt.Fprintf(buf, "# nodespacing: %d\n", header.NodeSpacing)
+		writeDrawIODirective(buf, drawioKeyNodeSpacing, strconv.Itoa(header.NodeSpacing))
 	}
 	if header.LevelSpacing > 0 {
-		fmt.Fprintf(buf, "# levelspacing: %d\n", header.LevelSpacing)
+		writeDrawIODirective(buf, drawioKeyLevelSpacing, strconv.Itoa(header.LevelSpacing))
 	}
 	if header.EdgeSpacing > 0 {
-		fmt.Fprintf(buf, "# edgespacing: %d\n", header.EdgeSpacing)
+		writeDrawIODirective(buf, drawioKeyEdgeSpacing, strconv.Itoa(header.EdgeSpacing))
 	}
 
 	// Padding
 	if header.Padding > 0 {
-		fmt.Fprintf(buf, "# padding: %d\n", header.Padding)
+		writeDrawIODirective(buf, drawioKeyPadding, strconv.Itoa(header.Padding))
 	}
 
 	// Link
 	if header.Link != "" {
-		fmt.Fprintf(buf, "# link: %s\n", header.Link)
+		writeDrawIODirective(buf, drawioKeyLink, header.Link)
 	}
 
 	// Position columns (only for layout=none)
 	if header.Layout == DrawIOLayoutNone {
 		if header.Left != "" {
-			fmt.Fprintf(buf, "# left: %s\n", header.Left)
+			writeDrawIODirective(buf, drawioKeyLeft, header.Left)
 		}
 		if header.Top != "" {
-			fmt.Fprintf(buf, "# top: %s\n", header.Top)
+			writeDrawIODirective(buf, drawioKeyTop, header.Top)
 		}
 	}
 
 	// Layout
 	if header.Layout != "" {
-		fmt.Fprintf(buf, "# layout: %s\n", header.Layout)
+		writeDrawIODirective(buf, drawioKeyLayout, header.Layout)
 	}
 }
 

--- a/v2/graph_renderers.go
+++ b/v2/graph_renderers.go
@@ -3,6 +3,7 @@ package output
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"sort"
@@ -643,8 +644,12 @@ func (d *drawioRenderer) renderDrawIOContent(buf *bytes.Buffer, content *DrawIOC
 	// Generate CSV header based on DrawIOHeader configuration
 	d.writeDrawIOHeader(buf, header)
 
-	// Extract column names from records
-	columnNames := d.extractColumnNames(records)
+	// Use the explicit column order when set; otherwise fall back to
+	// alphabetized auto-detection from the records.
+	columnNames := content.GetColumns()
+	if len(columnNames) == 0 {
+		columnNames = d.extractColumnNames(records)
+	}
 
 	// Write CSV header row
 	d.writeCSVRow(buf, columnNames)
@@ -761,11 +766,15 @@ func (d *drawioRenderer) writeDrawIOHeader(buf *bytes.Buffer, header DrawIOHeade
 		fmt.Fprintf(buf, "# namespace: %s\n", header.Namespace)
 	}
 
-	// Connections
+	// Connections: encode through the drawioConnectionJSON mirror struct so
+	// values are escaped per JSON rules while &, <, and > stay verbatim
+	// (requirement 3.5). Encode's trailing newline terminates the line.
+	enc := json.NewEncoder(buf)
+	enc.SetEscapeHTML(false)
 	for _, conn := range header.Connections {
-		connJSON := fmt.Sprintf(`{"from":"%s","to":"%s","invert":%t,"label":"%s","style":"%s"}`,
-			conn.From, conn.To, conn.Invert, conn.Label, conn.Style)
-		fmt.Fprintf(buf, "# connect: %s\n", connJSON)
+		buf.WriteString("# connect: ")
+		// Encoding a struct of strings and a bool cannot fail.
+		_ = enc.Encode(drawioConnectionJSON(conn))
 	}
 
 	// Dimensions
@@ -825,8 +834,14 @@ func (d *drawioRenderer) writeCSVRow(buf *bytes.Buffer, row []string) {
 			buf.WriteByte(',')
 		}
 
-		// Escape field if it contains comma, quote, or newline
-		if strings.ContainsAny(field, ",\"\n\r") {
+		// Quote fields containing comma, quote, or newline; fields starting
+		// with '#' (which would otherwise look like a comment or directive);
+		// and a single empty sole field (which would otherwise render as a
+		// blank line that CSV readers silently skip). Requirement 3.6.
+		needsQuoting := strings.ContainsAny(field, ",\"\n\r") ||
+			strings.HasPrefix(field, "#") ||
+			(len(row) == 1 && field == "")
+		if needsQuoting {
 			escaped := strings.ReplaceAll(field, "\"", "\"\"")
 			fmt.Fprintf(buf, "\"%s\"", escaped)
 		} else {

--- a/v2/graph_renderers_test.go
+++ b/v2/graph_renderers_test.go
@@ -778,7 +778,7 @@ func TestDrawioRenderer_StableNodeOrder(t *testing.T) {
 		"End,,,",
 	}, "\n")
 
-	for i := 0; i < 100; i++ {
+	for i := range 100 {
 		got, err := renderer.Render(ctx, doc)
 		if err != nil {
 			t.Fatalf("DrawioRenderer.Render() error = %v", err)

--- a/v2/mermaid_chart_test.go
+++ b/v2/mermaid_chart_test.go
@@ -224,7 +224,7 @@ func TestMermaidRenderer_GanttSectionOrder(t *testing.T) {
 		"section Delta",
 	}
 
-	for iter := 0; iter < 100; iter++ {
+	for iter := range 100 {
 		result, err := renderer.Render(context.Background(), doc)
 		if err != nil {
 			t.Fatalf("Render() error = %v", err)

--- a/v2/progress_core_test.go
+++ b/v2/progress_core_test.go
@@ -462,8 +462,7 @@ func TestProgress_SetContext_Replacement_DoesNotFail(t *testing.T) {
 	}
 
 	// Install the first context.
-	ctx1, cancel1 := context.WithCancel(context.Background())
-	defer cancel1()
+	ctx1 := t.Context()
 	progress.SetContext(ctx1)
 
 	// Replace it with a fresh, live context. This cancels the first derived
@@ -919,8 +918,7 @@ func TestPrettyProgress_SetContext_Replacement_DoesNotFail(t *testing.T) {
 	p.SetCurrent(50)
 
 	// Install the first context.
-	ctx1, cancel1 := context.WithCancel(context.Background())
-	defer cancel1()
+	ctx1 := t.Context()
 	p.SetContext(ctx1)
 
 	// Replace it with a fresh, live context. This cancels the first derived

--- a/v2/progress_text.go
+++ b/v2/progress_text.go
@@ -140,10 +140,7 @@ func (p *textProgress) renderDefault() string {
 		// Guard against a non-positive configured width (e.g. WithWidth(-1) or
 		// WithTrackerLength(-1)); a negative width would otherwise feed a
 		// negative count into strings.Repeat below.
-		barWidth := p.config.Width
-		if barWidth < 0 {
-			barWidth = 0
-		}
+		barWidth := max(p.config.Width, 0)
 
 		// Clamp filled to [0, barWidth] so an overrun (current > total) renders
 		// a full bar instead of producing a negative empty-cell count, which


### PR DESCRIPTION
## Summary

Adds a draw.io CSV reader to go-output v2, plus the writer changes needed for lossless round-tripping. This replaces v1's `GetHeaderAndContentsFromFile` and unblocks read-modify-rewrite workflows (e.g. the awstools `tgw overview --append` multi-account merge). Ticket: T-1539.

## What's included

**Parser** (`v2/drawio_reader.go`)
- `ParseDrawIOCSV(io.Reader)` / `ParseDrawIOFile(path)` → `*ParsedDrawIO{Header, Columns, Records}`
- Staged pipeline: BOM strip → directive pre-pass (18 keys, case-sensitive `# key: ` grammar, unknown keys ignored, scalars last-wins, `connect` append-all) → quote-parity scan (rejects trailing directives / second diagram blocks) → `csv.Reader` (Comment mode off, `FieldsPerRecord` enforced) → empty-string cell fill
- Four `errors.Is`-matchable sentinels: `ErrDrawIONoColumnHeader`, `ErrDrawIOTrailingDirective`, `ErrDrawIODuplicateColumn`, `ErrDrawIODirective`

**Writer changes** (`v2/graph_content.go`, `v2/graph_renderers.go`, `v2/document.go`)
- Explicit column order via `WithDrawIOColumns` / `GetColumns`; `NewDrawIOContentFromTable` captures schema field order
- `# connect:` emitted via `json.Encoder` with `SetEscapeHTML(false)` (valid JSON, `&`/`<`/`>` verbatim, byte-compatible with prior output for escape-free values)
- Quoting for leading-`#` fields and single-empty-field rows so data can't be mistaken for comments or blank lines
- `Builder.DrawIO` gains variadic `opts ...DrawIOOption` (backward compatible)

## Round-trip guarantees

Property-tested with `pgregory.net/rapid` (test-only dependency) plus a golden awstools-style file:
- **Idempotency**: render→parse→render→parse→render stabilizes from the first re-render
- **Byte-identity**: holds for CR-free renderer output
- **No-panic**: arbitrary bytes and malformed directives never panic

`DrawIOConnection` stays untagged so JSON/YAML document output is unchanged (regression-tested).

## Validation

`make check` (fmt + lint + full suite) passes. All 24 acceptance criteria have behavioral tests; deliberate carve-outs are documented in the spec's Out of Scope list and decision log.

A pre-push review ran over the branch (findings fixed in `T-1539: pre-push review fixes`); see `specs/drawio-csv-reader/implementation.md` for the three-level implementation explanation.
