### PR TITLE
Fix T-1689: Builder Silent Content Drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Fixed
+- The Builder now records an error when content or metadata is added after `Build()` has finalized the document; previously such mutations vanished silently with `HasErrors()` returning false (T-1689). The built document remains unchanged and the fluent API remains non-panicking.
+- The DOT and Mermaid renderers now propagate `NewGraphContentFromTable` errors instead of discarding them (T-1689). No behavior change today — the only current error condition is unreachable at those call sites — but future error conditions will surface through `Render`.
+- The godoc for `Builder`, `Build`, `Table`, and `Raw` now documents the fluent-chain error contract: failures are recorded on the builder, the affected content is omitted from the document, and callers should check `HasErrors()`/`Errors()` after building (T-1689).
+
 ## 2.7.0 / 2026-06-21
 
 This release adds a draw.io CSV reader so draw.io output can be read back into structured data (a full write/read round-trip), along with a set of robustness and correctness fixes across rendering, transformations, progress, and concurrency.

--- a/specs/bugfixes/builder-silent-content-drop/report.md
+++ b/specs/bugfixes/builder-silent-content-drop/report.md
@@ -1,7 +1,7 @@
 # Bugfix Report: Builder Silently Drops Failed and Post-Build Content
 
 **Date:** 2026-07-08
-**Status:** In Progress
+**Status:** Fixed
 **Ticket:** T-1689
 
 ## Description of the Issue
@@ -37,7 +37,17 @@ Systematic (Fagan-style) inspection of `v2/document.go`, `v2/graph_content.go`, 
 
 ## Resolution for the Issue
 
-_To be completed after the fix is implemented._
+**Changes made:**
+- `v2/document.go` (`SetMetadata`, `AddContent`) — the `if b.doc != nil` silent no-op guards now record a builder error when called after `Build()`: `"SetMetadata %q: cannot set metadata after Build() has been called"` / `"AddContent: cannot add content after Build() has been called"`. All fluent content helpers (`Table`, `Text`, `Section`, …) route through `AddContent`, so every post-Build mutation is now detectable via `HasErrors()`/`Errors()`. The built document remains unchanged, preserving immutability.
+- `v2/document.go` (godoc on `Builder`, `Build`, `Table`, `Raw`) — documents the fluent-chain error contract: fluent methods never return errors mid-chain; failures are recorded on the builder and the offending content is omitted from the rendered output; `Build` is one-shot; check `HasErrors()`/`Errors()` after building.
+- `v2/graph_renderers.go` (both `extractGraphFromTable` implementations and their `Render` callers) — the methods now return `(*GraphContent, error)` and the DOT/Mermaid `Render` methods propagate the error instead of discarding it with `graph, _ :=`. A `(nil, nil)` return still means "not a graph table, render normally".
+
+**Approach rationale:** mirrors the error-accumulation pattern the builder already uses for constructor failures and finalized-sub-builder misuse (Section/CollapsibleSection), removing the internal inconsistency without any breaking API change. The graph fix propagates rather than re-hides the error so any future error condition in `NewGraphContentFromTable` surfaces through `Render`.
+
+**Alternatives considered:**
+- Panic on post-Build mutation — rejected: the fluent API is deliberately non-panicking, and existing (buggy but tolerated) callers would start crashing.
+- Change `Build()` to return `(*Document, error)` now — rejected: breaking change; queued for v3 on T-1697 (Build is chain-terminal, so the fluent style survives that change).
+- Keep `extractGraphFromTable`'s single-return signature and just drop the error explicitly — rejected: the error would remain unobservable; propagation costs only two small caller changes.
 
 ## Regression Test
 
@@ -52,17 +62,21 @@ The discarded graph error has no failing test because the error path is unreacha
 
 ## Affected Files
 
-_To be completed after the fix is implemented._
+| File | Change |
+|------|--------|
+| `v2/document.go` | `SetMetadata`/`AddContent` record errors post-Build; godoc for the error contract on `Builder`, `Build`, `Table`, `Raw` |
+| `v2/graph_renderers.go` | Both `extractGraphFromTable` methods return `(*GraphContent, error)`; DOT/Mermaid `Render` propagate the error |
+| `v2/document_test.go` | Regression test `TestBuilder_PostBuildMutationsRecordErrors` |
 
 ## Verification
 
 **Automated:**
-- [ ] Regression test passes
-- [ ] Full test suite passes
-- [ ] Linters/validators pass
+- [x] Regression test passes (`TestBuilder_PostBuildMutationsRecordErrors`, 4 subtests)
+- [x] Full test suite passes (`make test` and `make test-integration`)
+- [x] Linters/validators pass (`golangci-lint run`: 0 issues; `gofmt` clean)
 
 **Manual verification:**
