### PR TITLE
Fix T-1707: Pin claude-sonnet-5 in claude-code-review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,6 +39,10 @@ jobs:
 
           # Pinned explicitly: the action's default model (Claude Sonnet 4) was
           # retired and returns 404, which failed every review run (T-1707).
+          # "claude-sonnet-5" is the dateless alias that tracks the Sonnet 5
+          # line (not a dated snapshot), so it only breaks if the whole line is
+          # retired — check the model deprecations page on platform.claude.com
+          # if reviews 404 again.
           model: "claude-sonnet-5"
 
           # Direct prompt for automated review (no @claude mention needed)

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,8 +37,9 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4.1)
-          # model: "claude-opus-4-1-20250805"
+          # Pinned explicitly: the action's default model (Claude Sonnet 4) was
+          # retired and returns 404, which failed every review run (T-1707).
+          model: "claude-sonnet-5"
 
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |


### PR DESCRIPTION
## Summary

Fixes T-1707: the claude-code-review workflow has failed on **every** run since at least 2026-05-30 because the `anthropics/claude-code-action@beta` default model (Claude Sonnet 4, `claude-sonnet-4-20250514`) has been retired and now returns `404 not_found_error`. Example failing run: https://github.com/ArjenSchwarz/go-output/actions/runs/28911423216 (on PR #95).

## Changes

- Pin `model: "claude-sonnet-5"` explicitly in `.github/workflows/claude-code-review.yml` (the `model:` input was previously commented out, leaving the action on its retired default). An explicit pin also prevents future default-model retirements from silently breaking the job.
- `push.yaml` is the only other workflow and doesn't use the action, so no other changes are needed.

## Testing

- The remote claude-review run on this PR itself still uses the workflow definition from `main`, so it cannot validate this change — a local review will be run on this PR instead. The pin takes effect for PRs once this merges.