### PR TITLE
Prepare v2.7.0 release

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v3
         with:
-          go-version: '1.24' # The Go version to download (if necessary) and use.
+          go-version: '1.25' # The Go version to download (if necessary) and use.
       - name: Format and check v2 Go files
         run: |
           cd v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This release adds a draw.io CSV reader so draw.io output can be read back into s
 
 ### Changed
 - **Minimum Go version is now 1.25** (raised from 1.24). This pulls in the fix for [GO-2026-5024](https://pkg.go.dev/vuln/GO-2026-5024) in the indirect `golang.org/x/sys` dependency (a Windows-only issue in code go-output does not call). Upgrade your toolchain to Go 1.25 or newer before updating.
+- Added test-only dependency `pgregory.net/rapid` for property-based round-trip tests. It is not required by library consumers.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,46 +1,42 @@
-## Unreleased
+## 2.7.0 / 2026-06-21
+
+This release adds a draw.io CSV reader so draw.io output can be read back into structured data (a full write/read round-trip), along with a set of robustness and correctness fixes across rendering, transformations, progress, and concurrency.
 
 ### Added
-- **Draw.io CSV Round-Trip Guarantees** (drawio-csv-reader phase 3) - Property-based tests (via new test-only dependency `pgregory.net/rapid`) verifying the writer/parser round-trip contracts
-  - Idempotency: render → parse → render → parse → render stabilizes from the first re-render onward for arbitrary headers, columns, and records
-  - Byte identity: for CR-free content, the first re-render is byte-identical to the original render
-  - No-panic: the parser returns a result or an error (never panics) for arbitrary byte input, including malformed `# connect:` JSON and non-integer numeric directives
-  - Example-based golden round-trip with a realistic awstools-style file as an anchor against generator blind spots
-- **Draw.io CSV Parser** (drawio-csv-reader phase 2) - New `ParseDrawIOCSV(io.Reader)` and `ParseDrawIOFile(path)` functions parse draw.io CSV (as written by the drawio renderer) into a `ParsedDrawIO` struct with header directives, column order, and records
-  - All 18 directive keys map onto `DrawIOHeader` fields; grammar is case-sensitive `# key: ` exact-prefix with verbatim untrimmed values; unknown directives and comments are ignored; scalar directives are last-wins while `# connect:` appends all occurrences in order
-  - Handles UTF-8 BOM, CRLF line endings, blank lines, quoted fields containing commas/quotes/newlines, data rows starting with `#`, and multi-line quoted column names; empty cells materialize as empty strings; absent directives leave header fields zero-valued
-  - New sentinel errors (`ErrDrawIONoColumnHeader`, `ErrDrawIOTrailingDirective`, `ErrDrawIODuplicateColumn`, `ErrDrawIODirective`) discriminable via `errors.Is`, wrapped with line/directive context; trailing-directive detection takes precedence over CSV field-count errors; CSV parse errors report whole-file line numbers
-- **Draw.io CSV Writer Round-Trip Support** (drawio-csv-reader phase 1) - Writer changes so draw.io CSV output can round-trip through the upcoming parser
-  - `DrawIOContent` gains an explicit column order: new `DrawIOOption` type with `WithDrawIOColumns()`, variadic options on `NewDrawIOContent`, `NewDrawIOContentFromTable`, and `Builder.DrawIO`, plus a `GetColumns()` accessor (backward compatible)
-  - `NewDrawIOContentFromTable` now captures the table schema's field order instead of leaving columns to be alphabetized at render time
-  - The renderer uses the explicit column order when set (including the header row with zero records); record keys outside the column list are not rendered
-  - `# connect:` directives are now emitted via `json.Encoder` with HTML escaping disabled: quotes/backslashes escaped per JSON, `&`/`<`/`>` verbatim, `invert` always present, byte-identical to the previous output for escape-free values
-  - Data fields starting with `#` and single-empty-field rows are now quoted so they cannot be mistaken for comments, directives, or blank lines
+- **Draw.io CSV round-trip** - draw.io CSV produced by the renderer can now be parsed back into structured data:
+  - `ParseDrawIOCSV(io.Reader)` and `ParseDrawIOFile(path)` return a `ParsedDrawIO` holding the header directives, column order, and records. All 18 header directives are recognized; UTF-8 BOM, CRLF line endings, blank lines, quoted fields, and `#`-prefixed data are handled; unknown directives and comments are ignored; absent directives leave header fields zero-valued.
+  - Discriminable sentinel errors (`ErrDrawIONoColumnHeader`, `ErrDrawIOTrailingDirective`, `ErrDrawIODuplicateColumn`, `ErrDrawIODirective`) work with `errors.Is` and carry line/directive context.
+  - Writer support for stable round-trips: explicit column ordering via the new `DrawIOOption`/`WithDrawIOColumns()` (on `NewDrawIOContent`, `NewDrawIOContentFromTable`, and `Builder.DrawIO`) plus a `GetColumns()` accessor; `NewDrawIOContentFromTable` preserves the table's schema field order; `# connect:` directives emit deterministic JSON. These additions are backward compatible.
+
+### Changed
+- **Minimum Go version is now 1.25** (raised from 1.24). This pulls in the fix for [GO-2026-5024](https://pkg.go.dev/vuln/GO-2026-5024) in the indirect `golang.org/x/sys` dependency (a Windows-only issue in code go-output does not call). Upgrade your toolchain to Go 1.25 or newer before updating.
 
 ### Fixed
-- **Pretty Progress SetContext Stale Watcher** - Fixed `prettyProgress.SetContext` spuriously marking a healthy progress as failed when the context was replaced (the same stale-watcher defect previously fixed for `textProgress` in T-1254)
-  - The watcher goroutine now captures its own derived context (`watchedCtx`) as a local instead of reading the shared `p.ctx` field, removing a data race and ignoring stale completions when the context has been replaced (`p.ctx != watchedCtx`)
-  - `SetContext(nil)` now clears `p.ctx`/`p.cancel` and returns early
-  - Added regression test `TestPrettyProgress_SetContext_Replacement_DoesNotFail`
-- **GroupBy Composite Key Collision** - Fixed `GroupByOp.createGroupKey` merging distinct groups when grouped values contain the `||` separator (e.g. `{a:"x||y", b:"z"}` and `{a:"x", b:"y||z"}` both produced key `x||y||z`)
-  - Replaced fixed-delimiter concatenation with a collision-safe length-prefixed encoding (`<len>:<value>` per column)
-  - Missing values now use a distinct `nil:` marker so they no longer collide with the literal string `"<nil>"`
-  - Added regression test `TestGroupByCompositeKeyCollision`
-- **Pretty Progress Signal Context Safety** - Fixed startup panic in `NewPrettyProgress` when `handleSignals` accessed `p.ctx.Done()` before `SetContext` initialized the context
-  - Initialize a default cancellable background context before starting signal handling
-  - Added nil-safe context channel handling and closed-signal channel exit in `handleSignals`
-  - Added regression test `TestPrettyProgress_HandleSignals_NilContext_DoesNotPanic`
-- **S3 Output Panic Prevention** - Fixed panic in `PrintByteSlice` when S3Output has Bucket set but S3Client is nil
-  - Added validation guard clause to return clear error message instead of panicking
-  - Error message guides users to use `SetS3Bucket()` for proper S3 configuration
-  - Added regression test to prevent future occurrences
-- **S3Writer Append Size Validation** - Fixed bug where append operations could exceed maxAppendSize limit
-  - Now validates new data size before making API calls
-  - Validates combined size (existing + new data) to prevent memory exhaustion
-  - Provides specific error messages for different size limit violations
-  - Prevents operations that would exceed the intended size guard
-- **Draw.io CSV Output Buffer Flushing** - Fixed issue where `drawio.CreateCSV` function did not flush the underlying `bufio.Writer`, potentially causing data loss when writing to files with small datasets
-- **CI Lint Compliance** - Replaced `WriteString(fmt.Sprintf(...))` with `fmt.Fprintf(...)` across `html_renderer.go`, `markdown_renderer.go`, and `table_renderer.go` to satisfy staticcheck QF1012
+
+**Robustness** — operations that previously panicked now return an error or no-op safely:
+- Renderers no longer panic on nil documents or nil writers (Markdown, graph/DOT/Mermaid renderers, every `RenderTo` implementation, and `MultiWriter`).
+- Builder methods reject or safely ignore nil inputs: `AddContent` (on both `Builder` and `SectionContent`), `Section` and nested-section callbacks, and table operations on nil content.
+- Transformation handling no longer panics on nil operations or transformers; `GroupByOp.Validate` rejects nil aggregate functions; `Output.Render` validates nil configuration entries.
+- `NewDrawIOContentFromTable` guards against a nil table; S3 output returns a clear error instead of panicking when a bucket is set without a client.
+- Progress: fixed a startup context panic, a nil-writer panic on draw, and a progress-bar overflow panic.
+
+**Deterministic output:**
+- Stable row order in graph renderers, deterministic GroupBy aggregate column order, and deterministic Markdown front-matter order.
+- `GenerateID` no longer returns a constant fallback; GroupBy no longer merges distinct rows whose composite keys collide; transformers now run in priority order; `SortTransformer` keeps the Markdown separator row directly under the header.
+
+**Data integrity** — caller-owned data is now defensively copied so later caller mutations cannot corrupt output:
+- Table records, schema key order, chart data, graph/Draw.io data, collapsible values and sections, and CollapsibleValue format hints.
+- Fixed a race in `DefaultCollapsibleValue` lazy caching during concurrent rendering.
+
+**Rendering correctness:**
+- CSV: headers are retained for later tables and for schema changes inside collapsible/nested sections; append no longer merges rows when the existing file lacks a trailing newline; flush errors are surfaced; tabular transformers parse quoted CSV correctly; draw.io CSV output is flushed.
+- Graph renderers now apply table transformations; DOT and Mermaid labels are escaped; HTML charts render Mermaid correctly instead of emitting raw text; Mermaid pie charts accept all numeric types.
+- The emoji transformer no longer corrupts words that contain emoji-indicator substrings.
+- Caller context is threaded through nested renderers; `prettyProgress.SetContext` no longer marks a healthy progress as failed when the context is replaced.
+
+**Other:**
+- `AddColumn` rejects duplicate column names; the Builder surfaces previously dropped nested-section errors; the S3 append size limit now accounts for the size of the new data.
+
 ## 2.6.0 / 2025-11-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A comprehensive Go library for outputting structured data in multiple formats with thread-safe operations and preserved key ordering. This library provides a unified interface to convert your data into JSON, YAML, CSV, HTML, tables, markdown, DOT graphs, Mermaid diagrams, and Draw.io files.
 
-**Version 2.0** represents a complete redesign with no backward compatibility, eliminating global state and providing modern Go 1.24+ features.
+**Version 2.0** represents a complete redesign with no backward compatibility, eliminating global state and providing modern Go 1.25+ features.
 
 ## Features
 
@@ -16,6 +16,7 @@ A comprehensive Go library for outputting structured data in multiple formats wi
 - **Multiple Writers**: Output to stdout, files, S3, or multiple destinations simultaneously
 - **Progress Indicators**: Visual progress bars for long-running operations
 - **Chart Generation**: Gantt charts, pie charts, and flow diagrams
+- **Draw.io CSV Round-Trip**: Parse generated draw.io CSV back into structured data with `ParseDrawIOCSV`/`ParseDrawIOFile`
 
 ## Supported Output Formats
 
@@ -211,7 +212,7 @@ This library uses several excellent external packages:
 
 ## Requirements
 
-- **Go 1.24+** - Uses modern Go features including `any` type and latest testing patterns
+- **Go 1.25+** - Uses modern Go features including `any` type and latest testing patterns
 - **Thread-safe usage** - All components designed for concurrent operations
 
 ## Usage in Projects
@@ -288,7 +289,7 @@ The Makefile automatically handles both the v2 library code and all example dire
 - Add unit tests with concurrent operation coverage
 - Test key order preservation for table functionality
 - Include integration tests for complex scenarios
-- Test with Go 1.24+ features
+- Test with Go 1.25+ features
 
 ## License
 

--- a/docs/release_notes/RELEASE_NOTES_v2.7.0.md
+++ b/docs/release_notes/RELEASE_NOTES_v2.7.0.md
@@ -136,7 +136,7 @@ go get github.com/ArjenSchwarz/go-output/v2@v2.7.0
 ## ⬆️ Upgrade Notes
 
 - **Requires Go 1.25 or newer.** Update your toolchain before upgrading (see Breaking Changes).
-- **No code changes required.** Aside from the toolchain bump, this is a drop-in upgrade from any v2.x release.
+- **No code changes required.** Aside from the toolchain bump, this is a drop-in upgrade from v2.6.x. Upgrading from v2.5.x or earlier additionally involves the breaking changes introduced in those releases (see the v2.4.0 and v2.5.0 changelog entries).
 - Applications relying on the previous (incorrect) behaviors fixed above — for example, code that depended on alphabetized draw.io columns, or that passed nil values expecting a panic — should review the Bug Fixes section.
 - Output that was previously nondeterministic (graph row order, GroupBy aggregate columns, Markdown front matter) is now stable; update any golden-file fixtures accordingly.
 

--- a/docs/release_notes/RELEASE_NOTES_v2.7.0.md
+++ b/docs/release_notes/RELEASE_NOTES_v2.7.0.md
@@ -1,0 +1,150 @@
+# Release Notes: go-output v2.7.0
+
+**Release Date:** June 21, 2026
+
+## Overview
+
+Version 2.7.0 adds a draw.io CSV reader: output produced by the draw.io renderer can now be **parsed back into structured data**, giving a full write → read round-trip. It also includes a set of robustness and correctness fixes across rendering, transformations, progress reporting, and concurrent use.
+
+## ⚠️ Breaking Changes
+
+**No API breaking changes** — every new API is additive and existing behavior is unchanged except where it was previously incorrect (see Bug Fixes).
+
+**One build requirement change:** the **minimum Go version is now 1.25** (raised from 1.24). This was necessary to pull in the fix for [GO-2026-5024](https://pkg.go.dev/vuln/GO-2026-5024) in the indirect `golang.org/x/sys` dependency — a Windows-only issue in code go-output does not call, addressed here as a hygiene measure. Upgrade your toolchain to Go 1.25 or newer before updating.
+
+---
+
+## ✨ New Features
+
+### Draw.io CSV Round-Trip
+
+**What's New:**
+Two new functions read draw.io CSV (as written by the draw.io renderer) back into a structured `ParsedDrawIO` value:
+
+```go
+type ParsedDrawIO struct {
+    Header  DrawIOHeader // zero-valued fields for absent directives
+    Columns []string     // column header row, in file order
+    Records []Record     // data rows, in file order
+}
+
+func ParseDrawIOCSV(r io.Reader) (*ParsedDrawIO, error)
+func ParseDrawIOFile(path string) (*ParsedDrawIO, error)
+```
+
+**Why This Matters:**
+Previously draw.io CSV was write-only. You can now load a generated diagram file, inspect or modify its header directives, columns, and records, and re-render it — useful for tooling that edits diagrams, validates generated output, or migrates data between formats.
+
+**Example:**
+
+```go
+parsed, err := output.ParseDrawIOFile("infrastructure.csv")
+if err != nil {
+    log.Fatal(err)
+}
+
+fmt.Println("Columns:", parsed.Columns)
+for _, rec := range parsed.Records {
+    fmt.Printf("%v (%v)\n", rec["Name"], rec["Type"])
+}
+```
+
+**Robust parsing:**
+- Recognizes all 18 draw.io header directives and maps them onto `DrawIOHeader`.
+- Handles UTF-8 BOM, CRLF line endings, blank lines, quoted fields (commas, quotes, embedded newlines), and data rows starting with `#`.
+- Unknown directives and comments are ignored; absent directives leave the corresponding `DrawIOHeader` field zero-valued (defaults are never substituted).
+
+**Discriminable errors:**
+The parser returns sentinel errors that work with `errors.Is` and carry line/directive context:
+
+```go
+if _, err := output.ParseDrawIOFile("diagram.csv"); err != nil {
+    switch {
+    case errors.Is(err, output.ErrDrawIONoColumnHeader):
+        // input had no column header row
+    case errors.Is(err, output.ErrDrawIODuplicateColumn):
+        // column header row repeats a name
+    case errors.Is(err, output.ErrDrawIOTrailingDirective):
+        // a directive appeared after the column header row
+    case errors.Is(err, output.ErrDrawIODirective):
+        // a directive had an invalid value (e.g. bad connect JSON)
+    }
+}
+```
+
+### Stable, Round-Trippable Draw.io Output
+
+To make round-trips deterministic, the draw.io writer gained explicit column ordering:
+
+```go
+doc := output.New().
+    DrawIO("infrastructure", records, output.DefaultDrawIOHeader(),
+        output.WithDrawIOColumns("Name", "Type", "Region")).
+    Build()
+```
+
+- New `DrawIOOption` type and `WithDrawIOColumns()` option, accepted by `NewDrawIOContent`, `NewDrawIOContentFromTable`, and `Builder.DrawIO`.
+- New `GetColumns()` accessor on `DrawIOContent`.
+- `NewDrawIOContentFromTable` now preserves the table's schema field order instead of alphabetizing columns at render time.
+- `# connect:` directives emit deterministic JSON.
+
+All of these are backward compatible — existing calls without the new option keep working.
+
+---
+
+## 🛠️ Bug Fixes
+
+This release resolves a broad set of defects. They are grouped by theme below.
+
+### Robustness — panics replaced with errors or safe no-ops
+- Renderers no longer panic on nil documents or nil writers (Markdown, graph/DOT/Mermaid renderers, every `RenderTo` implementation, and `MultiWriter`).
+- Builder methods reject or safely ignore nil inputs: `AddContent` (on both `Builder` and `SectionContent`), `Section` and nested-section callbacks, and table operations on nil content.
+- Transformation handling no longer panics on nil operations or transformers; `GroupByOp.Validate` rejects nil aggregate functions; `Output.Render` validates nil configuration entries.
+- `NewDrawIOContentFromTable` guards against a nil table; S3 output returns a clear error instead of panicking when a bucket is set without a client.
+- Progress: fixed a startup context panic, a nil-writer panic on draw, and a progress-bar overflow panic.
+
+### Deterministic output
+- Stable row order in graph renderers, deterministic GroupBy aggregate column order, and deterministic Markdown front-matter order.
+- `GenerateID` no longer returns a constant fallback ID.
+- GroupBy no longer merges distinct rows whose composite keys collide.
+- Transformers now run in priority order; `SortTransformer` keeps the Markdown separator row directly under the header.
+
+### Data integrity
+Caller-owned data is now defensively copied so later caller mutations cannot corrupt rendered output. This covers table records, schema key order, chart data, graph/Draw.io data, collapsible values and sections, and `CollapsibleValue` format hints. A race in `DefaultCollapsibleValue` lazy caching during concurrent rendering was also fixed.
+
+### Rendering correctness
+- CSV: headers are retained for later tables and for schema changes inside collapsible/nested sections; append no longer merges rows when the existing file lacks a trailing newline; flush errors are surfaced; tabular transformers parse quoted CSV correctly; draw.io CSV output is flushed.
+- Graph renderers now apply table transformations; DOT and Mermaid labels are escaped; HTML charts render Mermaid correctly instead of emitting raw text; Mermaid pie charts accept all numeric types.
+- The emoji transformer no longer corrupts words that contain emoji-indicator substrings.
+- Caller context is threaded through nested renderers; `prettyProgress.SetContext` no longer marks a healthy progress as failed when the context is replaced.
+
+### Other
+- `AddColumn` rejects duplicate column names.
+- The Builder surfaces previously dropped nested-section errors.
+- The S3 append size limit now accounts for the size of the new data.
+
+---
+
+## 📦 Installation
+
+```bash
+go get github.com/ArjenSchwarz/go-output/v2@v2.7.0
+```
+
+---
+
+## ⬆️ Upgrade Notes
+
+- **Requires Go 1.25 or newer.** Update your toolchain before upgrading (see Breaking Changes).
+- **No code changes required.** Aside from the toolchain bump, this is a drop-in upgrade from any v2.x release.
+- Applications relying on the previous (incorrect) behaviors fixed above — for example, code that depended on alphabetized draw.io columns, or that passed nil values expecting a panic — should review the Bug Fixes section.
+- Output that was previously nondeterministic (graph row order, GroupBy aggregate columns, Markdown front matter) is now stable; update any golden-file fixtures accordingly.
+
+---
+
+## 📖 Additional Resources
+
+- [CHANGELOG.md](../../CHANGELOG.md) - Complete version history
+- [README.md](../../README.md) - Quick start and feature overview
+- [v2/docs/](../../v2/docs/) - API reference and migration guides
+- [v2/examples/](../../v2/examples/) - Working code examples

--- a/v2/CLAUDE.md
+++ b/v2/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is the **v2** directory of the go-output library, representing a complete redesign of the original library. This is a major version bump (v2.0.0) with **no backward compatibility** with v1. The v2 redesign eliminates global state, provides thread-safe operations, and uses modern Go 1.24+ features.
+This is the **v2** directory of the go-output library, representing a complete redesign of the original library. This is a major version bump (v2.0.0) with **no backward compatibility** with v1. The v2 redesign eliminates global state, provides thread-safe operations, and uses modern Go 1.25+ features.
 
 ## Development Commands
 
@@ -117,7 +117,7 @@ Major components are interfaces to support extensibility:
 
 ### Type Safety with Modern Go
 - Uses `any` instead of `interface{}` (enforced by golangci-lint)
-- Leverages Go 1.24+ features including new testing.B.Loop for benchmarks
+- Leverages Go 1.25+ features including new testing.B.Loop for benchmarks
 - Proper error handling with wrapped errors and context
 
 ## Development Notes
@@ -153,7 +153,7 @@ The v2 codebase follows modern Go 2025 testing best practices:
 #### Test Categories
 - **Unit Tests**: Run by default with `make test` or `go test ./...`
 - **Integration Tests**: Require `INTEGRATION=1`, run with `make test-integration`
-- **Benchmark Tests**: Use modern `b.Loop()` pattern (Go 1.24+)
+- **Benchmark Tests**: Use modern `b.Loop()` pattern (Go 1.25+)
 - **Key Order Tests**: Extensive testing of key preservation across scenarios
 - **Thread Safety**: Concurrent operation tests with multiple goroutines
 - **Immutability**: Tests ensuring documents cannot be modified after Build()

--- a/v2/doc.go
+++ b/v2/doc.go
@@ -13,7 +13,7 @@ Key features:
   - Exact preservation of user-specified column ordering
   - Multiple output formats (JSON, YAML, CSV, HTML, Tables, Markdown, DOT, Mermaid, Draw.io)
   - Document-Builder pattern with clean separation of concerns
-  - Modern Go 1.24+ features with 'any' instead of 'interface{}'
+  - Modern Go 1.25+ features with 'any' instead of 'interface{}'
   - No global state - complete elimination from v1
   - Per-content transformations for filtering, sorting, limiting, and more
 

--- a/v2/docs/API.md
+++ b/v2/docs/API.md
@@ -4,8 +4,8 @@
 
 Go-Output v2 is a complete redesign of the library providing thread-safe document generation with preserved key ordering and multiple output formats. This API documentation covers all public interfaces and methods.
 
-**Version**: v2.5.0
-**Go Version**: 1.24+
+**Version**: v2.7.0
+**Go Version**: 1.25+
 **Import Path**: `github.com/ArjenSchwarz/go-output/v2`
 
 > **Breaking Change in v2.5.0**: Format variables have been converted to functions to ensure thread safety and support for parallel tests. See [Migration Guide](#migration-from-v24x-to-v25x) for details.

--- a/v2/docs/DOCUMENTATION.md
+++ b/v2/docs/DOCUMENTATION.md
@@ -22,7 +22,7 @@ go get github.com/ArjenSchwarz/go-output/v2@latest
 ```
 
 Requirements:
-- Go 1.24 or later
+- Go 1.25 or later
 - No global state dependencies
 - Thread-safe by design
 

--- a/v2/docs/GETTING-STARTED.md
+++ b/v2/docs/GETTING-STARTED.md
@@ -51,7 +51,7 @@ func main() {
 ✅ **Key Order Preservation**: Exact preservation of user-specified column ordering  
 ✅ **Multiple Output Formats**: JSON, YAML, CSV, HTML, Tables, Markdown, DOT, Mermaid, Draw.io  
 ✅ **Document-Builder Pattern**: Clean separation of content building and rendering  
-✅ **Modern Go**: Uses Go 1.24+ features with `any` instead of `interface{}`  
+✅ **Modern Go**: Uses Go 1.25+ features with `any` instead of `interface{}`  
 ✅ **No Global State**: Complete elimination of global state from v1  
 
 ## Common Use Cases

--- a/v2/docs/MIGRATION.md
+++ b/v2/docs/MIGRATION.md
@@ -2,7 +2,7 @@
 
 This guide provides comprehensive instructions for migrating between go-output versions. It covers both v1→v2 migration and intra-v2 breaking changes.
 
-**Current Version**: v2.5.0
+**Current Version**: v2.7.0
 
 **Breaking Changes in v2.5.0**:
 - **Format variables converted to functions** - For thread safety and parallel test support

--- a/v2/docs/README.md
+++ b/v2/docs/README.md
@@ -49,7 +49,7 @@ make test-coverage
   - Makefile targets and commands
   - Testing philosophy and organization  
   - Code architecture and patterns
-  - Modernization details (Go 1.24+ features)
+  - Modernization details (Go 1.25+ features)
 
 ### Testing Strategy
 

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,6 +1,6 @@
 module github.com/ArjenSchwarz/go-output/v2
 
-go 1.24.3
+go 1.25.0
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.39.3
@@ -25,5 +25,5 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
-	golang.org/x/sys v0.25.0 // indirect
+	golang.org/x/sys v0.46.0 // indirect
 )

--- a/v2/go.sum
+++ b/v2/go.sum
@@ -47,8 +47,8 @@ github.com/stretchr/testify v1.7.4/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.25.0 h1:r+8e+loiHxRqhXVl6ML1nO3l1+oFoWbnlu2Ehimmi34=
-golang.org/x/sys v0.25.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
+golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
Release preparation for **go-output v2.7.0** (minor — additive draw.io CSV reader API, no breaking API changes).

## Changes
- **CHANGELOG**: rebuilt the `Unreleased` section into a complete, condensed `2.7.0` entry. The old section listed only 7 of ~50 user-facing fixes shipped since v2.6.0; the rest were reconstructed from `git log v2.6.0..HEAD` and grouped by theme.
- **Release notes**: new `docs/release_notes/RELEASE_NOTES_v2.7.0.md`.
- **README**: documents the new Draw.io CSV round-trip capability.
- **Security / dependency**: `golang.org/x/sys` v0.25.0 → v0.46.0 to clear advisory [GO-2026-5024](https://pkg.go.dev/vuln/GO-2026-5024) (Windows-only, uncalled, indirect). `govulncheck` is now clean.

## ⚠️ Reviewer note — minimum Go version raised to 1.25
The x/sys fix only exists in versions that declare `go 1.25`, so this bumps the module's `go` directive from 1.24.3 to **1.25.0**. The requirement was propagated to the README, CI workflow (`go-version: '1.25'`), changelog, release notes, and the `v2/docs/` requirement statements. This is the one consumer-facing requirement change in the release.

## Verification
`make test` ✓ · `golangci-lint` 0 issues ✓ · `go vet` ✓ · `gofmt` ✓ · `govulncheck` no vulnerabilities ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)