-- _To be completed._
+- Confirmed `TestBuilder_NilSafety` still passes: post-Build mutations remain non-panicking and the built document remains unchanged; only the error recording is new.
 
 ## Prevention
 

--- a/specs/bugfixes/builder-silent-content-drop/report.md
+++ b/specs/bugfixes/builder-silent-content-drop/report.md
@@ -1,0 +1,79 @@
+# Bugfix Report: Builder Silently Drops Failed and Post-Build Content
+
+**Date:** 2026-07-08
+**Status:** In Progress
+**Ticket:** T-1689
+
+## Description of the Issue
+
+The v2 fluent `Builder` can lose content with no error signal in three related ways:
+
+1. **Post-Build mutations vanish silently.** `Build()` sets `b.doc = nil` and every mutator guards `if b.doc != nil`, so content or metadata added after `Build()` disappears with `HasErrors() == false`. This is internally inconsistent: the `Section`/`CollapsibleSection` paths *do* record errors for the analogous finalized-sub-builder misuse.
+2. **Constructor failures are recorded but never surfaced by the promoted style.** `Builder.Table`/`Raw` swallow constructor errors into `b.errors`; `Build()` always returns `*Document` and rendering succeeds with the failed content silently missing. The fluent chain `output.New().Table(...).Build()` gives no point to call `HasErrors()`, and nothing documents that the caller must break the chain to check.
+3. **Discarded constructor errors in renderers.** `NewGraphContentFromTable` returns `(*GraphContent, error)`, but both `extractGraphFromTable` implementations discard the error with `graph, _ :=` (graph_renderers.go:171 and :482).
+
+**Reproduction steps:**
+1. `builder := output.New()`; `doc := builder.Build()`
+2. `builder.Text("hello")` — or any other content/metadata mutation
+3. `builder.HasErrors()` returns `false` and `doc` (and any later render) contains no trace of the content
+
+**Impact:** High severity (multi-agent code audit, 2026-07-07; claims verified by execution). Any consumer that accidentally reuses a builder after `Build()`, or whose table/raw data fails construction, produces silently incomplete output — the worst failure mode for an output library.
+
+## Investigation Summary
+
+Systematic (Fagan-style) inspection of `v2/document.go`, `v2/graph_content.go`, and `v2/graph_renderers.go`, confirming all three audit claims in code.
+
+- **Symptoms examined:** post-Build mutations no-op with no recorded error; fluent chain offers no error observation point; `graph, _ :=` discards at graph_renderers.go:171/:482.
+- **Code inspected:** `document.go:55-63` (`Build`), `:94-123` (`SetMetadata`/`AddContent` guards), `:126-158` (`Table`/`Raw` error accumulation), `:161-291` (Section paths that *do* record misuse errors); `graph_content.go:58-98` (`NewGraphContentFromTable`); `graph_renderers.go:137-176`, `:448-487` (both `extractGraphFromTable` implementations) and their callers at `:83` and `:275`.
+- **Hypotheses tested:** whether the discarded graph error is reachable — it is not today (it only fires for a nil table, and both call sites dereference the table before calling), so it is fragile rather than currently harmful. Checked `TestBuilder_NilSafety` (document_test.go:346): it asserts post-Build mutations don't panic and don't modify the document, but does *not* assert errors stay absent, so recording errors is compatible with existing tests.
+
+## Discovered Root Cause
+
+**Defect type:** Silent failure / missing error propagation.
+
+**Why it occurred:** `Build()` enforces document immutability by clearing `b.doc`; the `if b.doc != nil` guards were written purely to prevent nil-pointer panics. Error accumulation (`b.errors`) was introduced later for constructor failures and, later still, for finalized-sub-builder misuse in the Section paths — but the post-Build no-op branches were never wired into it. Because the fluent API has no per-call error channel and `Build()` returns only `*Document`, silent degradation is the structural default failure mode.
+
+**Contributing factors:** the error-observation contract (`HasErrors()`/`Errors()` after building) is undocumented on `Builder`/`Build`; constructor signatures are split between `(*T, error)` and bare `*T`, inviting `_` discards.
+
+## Resolution for the Issue
+
+_To be completed after the fix is implemented._
+
+## Regression Test
+
+**Test file:** `v2/document_test.go`
+**Test name:** `TestBuilder_PostBuildMutationsRecordErrors`
+
+**What it verifies:** `AddContent`, `SetMetadata`, `Table`, and `Text` called after `Build()` each record exactly one builder error (detectable via `HasErrors()`/`Errors()`) while leaving the already-built document unchanged.
+
+**Run command:** `cd v2 && go test -run TestBuilder_PostBuildMutationsRecordErrors -v`
+
+The discarded graph error has no failing test because the error path is unreachable today (nil-table check precedes the only error condition); the fix propagates the error so future error conditions surface, covered by compile-time checking and the existing renderer tests.
+
+## Affected Files
+
+_To be completed after the fix is implemented._
+
+## Verification
+
+**Automated:**
+- [ ] Regression test passes
+- [ ] Full test suite passes
+- [ ] Linters/validators pass
+
+**Manual verification:**
+- _To be completed._
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Route all builder misuse through the existing `b.errors` accumulation channel instead of silent no-op guards.
+- Never discard `error` returns with `_`; propagate or handle explicitly with a comment stating why.
+- v3 (queued on T-1697): make `Build()` return `(*Document, error)` — Build is chain-terminal so the fluent style survives — and unify content constructors on `(*T, error)` routed through builder error accumulation.
+
+## Related
+
+- T-1689 (this bug), found in multi-agent code audit 2026-07-07
+- T-1697 — Compile the v3 breaking-changes inventory (v3 portion of the fix queued there)
+- T-1516 — no-op Output options; T-1527 — error taxonomy
+- T-1353 — nil nested content in SectionContent (introduced the Section-path misuse errors this fix mirrors)

--- a/v2/document.go
+++ b/v2/document.go
@@ -35,7 +35,19 @@ func (d *Document) GetMetadata() map[string]any {
 	return metadata
 }
 
-// Builder constructs documents with a fluent API
+// Builder constructs documents with a fluent API.
+//
+// Fluent methods never return errors mid-chain. Failures — such as a Table or
+// Raw constructor error, or any mutation after Build() — are recorded on the
+// builder and the offending content is omitted from the document. A document
+// with recorded errors still builds and renders successfully with that
+// content missing, so check HasErrors or Errors after building:
+//
+//	builder := output.New().Table("data", rows).Text("note")
+//	doc := builder.Build()
+//	if builder.HasErrors() {
+//		// handle builder.Errors()
+//	}
 type Builder struct {
 	doc    *Document
 	mu     sync.Mutex // Ensure thread-safe building
@@ -51,7 +63,15 @@ func New() *Builder {
 	}
 }
 
-// Build finalizes and returns the document
+// Build finalizes and returns the document.
+//
+// Build is one-shot: it clears the builder's document reference to enforce
+// immutability. Any later mutation (SetMetadata, AddContent, or the content
+// helpers that route through them) records a builder error and leaves the
+// built document unchanged; a second Build call returns nil. Errors
+// accumulated during building remain available via HasErrors and Errors —
+// check them after Build, because content that failed to construct is
+// silently absent from the returned document.
 func (b *Builder) Build() *Document {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -90,14 +110,19 @@ func (b *Builder) addError(err error) {
 	}
 }
 
-// SetMetadata sets a metadata key-value pair
+// SetMetadata sets a metadata key-value pair.
+//
+// Calling SetMetadata after Build() records a builder error and leaves the
+// built document unchanged (T-1689).
 func (b *Builder) SetMetadata(key string, value any) *Builder {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
-	if b.doc != nil {
-		b.doc.metadata[key] = value
+	if b.doc == nil {
+		b.addError(fmt.Errorf("SetMetadata %q: cannot set metadata after Build() has been called", key))
+		return b
 	}
+	b.doc.metadata[key] = value
 	return b
 }
 
@@ -107,6 +132,9 @@ func (b *Builder) SetMetadata(key string, value any) *Builder {
 // error is recorded instead (consistent with Table and Raw). This prevents nil
 // entries in the document's contents, which would otherwise cause nil
 // dereferences during rendering and transformation.
+//
+// Calling AddContent after Build() records a builder error and leaves the
+// built document unchanged (T-1689).
 func (b *Builder) AddContent(content Content) *Builder {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -116,13 +144,20 @@ func (b *Builder) AddContent(content Content) *Builder {
 		return b
 	}
 
-	if b.doc != nil {
-		b.doc.contents = append(b.doc.contents, content)
+	if b.doc == nil {
+		b.addError(fmt.Errorf("AddContent: cannot add content after Build() has been called"))
+		return b
 	}
+
+	b.doc.contents = append(b.doc.contents, content)
 	return b
 }
 
-// Table adds a table with preserved key ordering
+// Table adds a table with preserved key ordering.
+//
+// If table construction fails, the error is recorded on the builder, no
+// content is added, and the chain continues; the built document renders
+// without the failed table. Check HasErrors or Errors after building.
 func (b *Builder) Table(title string, data any, opts ...TableOption) *Builder {
 	table, err := NewTableContent(title, data, opts...)
 	if err != nil {
@@ -145,7 +180,11 @@ func (b *Builder) Header(text string) *Builder {
 	return b.Text(text, WithHeader(true))
 }
 
-// Raw adds format-specific raw content
+// Raw adds format-specific raw content.
+//
+// If content construction fails, the error is recorded on the builder, no
+// content is added, and the chain continues; the built document renders
+// without the failed content. Check HasErrors or Errors after building.
 func (b *Builder) Raw(format string, data []byte, opts ...RawOption) *Builder {
 	rawContent, err := NewRawContent(format, data, opts...)
 	if err != nil {

--- a/v2/document_test.go
+++ b/v2/document_test.go
@@ -486,3 +486,70 @@ func TestBuilder_ErrorHandling_ThreadSafety(t *testing.T) {
 		t.Errorf("Expected %d valid contents, got %d", numGoroutines, len(contents))
 	}
 }
+
+// TestBuilder_PostBuildMutationsRecordErrors is a regression test for T-1689.
+// Content and metadata added after Build() finalizes the builder used to
+// vanish silently with HasErrors() == false. The builder must record an error
+// for post-Build mutations so the misuse is detectable via HasErrors() and
+// Errors(), consistent with the finalized-sub-builder errors recorded by
+// Section and CollapsibleSection.
+func TestBuilder_PostBuildMutationsRecordErrors(t *testing.T) {
+	tests := map[string]struct {
+		mutate  func(b *Builder)
+		wantErr string
+	}{
+		"AddContent after Build records error": {
+			mutate: func(b *Builder) {
+				b.AddContent(&testContent{id: "post-build", contentType: ContentTypeText})
+			},
+			wantErr: "AddContent",
+		},
+		"SetMetadata after Build records error": {
+			mutate: func(b *Builder) {
+				b.SetMetadata("key", "value")
+			},
+			wantErr: "SetMetadata",
+		},
+		"Table after Build records error": {
+			mutate: func(b *Builder) {
+				b.Table("PostBuildTable", []map[string]any{{"k": "v"}}, WithKeys("k"))
+			},
+			wantErr: "AddContent",
+		},
+		"Text after Build records error": {
+			mutate: func(b *Builder) {
+				b.Text("post-build text")
+			},
+			wantErr: "AddContent",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			builder := New()
+			doc := builder.Build()
+
+			tc.mutate(builder)
+
+			if !builder.HasErrors() {
+				t.Fatal("HasErrors() = false, want true after post-Build mutation")
+			}
+			errs := builder.Errors()
+			if len(errs) != 1 {
+				t.Fatalf("len(Errors()) = %d, want 1", len(errs))
+			}
+			got := errs[0].Error()
+			if !strings.Contains(got, tc.wantErr) || !strings.Contains(got, "Build()") {
+				t.Errorf("error = %q, want mention of %q and \"Build()\"", got, tc.wantErr)
+			}
+
+			// The already-built document must remain unchanged.
+			if len(doc.GetContents()) != 0 {
+				t.Errorf("len(doc.GetContents()) = %d, want 0 (document modified after Build())", len(doc.GetContents()))
+			}
+			if len(doc.GetMetadata()) != 0 {
+				t.Errorf("len(doc.GetMetadata()) = %d, want 0 (metadata modified after Build())", len(doc.GetMetadata()))
+			}
+		})
+	}
+}

--- a/v2/graph_renderers.go
+++ b/v2/graph_renderers.go
@@ -80,7 +80,11 @@ func (d *dotRenderer) Render(ctx context.Context, doc *Document) ([]byte, error)
 			d.renderGraphContent(&buf, c)
 		case *TableContent:
 			// Try to extract graph from table if it has from/to columns
-			if graph := d.extractGraphFromTable(c); graph != nil {
+			graph, err := d.extractGraphFromTable(c)
+			if err != nil {
+				return nil, err
+			}
+			if graph != nil {
 				d.renderGraphContent(&buf, graph)
 			}
 		}
@@ -133,8 +137,11 @@ func (d *dotRenderer) renderGraphContent(buf *bytes.Buffer, graph *GraphContent)
 	}
 }
 
-// extractGraphFromTable attempts to extract graph data from a table
-func (d *dotRenderer) extractGraphFromTable(table *TableContent) *GraphContent {
+// extractGraphFromTable attempts to extract graph data from a table. A nil
+// graph with nil error means the table has no recognizable from/to columns
+// and should be rendered as a regular table; an error means the table matched
+// the graph column heuristics but graph construction failed (T-1689).
+func (d *dotRenderer) extractGraphFromTable(table *TableContent) (*GraphContent, error) {
 	// Look for common from/to column names
 	fromColumns := graphFromColumns
 	toColumns := graphToColumns
@@ -168,11 +175,10 @@ func (d *dotRenderer) extractGraphFromTable(table *TableContent) *GraphContent {
 
 	// If we found both from and to columns, extract graph
 	if fromCol != "" && toCol != "" {
-		graph, _ := NewGraphContentFromTable(table, fromCol, toCol, labelCol)
-		return graph
+		return NewGraphContentFromTable(table, fromCol, toCol, labelCol)
 	}
 
-	return nil
+	return nil, nil
 }
 
 // mermaidRenderer implements Mermaid diagram output format
@@ -272,7 +278,11 @@ func (m *mermaidRenderer) Render(ctx context.Context, doc *Document) ([]byte, er
 				m.renderGraphContent(&buf, c)
 			case *TableContent:
 				// Try to extract graph from table if it has from/to columns
-				if graph := m.extractGraphFromTable(c); graph != nil {
+				graph, err := m.extractGraphFromTable(c)
+				if err != nil {
+					return nil, err
+				}
+				if graph != nil {
 					m.renderGraphContent(&buf, graph)
 				}
 			}
@@ -444,8 +454,11 @@ func (m *mermaidRenderer) renderFlowchartContent(buf *bytes.Buffer, chart *Chart
 	}
 }
 
-// extractGraphFromTable attempts to extract graph data from a table
-func (m *mermaidRenderer) extractGraphFromTable(table *TableContent) *GraphContent {
+// extractGraphFromTable attempts to extract graph data from a table. A nil
+// graph with nil error means the table has no recognizable from/to columns
+// and should be rendered as a regular table; an error means the table matched
+// the graph column heuristics but graph construction failed (T-1689).
+func (m *mermaidRenderer) extractGraphFromTable(table *TableContent) (*GraphContent, error) {
 	// Look for common from/to column names
 	fromColumns := graphFromColumns
 	toColumns := graphToColumns
@@ -479,11 +492,10 @@ func (m *mermaidRenderer) extractGraphFromTable(table *TableContent) *GraphConte
 
 	// If we found both from and to columns, extract graph
 	if fromCol != "" && toCol != "" {
-		graph, _ := NewGraphContentFromTable(table, fromCol, toCol, labelCol)
-		return graph
+		return NewGraphContentFromTable(table, fromCol, toCol, labelCol)
 	}
 
-	return nil
+	return nil, nil
 }
 
 // sanitizeMermaidID makes a string safe for use as a Mermaid identifier


### PR DESCRIPTION
## Summary

Fixes T-1689 (high, from the 2026-07-07 multi-agent code audit): the fluent `Builder` could lose content with no error signal.

**Bug:** `Build()` clears `b.doc` to enforce immutability, and every mutator guarded `if b.doc != nil` with a silent no-op — so content or metadata added after `Build()` vanished with `HasErrors() == false`. This was internally inconsistent: the `Section`/`CollapsibleSection` paths already record errors for the analogous finalized-sub-builder misuse. Separately, both `extractGraphFromTable` implementations discarded `NewGraphContentFromTable`'s error with `graph, _ :=`, and nothing documented that `Table`/`Raw` constructor failures leave the content silently missing from rendered output.

**Root cause:** immutability was enforced by silently disabling mutators instead of routing misuse through the builder's existing error-accumulation channel, and the check-`HasErrors()` contract was undocumented. Full analysis in `specs/bugfixes/builder-silent-content-drop/report.md`.

## Changes

- `SetMetadata`/`AddContent` record a builder error when called after `Build()`; all fluent content helpers route through `AddContent`, so every post-Build mutation is now detectable. The built document remains unchanged and the API remains non-panicking.
- Both `extractGraphFromTable` methods (DOT, Mermaid) now return `(*GraphContent, error)` and `Render` propagates the error. The only current error condition is unreachable at these sites, so no behavior changes today.
- Godoc on `Builder`, `Build`, `Table`, `Raw` documents the fluent-chain error contract.
- The v3 breaking-change portion (`Build()` returning `(*Document, error)`, unified constructor signatures) is queued on T-1697.

## Testing

- New regression test `TestBuilder_PostBuildMutationsRecordErrors` (4 subtests) — written first and confirmed failing, passes after the fix.
- Full unit + integration suites pass; `golangci-lint`: 0 issues; `gofmt` clean.
- `TestBuilder_NilSafety` still passes: post-Build mutations remain non-panicking and the built document stays unchanged.