### PR TITLE
T-1690: Fix docs describing non-existent APIs; add doc-example compile check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ help: ## Show available make targets and their descriptions
 	@awk 'BEGIN {FS = ":.*##"} /^test.*:.*##/ { printf "  %-18s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 	@echo ""
 	@echo "Code quality targets:"
-	@awk 'BEGIN {FS = ":.*##"} /^(lint|fmt|modernize):.*##/ { printf "  %-18s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
+	@awk 'BEGIN {FS = ":.*##"} /^(lint|fmt|modernize|doc-examples):.*##/ { printf "  %-18s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
 	@echo ""
 	@echo "Development targets:"
 	@awk 'BEGIN {FS = ":.*##"} /^(mod-tidy|benchmark|clean):.*##/ { printf "  %-18s %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
@@ -76,6 +76,11 @@ fmt: ## Format all Go code in v2 and example directories
 		fi; \
 	done
 
+.PHONY: doc-examples
+doc-examples: ## Compile-check complete Go examples embedded in the docs
+	@echo "Checking documentation examples compile..."
+	@cd v2 && go test -run '^TestDocumentationExamplesCompile$$' ./...
+
 .PHONY: modernize
 modernize: ## Apply modernize tool fixes to v2 and example directories
 	@echo "Running modernize on v2 code..."
@@ -123,5 +128,5 @@ clean: ## Remove generated files and test caches
 
 # Composite targets
 .PHONY: check
-check: fmt lint test ## Run complete validation: format, lint, and test
+check: fmt lint test ## Run complete validation: format, lint, and test (test includes doc-example compilation)
 	@echo "All checks completed successfully!"

--- a/v2/.gitignore
+++ b/v2/.gitignore
@@ -22,3 +22,6 @@ examples/*/transformations
 # Coverage files
 *.out
 coverage.html
+
+# Temp build dirs from scripts/doccheck.go
+.doccheck*

--- a/v2/CLAUDE.md
+++ b/v2/CLAUDE.md
@@ -161,17 +161,10 @@ The v2 codebase follows modern Go 2025 testing best practices:
 
 #### Test File Organization
 Large test files have been split for maintainability:
-- `pipeline_*.go` - Split by operation type (filter, sort, limit, etc.)
 - `renderer_*.go` - Split by renderer type (JSON, YAML, CSV, etc.)
 - `operations_*.go` - Split by operation category
 - `errors_*.go` - Split by error type
 - `progress_*.go` - Split by progress feature
-
-#### Test Conversion Tools
-The `v2/test-conversion/` directory contains tools for modernizing test patterns:
-- Converts slice-based to map-based table tests
-- Updates for loop patterns to use map keys
-- Maintains test functionality while improving organization
 
 ### Future Implementation Areas
 Based on the task breakdown in agents/v2-redesign/tasks.md, the following major components are planned:

--- a/v2/doc_examples_test.go
+++ b/v2/doc_examples_test.go
@@ -1,0 +1,106 @@
+package output
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// docGoBlock is a fenced ```go code block extracted from a Markdown file.
+type docGoBlock struct {
+	startLine int    // 1-indexed line of the opening fence
+	code      string // block contents (without the fences)
+}
+
+// TestDocumentationExamplesCompile compiles the complete Go programs embedded in
+// the docs/ Markdown files so that documentation drift — examples that reference
+// APIs which no longer exist — fails the build.
+//
+// Only fenced ```go blocks that are complete programs (they contain both
+// "package main" and a "func main(") are compiled. Fragments (method signatures,
+// partial chains, snippets without a main) are illustrative and skipped.
+//
+// Each program is written to a temporary directory nested inside this module so
+// that imports of the local github.com/ArjenSchwarz/go-output/v2 package resolve
+// to the working tree, then built with "go build".
+func TestDocumentationExamplesCompile(t *testing.T) {
+	docFiles, err := filepath.Glob(filepath.Join("docs", "*.md"))
+	if err != nil {
+		t.Fatalf("glob docs: %v", err)
+	}
+	if len(docFiles) == 0 {
+		t.Fatal("no documentation files found under docs/")
+	}
+
+	// Temp build dirs must live inside this module so local imports resolve to
+	// the working tree rather than a downloaded version.
+	tmpRoot, err := os.MkdirTemp(".", ".doccheck")
+	if err != nil {
+		t.Fatalf("create temp dir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpRoot) })
+
+	checked := 0
+	for _, file := range docFiles {
+		for i, block := range extractGoBlocks(t, file) {
+			if !strings.Contains(block.code, "package main") || !strings.Contains(block.code, "func main(") {
+				continue
+			}
+			checked++
+			name := fmt.Sprintf("%s:%d", file, block.startLine)
+			t.Run(name, func(t *testing.T) {
+				dir := filepath.Join(tmpRoot, fmt.Sprintf("%s_%d", filepath.Base(file), i))
+				if err := os.MkdirAll(dir, 0o755); err != nil {
+					t.Fatalf("mkdir: %v", err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte(block.code+"\n"), 0o644); err != nil {
+					t.Fatalf("write example: %v", err)
+				}
+				cmd := exec.Command("go", "build", "-o", os.DevNull, ".")
+				cmd.Dir = dir
+				if out, err := cmd.CombinedOutput(); err != nil {
+					t.Errorf("example does not compile:\n%s", out)
+				}
+			})
+		}
+	}
+	if checked == 0 {
+		t.Fatal("no complete documentation examples were found to compile")
+	}
+	t.Logf("compiled %d complete documentation example(s)", checked)
+}
+
+// extractGoBlocks returns every fenced ```go block in the Markdown file.
+func extractGoBlocks(t *testing.T, file string) []docGoBlock {
+	t.Helper()
+	data, err := os.ReadFile(file)
+	if err != nil {
+		t.Fatalf("read %s: %v", file, err)
+	}
+
+	var blocks []docGoBlock
+	var buf []string
+	inBlock := false
+	startLine := 0
+	for i, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if !inBlock {
+			if trimmed == "```go" || trimmed == "```golang" {
+				inBlock = true
+				buf = nil
+				startLine = i + 1
+			}
+			continue
+		}
+		if trimmed == "```" {
+			blocks = append(blocks, docGoBlock{startLine: startLine, code: strings.Join(buf, "\n")})
+			inBlock = false
+			continue
+		}
+		buf = append(buf, line)
+	}
+	return blocks
+}

--- a/v2/docs/API.md
+++ b/v2/docs/API.md
@@ -740,38 +740,47 @@ Collapsible content adapts automatically to each output format:
 
 #### Renderer Configuration
 
-Control collapsible behavior globally per renderer:
+Collapsible behavior is configured **per renderer** via `RendererConfig`. Build a
+renderer with the desired configuration, wrap it in a `Format`, and pass that
+`Format` to the `Output`:
 
 ```go
-type CollapsibleConfig struct {
-    GlobalExpansion      bool              // Override all IsExpanded() settings
+type RendererConfig struct {
+    ForceExpansion       bool              // Override all IsExpanded() settings
     MaxDetailLength      int               // Character limit for details (default: 500)
     TruncateIndicator    string            // Truncation suffix (default: "[...truncated]")
     TableHiddenIndicator string            // Table collapse indicator
     HTMLCSSClasses       map[string]string // Custom CSS classes for HTML
 }
 
-// Apply configuration to renderers
+// Table renderer with custom collapsible configuration
+tableRenderer := output.NewTableRendererWithCollapsible("Default", output.RendererConfig{
+    ForceExpansion:       false,
+    TableHiddenIndicator: "[click to expand]",
+    MaxDetailLength:      200,
+})
 tableOutput := output.NewOutput(
-    output.WithFormat(output.Table()),
-    output.WithCollapsibleConfig(output.CollapsibleConfig{
-        GlobalExpansion:      false,
-        TableHiddenIndicator: "[click to expand]",
-        MaxDetailLength:      200,
-    }),
+    output.WithFormat(output.Format{Name: output.FormatTable, Renderer: tableRenderer}),
 )
 
+// HTML renderer with custom CSS classes
+htmlRenderer := output.NewHTMLRendererWithCollapsible(output.RendererConfig{
+    HTMLCSSClasses: map[string]string{
+        "details": "my-collapsible",
+        "summary": "my-summary",
+        "content": "my-details",
+    },
+})
 htmlOutput := output.NewOutput(
-    output.WithFormat(output.HTML()),
-    output.WithCollapsibleConfig(output.CollapsibleConfig{
-        HTMLCSSClasses: map[string]string{
-            "details": "my-collapsible",
-            "summary": "my-summary",
-            "content": "my-details",
-        },
-    }),
+    output.WithFormat(output.Format{Name: output.FormatHTML, Renderer: htmlRenderer}),
 )
 ```
+
+> **Note:** There is no `Output`-level collapsible option. Renderer constructors —
+> `NewTableRendererWithCollapsible`, `NewMarkdownRendererWithCollapsible`,
+> `NewHTMLRendererWithCollapsible`, `NewCSVRendererWithCollapsible` — each accept a
+> `RendererConfig`. Formats created with `output.Table()`, `output.HTML()`, etc. use
+> the default configuration.
 
 #### Complete Example
 
@@ -803,7 +812,7 @@ func main() {
     }
     
     // Create table with collapsible formatters
-    table := output.NewTableContent("Code Analysis", analysisData,
+    table, err := output.NewTableContent("Code Analysis", analysisData,
         output.WithSchema(
             output.Field{
                 Name: "file",
@@ -821,6 +830,9 @@ func main() {
                 Formatter: output.JSONFormatter(50, output.WithCollapsibleExpanded(false)),
             },
         ))
+    if err != nil {
+        panic(err)
+    }
     
     // Wrap in collapsible section
     section := output.NewCollapsibleTable(
@@ -833,17 +845,23 @@ func main() {
     doc := output.New().
         Header("Project Analysis Report").
         Text("Analysis completed successfully. Click sections to expand details.").
-        Add(section).
+        AddContent(section).
         Build()
     
+    // Table renderer with a custom collapse indicator (collapsible config is per renderer)
+    tableRenderer := output.NewTableRendererWithCollapsible("Default", output.RendererConfig{
+        TableHiddenIndicator: "[expand for details]",
+        MaxDetailLength:      100,
+    })
+
     // Render with custom configuration
     out := output.NewOutput(
-        output.WithFormats(output.Markdown(), output.JSON(), output.Table()),
+        output.WithFormats(
+            output.Markdown(),
+            output.JSON(),
+            output.Format{Name: output.FormatTable, Renderer: tableRenderer},
+        ),
         output.WithWriter(output.NewStdoutWriter()),
-        output.WithCollapsibleConfig(output.CollapsibleConfig{
-            TableHiddenIndicator: "[expand for details]",
-            MaxDetailLength:      100,
-        }),
     )
     
     if err := out.Render(context.Background(), doc); err != nil {
@@ -1108,15 +1126,13 @@ The HTML renderer can wrap content in complete HTML document templates with resp
 
 ```go
 // Use built-in responsive template
-htmlFormat := output.HTML.WithOptions(
-    output.WithHTMLTemplate(output.DefaultHTMLTemplate),
-)
+htmlFormat := output.HTMLWithTemplate(output.DefaultHTMLTemplate)
 
-// Or create custom template
+// Or create custom template. Customize theming via ThemeOverrides rather
+// than replacing the whole CSS block.
 customTemplate := &output.HTMLTemplate{
     Title:       "My Report",
     Description: "Analysis Results",
-    CSS:         output.DefaultResponsiveCSS,
     Author:      "AI Agent",
     Viewport:    "width=device-width, initial-scale=1.0",
     ThemeOverrides: map[string]string{
@@ -1125,9 +1141,7 @@ customTemplate := &output.HTMLTemplate{
     },
 }
 
-htmlFormat = output.HTML.WithOptions(
-    output.WithHTMLTemplate(customTemplate),
-)
+htmlFormat = output.HTMLWithTemplate(customTemplate)
 ```
 
 **Built-in Templates**:
@@ -1138,19 +1152,20 @@ htmlFormat = output.HTML.WithOptions(
 **Template Fields**:
 ```go
 type HTMLTemplate struct {
-    Title          string            // Page title
+    Title          string            // Page title (default: "Output Report")
+    Language       string            // HTML lang attribute (default: "en")
+    Charset        string            // Character encoding (default: "UTF-8")
+    Viewport       string            // Viewport meta tag
     Description    string            // Meta description
     Author         string            // Meta author
-    Keywords       string            // Meta keywords
-    Viewport       string            // Viewport meta tag
-    Charset        string            // Character encoding (default: utf-8)
-    CSS            string            // Embedded CSS styles
+    MetaTags       map[string]string // Additional custom meta tags
+    CSS            string            // Embedded CSS styles (unescaped)
     ExternalCSS    []string          // External stylesheet URLs
     ThemeOverrides map[string]string // CSS custom property overrides
     HeadExtra      string            // Additional head content (unescaped)
     BodyClass      string            // Body element class
-    BodyAttributes string            // Additional body attributes
-    BodyExtra      string            // Content after main (unescaped)
+    BodyAttrs      map[string]string // Additional body attributes
+    BodyExtra      string            // Content before </body> (unescaped)
 }
 ```
 
@@ -1159,9 +1174,10 @@ type HTMLTemplate struct {
 The default template uses CSS custom properties for easy theming:
 
 ```go
+// DefaultHTMLTemplate already supplies the responsive CSS; override individual
+// custom properties with ThemeOverrides instead of replacing the whole stylesheet.
 template := &output.HTMLTemplate{
     Title: "Report",
-    CSS:   output.DefaultResponsiveCSS,
     ThemeOverrides: map[string]string{
         "--primary-color":   "#0066cc",
         "--secondary-color": "#6c757d",
@@ -1452,446 +1468,12 @@ doc := output.New().
 
 For detailed migration guidance, see [PIPELINE_MIGRATION.md](PIPELINE_MIGRATION.md).
 
-### Data Transformation Pipeline System (REMOVED in v2.4.0)
-
-**⚠️ Deprecated**: The Pipeline API was removed in v2.4.0. Use per-content transformations instead (see above).
-
-The Pipeline API previously provided a fluent interface for performing data-level transformations on structured table content before rendering. This has been replaced with the more flexible per-content transformations system.
-
-#### Key Features
-
-- **Data-Level Operations**: Transform structured data before rendering
-- **Fluent API**: Chain operations with method chaining
-- **Format-Aware**: Operations can adapt behavior based on target output format
-- **Performance Optimized**: Operations are reordered for optimal execution
-- **Immutable**: Returns new transformed documents without modifying originals
-- **Error Handling**: Fail-fast with detailed context information
-
-#### Pipeline Interface
-
-```go
-// Create a pipeline from any document
-pipeline := doc.Pipeline()
-
-// Chain operations fluently
-transformedDoc := doc.Pipeline().
-    Filter(func(r Record) bool { return r["status"] == "active" }).
-    Sort(SortKey{Column: "timestamp", Direction: Descending}).
-    Limit(100).
-    AddColumn("age_days", func(r Record) any {
-        return time.Since(r["created"].(time.Time)).Hours() / 24
-    }).
-    Execute()
-```
-
-#### Core Operations
-
-##### Filter Operation
-
-Filters table records based on predicate functions:
-
-```go
-// Basic filtering
-doc.Pipeline().
-    Filter(func(r Record) bool {
-        return r["status"] == "active"
-    }).
-    Execute()
-
-// Complex filtering with type assertions
-doc.Pipeline().
-    Filter(func(r Record) bool {
-        score, ok := r["score"].(float64)
-        return ok && score > 85.0
-    }).
-    Execute()
-
-// Multiple filters (combined with AND logic)
-doc.Pipeline().
-    Filter(func(r Record) bool { return r["category"] == "premium" }).
-    Filter(func(r Record) bool { return r["verified"].(bool) }).
-    Execute()
-```
-
-**Filter Function Signature**: `func(Record) bool`
-- **Parameter**: `Record` (map[string]any) - Full record data
-- **Returns**: `bool` - true to keep record, false to filter out
-- **Type Assertions**: Use type assertions for type-safe access to record fields
-
-##### Sort Operations
-
-Sort table data by one or more columns:
-
-```go
-// Single column sort
-doc.Pipeline().
-    SortBy("name", Ascending).
-    Execute()
-
-// Multi-column sort with different directions
-doc.Pipeline().
-    Sort(
-        SortKey{Column: "category", Direction: Ascending},
-        SortKey{Column: "score", Direction: Descending},
-        SortKey{Column: "name", Direction: Ascending},
-    ).
-    Execute()
-
-// Custom comparator function
-doc.Pipeline().
-    SortWith(func(a, b Record) int {
-        // Custom comparison logic
-        aVal := a["priority"].(string)
-        bVal := b["priority"].(string)
-        priorities := map[string]int{"high": 3, "medium": 2, "low": 1}
-        return priorities[bVal] - priorities[aVal] // Reverse order
-    }).
-    Execute()
-```
-
-**Sort Types**:
-- `SortDirection`: `Ascending` or `Descending`
-- `SortKey`: `{Column: string, Direction: SortDirection}`
-- **Custom Comparator**: `func(a, b Record) int` - return -1, 0, or 1
-
-##### Limit Operation
-
-Restricts output to first N records:
-
-```go
-// Get top 10 records
-doc.Pipeline().
-    SortBy("score", Descending).
-    Limit(10).
-    Execute()
-
-// Pagination-style limiting
-doc.Pipeline().
-    Filter(func(r Record) bool { return r["category"] == "premium" }).
-    Limit(50).
-    Execute()
-```
-
-##### GroupBy and Aggregation
-
-Group records by columns and apply aggregate functions:
-
-```go
-// Basic grouping with count
-doc.Pipeline().
-    GroupBy(
-        []string{"category", "status"},
-        map[string]AggregateFunc{
-            "count":       CountAggregate,
-            "total_score": SumAggregate("score"),
-            "avg_score":   AverageAggregate("score"),
-            "max_score":   MaxAggregate("score"),
-            "min_score":   MinAggregate("score"),
-        },
-    ).
-    Execute()
-
-// Custom aggregate function
-customAggregate := func(records []Record) any {
-    var uniqueUsers []string
-    seen := make(map[string]bool)
-    for _, r := range records {
-        user := r["user"].(string)
-        if !seen[user] {
-            uniqueUsers = append(uniqueUsers, user)
-            seen[user] = true
-        }
-    }
-    return len(uniqueUsers)
-}
-
-doc.Pipeline().
-    GroupBy(
-        []string{"department"},
-        map[string]AggregateFunc{
-            "unique_users": customAggregate,
-        },
-    ).
-    Execute()
-```
-
-**Built-in Aggregate Functions**:
-- `CountAggregate`: Count records in group
-- `SumAggregate(column)`: Sum numeric values
-- `AverageAggregate(column)`: Average numeric values
-- `MinAggregate(column)`: Minimum value
-- `MaxAggregate(column)`: Maximum value
-- **Custom Function**: `func([]Record) any`
-
-##### AddColumn (Calculated Fields)
-
-Add calculated columns based on existing data:
-
-```go
-// Simple calculated field
-doc.Pipeline().
-    AddColumn("full_name", func(r Record) any {
-        return fmt.Sprintf("%s %s", r["first_name"], r["last_name"])
-    }).
-    Execute()
-
-// Complex calculations with type assertions
-doc.Pipeline().
-    AddColumn("duration_hours", func(r Record) any {
-        start := r["start_time"].(time.Time)
-        end := r["end_time"].(time.Time)
-        return end.Sub(start).Hours()
-    }).
-    AddColumn("status_icon", func(r Record) any {
-        switch r["status"].(string) {
-        case "completed":
-            return "✅"
-        case "failed":
-            return "❌"
-        case "pending":
-            return "⏳"
-        default:
-            return "❓"
-        }
-    }).
-    Execute()
-
-// Add column at specific position
-doc.Pipeline().
-    AddColumnAt("id", func(r Record) any {
-        return fmt.Sprintf("ID_%d", r["index"].(int))
-    }, 0). // Insert at beginning
-    Execute()
-```
-
-**Calculation Function**: `func(Record) any`
-- **Parameter**: `Record` - Full record with all existing fields
-- **Returns**: `any` - Calculated value for new column
-- **Position**: Use `AddColumnAt()` to specify column position
-- **Duplicate names**: The column name must not already exist in the table
-  schema. Adding a column whose name matches an existing field returns a
-  `ValidationError`; the operation never overwrites existing fields.
-
-#### Pipeline Options
-
-Configure pipeline behavior and resource limits:
-
-```go
-// Custom pipeline options
-options := PipelineOptions{
-    MaxOperations:    50,              // Max operations allowed
-    MaxExecutionTime: 10 * time.Second, // Execution timeout
-}
-
-doc.Pipeline().
-    WithOptions(options).
-    Filter(func(r Record) bool { return r["active"].(bool) }).
-    Execute()
-
-// Default options
-// MaxOperations: 100
-// MaxExecutionTime: 30 seconds
-```
-
-#### Format-Aware Transformations
-
-Operations can adapt behavior based on target output format:
-
-```go
-// Execute with specific format context
-transformedDoc := doc.Pipeline().
-    Filter(func(r Record) bool { return r["visible"].(bool) }).
-    ExecuteWithFormat(context.Background(), "json")
-
-// Operations can check format and adapt behavior
-// (Advanced usage - most operations work across all formats)
-```
-
-#### Error Handling
-
-Pipeline operations use fail-fast error handling with detailed context:
-
-```go
-transformedDoc, err := doc.Pipeline().
-    Filter(func(r Record) bool {
-        // This could panic if "score" field doesn't exist
-        return r["score"].(float64) > 50.0
-    }).
-    Execute()
-
-if err != nil {
-    var pipelineErr *PipelineError
-    if errors.As(err, &pipelineErr) {
-        fmt.Printf("Pipeline failed at operation: %s\n", pipelineErr.Operation)
-        fmt.Printf("Stage: %d\n", pipelineErr.Stage)
-        fmt.Printf("Cause: %v\n", pipelineErr.Cause)
-        // Access additional context
-        fmt.Printf("Context: %+v\n", pipelineErr.Context)
-    }
-}
-```
-
-**Error Types**:
-- `PipelineError`: Detailed pipeline execution error
-- `ValidationError`: Pre-execution validation error
-- **Context Information**: Operation name, stage, input sample, context data
-
-#### Performance Optimization
-
-Pipeline automatically optimizes operation order:
-
-```go
-// User-defined order (potentially inefficient)
-doc.Pipeline().
-    Sort("name", Ascending).        // Expensive operation first
-    Filter(func(r Record) bool {    // Filter after sort
-        return r["active"].(bool)
-    }).
-    Limit(10)                       // Limit after operations
-
-// Automatically optimized to:
-// 1. Filter (reduces dataset size)
-// 2. Sort (operates on smaller dataset)  
-// 3. Limit (gets top N of final results)
-```
-
-**Optimization Strategy**:
-1. **Filter**: Applied first to reduce data size
-2. **AddColumn**: Added next (may be needed for sorting/grouping)
-3. **GroupBy**: Applied to further reduce data
-4. **Sort**: Applied to smaller datasets
-5. **Limit**: Applied last to get top N results
-
-#### Complete Pipeline Example
-
-```go
-package main
-
-import (
-    "context"
-    "fmt"
-    "log"
-    "time"
-    
-    output "github.com/ArjenSchwarz/go-output/v2"
-)
-
-func main() {
-    // Create sample data
-    salesData := []map[string]any{
-        {
-            "salesperson": "Alice",
-            "region":      "North",
-            "amount":      15000.50,
-            "date":        time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
-            "status":      "completed",
-        },
-        {
-            "salesperson": "Bob",
-            "region":      "South",
-            "amount":      22000.75,
-            "date":        time.Date(2024, 1, 10, 0, 0, 0, 0, time.UTC),
-            "status":      "completed",
-        },
-        {
-            "salesperson": "Carol",
-            "region":      "North",
-            "amount":      8000.25,
-            "date":        time.Date(2024, 1, 20, 0, 0, 0, 0, time.UTC),
-            "status":      "pending",
-        },
-        // ... more data
-    }
-
-    // Create document
-    doc := output.New().
-        Table("Sales Data", salesData, 
-            output.WithKeys("salesperson", "region", "amount", "date", "status")).
-        Build()
-
-    // Transform data with pipeline
-    transformedDoc, err := doc.Pipeline().
-        // Filter completed sales only
-        Filter(func(r output.Record) bool {
-            return r["status"] == "completed"
-        }).
-        // Add calculated commission field
-        AddColumn("commission", func(r output.Record) any {
-            amount := r["amount"].(float64)
-            return amount * 0.05 // 5% commission
-        }).
-        // Add days since sale
-        AddColumn("days_ago", func(r output.Record) any {
-            saleDate := r["date"].(time.Time)
-            return int(time.Since(saleDate).Hours() / 24)
-        }).
-        // Sort by amount (highest first)
-        SortBy("amount", output.Descending).
-        // Limit to top 10
-        Limit(10).
-        Execute()
-
-    if err != nil {
-        log.Fatal(err)
-    }
-
-    // Output results
-    out := output.NewOutput(
-        output.WithFormats(output.Table(), output.JSON()),
-        output.WithWriter(output.NewStdoutWriter()),
-    )
-
-    if err := out.Render(context.Background(), transformedDoc); err != nil {
-        log.Fatal(err)
-    }
-
-    // Access transformation statistics
-    if stats := transformedDoc.GetTransformStats(); stats != nil {
-        fmt.Printf("\nTransformation Stats:\n")
-        fmt.Printf("Input Records: %d\n", stats.InputRecords)
-        fmt.Printf("Output Records: %d\n", stats.OutputRecords)
-        fmt.Printf("Filtered Count: %d\n", stats.FilteredCount)
-        fmt.Printf("Duration: %v\n", stats.Duration)
-        
-        for _, opStat := range stats.Operations {
-            fmt.Printf("Operation %s: %v (%d records)\n", 
-                opStat.Name, opStat.Duration, opStat.RecordsProcessed)
-        }
-    }
-}
-```
-
-#### Best Practices
-
-1. **Type Safety**: Always use type assertions when accessing record fields
-2. **Error Handling**: Handle pipeline errors with proper context checking
-3. **Performance**: Let pipeline optimize operation order automatically
-4. **Immutability**: Pipeline returns new documents, preserving originals
-5. **Resource Limits**: Use appropriate pipeline options for large datasets
-6. **Schema Preservation**: Pipeline maintains table schema and key ordering
-
-#### Migration from Byte Transformers
-
-**Old Approach** (byte transformers):
-```go
-// Post-rendering text manipulation
-transformer := &output.SortTransformer{Key: "name", Ascending: true}
-out := output.NewOutput(
-    output.WithTransformer(transformer),
-)
-```
-
-**New Approach** (data pipeline):
-```go
-// Pre-rendering data transformation
-transformedDoc := doc.Pipeline().
-    SortBy("name", output.Ascending).
-    Execute()
-```
-
-**When to Use Each**:
-- **Data Pipeline**: For data operations (filter, sort, aggregate, calculate fields)
-- **Byte Transformers**: For presentation styling (colors, emoji, formatting)
+### Data Transformation Pipeline System (Removed in v2.4.0)
+
+The fluent `doc.Pipeline()` API (`Filter`, `Sort`, `Limit`, `AddColumn`, `SortBy`,
+`Execute`, …) was removed in v2.4.0. Use the per-content transformations described
+above instead. For upgrade steps and before/after examples, see
+[PIPELINE_MIGRATION.md](PIPELINE_MIGRATION.md).
 
 ### Progress System
 
@@ -2468,9 +2050,9 @@ securitySection := output.NewCollapsibleReport(
 doc := output.New().
     Header("System Analysis Report").
     Text("Generated on " + time.Now().Format("2006-01-02 15:04:05")).
-    Add(userSection).
-    Add(performanceSection).
-    Add(securitySection).
+    AddContent(userSection).
+    AddContent(performanceSection).
+    AddContent(securitySection).
     Build()
 ```
 
@@ -2503,7 +2085,7 @@ mainSection := output.NewCollapsibleReport(
     output.WithSectionExpanded(true),
 )
 
-doc := output.New().Add(mainSection).Build()
+doc := output.New().AddContent(mainSection).Build()
 ```
 
 #### Cross-Format Collapsible Rendering
@@ -2514,15 +2096,15 @@ data := []map[string]any{
     {"errors": []string{"Error 1", "Error 2", "Error 3"}},
 }
 
-table := output.NewTableContent("Issues", data, output.WithSchema(
-    output.Field{
-        Name: "errors",
-        Type: "array",
-        Formatter: output.ErrorListFormatter(output.WithCollapsibleExpanded(false)),
-    },
-))
-
-doc := output.New().Add(table).Build()
+doc := output.New().
+    Table("Issues", data, output.WithSchema(
+        output.Field{
+            Name: "errors",
+            Type: "array",
+            Formatter: output.ErrorListFormatter(output.WithCollapsibleExpanded(false)),
+        },
+    )).
+    Build()
 
 // Markdown: GitHub <details> elements
 markdownOut := output.NewOutput(
@@ -2536,13 +2118,13 @@ jsonOut := output.NewOutput(
     output.WithWriter(output.NewFileWriter(".", "report.json")),
 )
 
-// Table: Terminal-friendly with expansion indicators
+// Table: Terminal-friendly with expansion indicators (collapsible config is per renderer)
+tableRenderer := output.NewTableRendererWithCollapsible("Default", output.RendererConfig{
+    TableHiddenIndicator: "[expand to view all errors]",
+})
 tableOut := output.NewOutput(
-    output.WithFormat(output.Table()),
+    output.WithFormat(output.Format{Name: output.FormatTable, Renderer: tableRenderer}),
     output.WithWriter(output.NewStdoutWriter()),
-    output.WithCollapsibleConfig(output.CollapsibleConfig{
-        TableHiddenIndicator: "[expand to view all errors]",
-    }),
 )
 
 // CSV: Automatic detail columns for spreadsheet analysis
@@ -2563,22 +2145,22 @@ csvOut.Render(ctx, doc)       // Creates: errors, errors_details columns
 
 ```go
 // Development/debug mode: expand all content
+debugRenderer := output.NewTableRendererWithCollapsible("Default", output.RendererConfig{
+    ForceExpansion: true, // Override all IsExpanded() settings
+})
 debugOut := output.NewOutput(
-    output.WithFormat(output.Table()),
-    output.WithCollapsibleConfig(output.CollapsibleConfig{
-        GlobalExpansion: true, // Override all IsExpanded() settings
-    }),
+    output.WithFormat(output.Format{Name: output.FormatTable, Renderer: debugRenderer}),
     output.WithWriter(output.NewStdoutWriter()),
 )
 
 // Production mode: respect individual expansion settings
+prodRenderer := output.NewMarkdownRendererWithCollapsible(output.RendererConfig{
+    ForceExpansion:    false, // Use individual IsExpanded() values
+    MaxDetailLength:   500,   // Limit detail length
+    TruncateIndicator: "... (truncated)",
+})
 prodOut := output.NewOutput(
-    output.WithFormat(output.Markdown()),
-    output.WithCollapsibleConfig(output.CollapsibleConfig{
-        GlobalExpansion: false, // Use individual IsExpanded() values
-        MaxDetailLength: 500,   // Limit detail length
-        TruncateIndicator: "... (truncated)",
-    }),
+    output.WithFormat(output.Format{Name: output.FormatMarkdown, Renderer: prodRenderer}),
     output.WithWriter(output.NewStdoutWriter()),
 )
 ```
@@ -2587,26 +2169,26 @@ prodOut := output.NewOutput(
 
 ```go
 // Custom HTML output with branded styling
+htmlRenderer := output.NewHTMLRendererWithCollapsible(output.RendererConfig{
+    HTMLCSSClasses: map[string]string{
+        "details": "company-collapsible",
+        "summary": "company-summary",
+        "content": "company-details",
+    },
+})
 htmlOut := output.NewOutput(
-    output.WithFormat(output.HTML()),
-    output.WithCollapsibleConfig(output.CollapsibleConfig{
-        HTMLCSSClasses: map[string]string{
-            "details": "company-collapsible",
-            "summary": "company-summary",
-            "content": "company-details",
-        },
-    }),
+    output.WithFormat(output.Format{Name: output.FormatHTML, Renderer: htmlRenderer}),
     output.WithWriter(output.NewFileWriter(".", "report.html")),
 )
 
 // Custom table output with branded indicators
+tableRenderer := output.NewTableRendererWithCollapsible("Default", output.RendererConfig{
+    TableHiddenIndicator: "📋 Click to expand detailed information",
+    MaxDetailLength:      150,
+    TruncateIndicator:    "... [see full details in expanded view]",
+})
 tableOut := output.NewOutput(
-    output.WithFormat(output.Table()),
-    output.WithCollapsibleConfig(output.CollapsibleConfig{
-        TableHiddenIndicator: "📋 Click to expand detailed information",
-        MaxDetailLength:      150,
-        TruncateIndicator:    "... [see full details in expanded view]",
-    }),
+    output.WithFormat(output.Format{Name: output.FormatTable, Renderer: tableRenderer}),
     output.WithWriter(output.NewStdoutWriter()),
 )
 ```
@@ -2697,14 +2279,13 @@ The v2 API is designed for extensibility:
 ### Output Configuration
 | Method | Purpose | Example |
 |--------|---------|---------|
-| `NewOutput(opts...)` | Create output instance | `NewOutput(WithFormat(Table))` |
+| `NewOutput(opts...)` | Create output instance | `NewOutput(WithFormat(output.Table()))` |
 | `WithFormat(format)` | Set single format | `WithFormat(output.JSON())` |
-| `WithFormats(formats...)` | Set multiple formats | `WithFormats(JSON, CSV, Table)` |
+| `WithFormats(formats...)` | Set multiple formats | `WithFormats(output.JSON(), output.CSV(), output.Table())` |
 | `WithWriter(writer)` | Set output destination | `WithWriter(NewStdoutWriter())` |
 | `WithWriters(writers...)` | Multiple destinations | `WithWriters(stdout, file)` |
-| `WithTransformer(t)` | Add transformer | `WithTransformer(&EmojiTransformer{})` |
+| `WithTransformer(t)` | Add transformer | `WithTransformer(output.NewColorTransformer())` |
 | `WithProgress(p)` | Add progress tracking | `WithProgress(progress)` |
-| `WithCollapsibleConfig(cfg)` | Configure collapsibles | `WithCollapsibleConfig(config)` |
 
 ### Writer Constructors
 | Constructor | Purpose | Example |

--- a/v2/docs/BREAKING_CHANGES.md
+++ b/v2/docs/BREAKING_CHANGES.md
@@ -325,19 +325,10 @@ p.SetColor(output.ProgressColorGreen)
 5. **Add context**: All rendering now requires context
 6. **Test thoroughly**: Ensure output matches expectations
 
-## Automated Migration
+## Migration Approach
 
-Use the migration tool for automated conversion:
-
-```bash
-# Install migration tool
-go install github.com/ArjenSchwarz/go-output/v2/migrate/cmd/migrate@latest
-
-# Run migration
-migrate -source ./myproject -verbose
-```
-
-The tool handles most common patterns but manual review is recommended.
+There is no automated migration tool — convert v1 code manually using the patterns in
+the [Full Migration Guide](./MIGRATION.md).
 
 ## Additional Resources
 

--- a/v2/docs/DOCUMENTATION.md
+++ b/v2/docs/DOCUMENTATION.md
@@ -2,6 +2,12 @@
 
 A comprehensive Go library for outputting structured data in multiple formats. Version 2 provides a complete redesign with a Document-Builder pattern, thread-safe operations, and guaranteed key order preservation.
 
+> **⚠️ Accuracy note:** Sections of this reference below the Quick Start still
+> describe an older, pre-release API (`NewBuilder`, `AddTable`, `doc.Render(...)`,
+> `NewSchema`, `RenderOptions`, and similar) that does **not** match the shipped v2
+> package and is being revised. For verified, compiling examples use
+> [GETTING-STARTED.md](GETTING-STARTED.md) and [API.md](API.md).
+
 ## Table of Contents
 
 - [Installation](#installation)
@@ -34,32 +40,32 @@ Here's a simple example demonstrating the v2 Document-Builder pattern:
 package main
 
 import (
+    "context"
     "fmt"
+    "os"
+
     output "github.com/ArjenSchwarz/go-output/v2"
 )
 
 func main() {
-    // Create a builder
-    builder := output.NewBuilder()
-    
-    // Add a table with preserved key ordering
-    builder.AddTable(
-        []map[string]any{
+    // Build an immutable document with a table.
+    // Keys are rendered in the exact order you list them.
+    doc := output.New().
+        Table("People", []map[string]any{
             {"Name": "Alice", "Age": 30, "City": "New York"},
             {"Name": "Bob", "Age": 25, "City": "London"},
-        },
-        output.WithKeys("Name", "Age", "City"), // Exact order preserved
+        }, output.WithKeys("Name", "Age", "City")).
+        Build()
+
+    // Render to JSON and a console table on stdout
+    out := output.NewOutput(
+        output.WithFormats(output.JSON(), output.Table()),
+        output.WithWriter(output.NewStdoutWriter()),
     )
-    
-    // Build immutable document
-    doc := builder.Build()
-    
-    // Render to different formats
-    json, _ := doc.Render("json")
-    fmt.Println(json)
-    
-    table, _ := doc.Render("table")
-    fmt.Println(table)
+    if err := out.Render(context.Background(), doc); err != nil {
+        fmt.Fprintln(os.Stderr, err)
+        os.Exit(1)
+    }
 }
 ```
 

--- a/v2/docs/DOCUMENTATION.md
+++ b/v2/docs/DOCUMENTATION.md
@@ -5,8 +5,8 @@ A comprehensive Go library for outputting structured data in multiple formats. V
 > **⚠️ Accuracy note:** Sections of this reference below the Quick Start still
 > describe an older, pre-release API (`NewBuilder`, `AddTable`, `doc.Render(...)`,
 > `NewSchema`, `RenderOptions`, and similar) that does **not** match the shipped v2
-> package and is being revised. For verified, compiling examples use
-> [GETTING-STARTED.md](GETTING-STARTED.md) and [API.md](API.md).
+> package and is being revised (tracked in T-1728). For verified, compiling examples
+> use [GETTING-STARTED.md](GETTING-STARTED.md) and [API.md](API.md).
 
 ## Table of Contents
 

--- a/v2/docs/GETTING-STARTED.md
+++ b/v2/docs/GETTING-STARTED.md
@@ -18,29 +18,32 @@ go get github.com/ArjenSchwarz/go-output/v2@latest
 package main
 
 import (
+    "context"
     "fmt"
+    "os"
+
     output "github.com/ArjenSchwarz/go-output/v2"
 )
 
 func main() {
-    // Create a builder
-    builder := output.NewBuilder()
-    
-    // Add a table with explicit key ordering
-    builder.AddTable(
-        []map[string]any{
+    // Build an immutable document with a table.
+    // Keys are rendered in the exact order you list them.
+    doc := output.New().
+        Table("Users", []map[string]any{
             {"Name": "Alice", "Age": 30, "Active": true},
             {"Name": "Bob", "Age": 25, "Active": false},
-        },
-        output.WithKeys("Name", "Age", "Active"), // Preserve exact key order
+        }, output.WithKeys("Name", "Age", "Active")).
+        Build()
+
+    // Render as a console table to stdout
+    out := output.NewOutput(
+        output.WithFormat(output.Table()),
+        output.WithWriter(output.NewStdoutWriter()),
     )
-    
-    // Build immutable document
-    doc := builder.Build()
-    
-    // Render as table
-    result, _ := doc.Render("table")
-    fmt.Print(result)
+    if err := out.Render(context.Background(), doc); err != nil {
+        fmt.Fprintln(os.Stderr, err)
+        os.Exit(1)
+    }
 }
 ```
 
@@ -68,10 +71,12 @@ func main() {
 ### Document-Builder Pattern
 ```go
 // v2: Clean separation of building and rendering
-builder := output.NewBuilder()
-builder.AddTable(data, output.WithKeys("col1", "col2"))
-doc := builder.Build()
-result, _ := doc.Render("json")
+doc := output.New().
+    Table("", data, output.WithKeys("col1", "col2")).
+    Build()
+
+out := output.NewOutput(output.WithFormat(output.JSON()))
+_ = out.Render(context.Background(), doc)
 
 // v1: Mixed concerns with global state
 output := format.OutputArray{Settings: settings}
@@ -82,7 +87,8 @@ output.Write()
 ### Key Order Preservation
 ```go
 // v2: Keys are preserved in exact order specified
-builder.AddTable(data, output.WithKeys("Name", "Age", "City"))
+builder := output.New()
+builder.Table("", data, output.WithKeys("Name", "Age", "City"))
 // Output will ALWAYS be Name, Age, City - never alphabetized
 
 // v1: Keys could be reordered unpredictably
@@ -94,13 +100,13 @@ output.Keys = []string{"Name", "Age", "City"}
 ```go
 // v2: Safe concurrent operations
 var wg sync.WaitGroup
-builder := output.NewBuilder()
+builder := output.New()
 
-for i := 0; i < 10; i++ {
+for i := range 10 {
     wg.Add(1)
     go func(id int) {
         defer wg.Done()
-        builder.AddText(fmt.Sprintf("Worker %d", id))
+        builder.Text(fmt.Sprintf("Worker %d", id))
     }(i)
 }
 wg.Wait()
@@ -132,16 +138,18 @@ doc := builder.Build()
 
 ## Quick Format Reference
 
-| Format | Use Case | Render Command |
-|--------|----------|----------------|
-| `json` | APIs, data exchange | `doc.Render("json")` |
-| `yaml` | Configuration files | `doc.Render("yaml")` |
-| `csv` | Spreadsheets | `doc.Render("csv")` |
-| `html` | Web reports | `doc.Render("html")` |
-| `table` | Console output | `doc.Render("table")` |
-| `markdown` | Documentation | `doc.Render("markdown")` |
-| `mermaid` | Diagrams | `doc.Render("mermaid")` |
-| `dot` | GraphViz graphs | `doc.Render("dot")` |
-| `drawio` | Draw.io import | `doc.Render("drawio")` |
+Select a format by passing its constructor to `output.WithFormat`:
+
+| Format | Use Case | Format Constructor |
+|--------|----------|--------------------|
+| JSON | APIs, data exchange | `output.JSON()` |
+| YAML | Configuration files | `output.YAML()` |
+| CSV | Spreadsheets | `output.CSV()` |
+| HTML | Web reports | `output.HTML()` |
+| Table | Console output | `output.Table()` |
+| Markdown | Documentation | `output.Markdown()` |
+| Mermaid | Diagrams | `output.Mermaid()` |
+| DOT | GraphViz graphs | `output.DOT()` |
+| Draw.io | Draw.io import | `output.DrawIO()` |
 
 Start with the Document-Builder pattern for clean, maintainable code that leverages v2's thread-safe, immutable design!

--- a/v2/docs/MIGRATION.md
+++ b/v2/docs/MIGRATION.md
@@ -26,7 +26,7 @@ This guide provides comprehensive instructions for migrating between go-output v
 
 - [Overview](#overview)
 - [Breaking Changes](#breaking-changes)
-- [Automated Migration](#automated-migration)
+- [Migration Approach](#migration-approach)
 - [Migration Patterns](#migration-patterns)
   - [Basic Output](#basic-output)
   - [Multiple Tables](#multiple-tables)
@@ -117,28 +117,11 @@ output.WithSchema(
 )
 ```
 
-## Automated Migration
+## Migration Approach
 
-Use the included migration tool to automatically convert most v1 code:
-
-```bash
-# Install the migration tool
-go install github.com/ArjenSchwarz/go-output/v2/migrate/cmd/migrate@latest
-
-# Migrate a single file
-migrate -file main.go
-
-# Migrate an entire directory
-migrate -source ./myproject
-
-# Dry run to see changes without applying them
-migrate -source ./myproject -dry-run
-
-# Verbose mode for detailed information
-migrate -source ./myproject -verbose
-```
-
-The migration tool handles approximately 80% of common v1 usage patterns. Manual adjustments may be needed for complex scenarios.
+Migration to v2 is manual — there is no automated migration tool. Work through the
+patterns below to convert your v1 code; see
+[MIGRATION_QUICK_REFERENCE.md](MIGRATION_QUICK_REFERENCE.md) for a condensed lookup.
 
 ## Migration Patterns
 
@@ -698,9 +681,7 @@ output.Write()
 #### v2 HTML with Templates
 ```go
 // v2 - Full HTML document with responsive template
-htmlFormat := output.HTML.WithOptions(
-    output.WithHTMLTemplate(output.DefaultHTMLTemplate),
-)
+htmlFormat := output.HTMLWithTemplate(output.DefaultHTMLTemplate)
 
 out := output.NewOutput(
     output.WithFormat(htmlFormat),
@@ -717,19 +698,13 @@ v2 provides three built-in templates:
 
 ```go
 // 1. DefaultHTMLTemplate - Responsive design with mobile-first CSS
-htmlFormat := output.HTML.WithOptions(
-    output.WithHTMLTemplate(output.DefaultHTMLTemplate),
-)
+htmlFormat := output.HTMLWithTemplate(output.DefaultHTMLTemplate)
 
 // 2. MinimalHTMLTemplate - Clean HTML with no styling
-htmlFormat := output.HTML.WithOptions(
-    output.WithHTMLTemplate(output.MinimalHTMLTemplate),
-)
+htmlFormat := output.HTMLWithTemplate(output.MinimalHTMLTemplate)
 
 // 3. MermaidHTMLTemplate - Optimized for Mermaid diagrams
-htmlFormat := output.HTML.WithOptions(
-    output.WithHTMLTemplate(output.MermaidHTMLTemplate),
-)
+htmlFormat := output.HTMLWithTemplate(output.MermaidHTMLTemplate)
 ```
 
 #### Custom Templates
@@ -741,7 +716,6 @@ customTemplate := &output.HTMLTemplate{
     Title:       "Sales Report Q4 2024",
     Description: "Quarterly sales analysis",
     Author:      "Analytics Team",
-    CSS:         output.DefaultResponsiveCSS,
     ThemeOverrides: map[string]string{
         "--primary-color":   "#0066cc",
         "--bg-color":        "#f8f9fa",
@@ -753,9 +727,7 @@ customTemplate := &output.HTMLTemplate{
     },
 }
 
-htmlFormat := output.HTML.WithOptions(
-    output.WithHTMLTemplate(customTemplate),
-)
+htmlFormat := output.HTMLWithTemplate(customTemplate)
 ```
 
 #### Template Features
@@ -770,7 +742,6 @@ htmlFormat := output.HTML.WithOptions(
 ```go
 template := &output.HTMLTemplate{
     Title: "Report",
-    CSS:   output.DefaultResponsiveCSS,
     ThemeOverrides: map[string]string{
         "--primary-color":   "#007bff",
         "--secondary-color": "#6c757d",
@@ -784,7 +755,7 @@ template := &output.HTMLTemplate{
 template := &output.HTMLTemplate{
     HeadExtra: `<script src="analytics.js"></script>`,
     BodyClass: "report-page",
-    BodyAttributes: `data-theme="dark"`,
+    BodyAttrs: map[string]string{"data-theme": "dark"},
     BodyExtra: `<footer>© 2024 Company</footer>`,
 }
 ```
@@ -801,9 +772,7 @@ fw, _ := output.NewFileWriterWithOptions(
     output.WithAppendMode(),
 )
 
-htmlFormat := output.HTML.WithOptions(
-    output.WithHTMLTemplate(output.DefaultHTMLTemplate),
-)
+htmlFormat := output.HTMLWithTemplate(output.DefaultHTMLTemplate)
 
 out := output.NewOutput(
     output.WithFormat(htmlFormat),
@@ -1121,18 +1090,24 @@ func main() {
         Table("Statistics", stats, output.WithKeys("Metric", "Value")).
         Build()
     
+    // File writer creation can fail (e.g. invalid directory)
+    fileWriter, err := output.NewFileWriter(".", "report.json")
+    if err != nil {
+        log.Fatalf("Failed to create file writer: %v", err)
+    }
+
     // Configure output
     out := output.NewOutput(
         // Multiple formats
-        output.WithFormat(output.Table),
-        output.WithFormat(output.JSON),
+        output.WithFormat(output.Table()),
+        output.WithFormat(output.JSON()),
         
         // Multiple destinations
-        output.WithWriter(&output.StdoutWriter{}),
-        output.WithWriter(output.NewFileWriter(".", "report.json")),
+        output.WithWriter(output.NewStdoutWriter()),
+        output.WithWriter(fileWriter),
         
         // Transformers
-        output.WithTransformer(&output.ColorTransformer{}),
+        output.WithTransformer(output.NewColorTransformer()),
         
         // Table styling
         output.WithTableStyle("ColoredBright"),
@@ -1151,6 +1126,7 @@ package main
 
 import (
     "context"
+    "fmt"
     "time"
     
     "github.com/ArjenSchwarz/go-output/v2"
@@ -1158,7 +1134,7 @@ import (
 
 func processData(ctx context.Context) {
     // Create progress indicator
-    progress := output.NewProgress(output.Table,
+    progress := output.NewProgressForFormat(output.Table(),
         output.WithProgressColor(output.ProgressColorGreen),
         output.WithProgressStatus("Processing records"),
     )
@@ -1167,7 +1143,7 @@ func processData(ctx context.Context) {
     progress.SetTotal(100)
     
     // Process data
-    for i := 0; i < 100; i++ {
+    for i := range 100 {
         // Simulate work
         time.Sleep(50 * time.Millisecond)
         
@@ -1186,6 +1162,10 @@ func processData(ctx context.Context) {
     
     // Complete
     progress.Complete()
+}
+
+func main() {
+    processData(context.Background())
 }
 ```
 
@@ -1322,12 +1302,12 @@ data := []map[string]any{
     },
 }
 
-table := output.NewTableContent("Issues", data, output.WithSchema(
-    output.Field{Name: "file", Type: "string", Formatter: output.FilePathFormatter(25)},
-    output.Field{Name: "errors", Type: "array", Formatter: output.ErrorListFormatter()},
-))
-
-doc := output.New().Add(table).Build()
+doc := output.New().
+    Table("Issues", data, output.WithSchema(
+        output.Field{Name: "file", Type: "string", Formatter: output.FilePathFormatter(25)},
+        output.Field{Name: "errors", Type: "array", Formatter: output.ErrorListFormatter()},
+    )).
+    Build()
 
 // Markdown: Creates GitHub-compatible <details> elements
 output.NewOutput(output.WithFormat(output.Markdown)).Render(ctx, doc)
@@ -1427,8 +1407,8 @@ reportSection := output.NewCollapsibleReport(
 )
 
 doc := output.New().
-    Add(analysisSection).
-    Add(reportSection).
+    AddContent(analysisSection).
+    AddContent(reportSection).
     Build()
 ```
 
@@ -1437,33 +1417,38 @@ doc := output.New().
 **Control collapsible behavior globally:**
 
 ```go
-// Table renderer with custom expansion settings
-tableRenderer := output.NewOutput(
-    output.WithFormat(output.Table),
-    output.WithCollapsibleConfig(output.CollapsibleConfig{
-        GlobalExpansion:      false,
-        TableHiddenIndicator: "[click to expand]",
-        MaxDetailLength:      200,
-        TruncateIndicator:    "...",
-    }),
+// Table renderer with custom expansion settings (collapsible config is per renderer)
+tableRenderer := output.NewTableRendererWithCollapsible("Default", output.RendererConfig{
+    ForceExpansion:       false,
+    TableHiddenIndicator: "[click to expand]",
+    MaxDetailLength:      200,
+    TruncateIndicator:    "...",
+})
+tableOut := output.NewOutput(
+    output.WithFormat(output.Format{Name: output.FormatTable, Renderer: tableRenderer}),
 )
 
 // HTML renderer with custom CSS classes
-htmlRenderer := output.NewOutput(
-    output.WithFormat(output.HTML),
-    output.WithCollapsibleConfig(output.CollapsibleConfig{
-        HTMLCSSClasses: map[string]string{
-            "details": "my-collapsible",
-            "summary": "my-summary",
-            "content": "my-details",
-        },
-    }),
+htmlRenderer := output.NewHTMLRendererWithCollapsible(output.RendererConfig{
+    HTMLCSSClasses: map[string]string{
+        "details": "my-collapsible",
+        "summary": "my-summary",
+        "content": "my-details",
+    },
+})
+htmlOut := output.NewOutput(
+    output.WithFormat(output.Format{Name: output.FormatHTML, Renderer: htmlRenderer}),
 )
 ```
 
 ## Data Transformation Pipeline Migration
 
-Version 2 introduces a powerful **Data Transformation Pipeline** system that operates on structured data before rendering, providing significant advantages over the traditional byte-based transformers. This section explains how to migrate from byte transformers to data pipelines and when to use each approach.
+> **⚠️ Removed in v2.4.0:** The fluent `doc.Pipeline()` API shown throughout this
+> section no longer exists. It was replaced by **per-content transformations**
+> (`output.WithTransformations(...)` passed to `Table`, etc.). For the current,
+> verified migration path see [PIPELINE_MIGRATION.md](PIPELINE_MIGRATION.md). The
+> `doc.Pipeline()` examples below are retained only to illustrate the old shape you
+> are migrating *away from* — do not copy them into new code.
 
 ### Overview: Two Transformation Systems
 
@@ -2205,4 +2190,4 @@ For complete migration examples and best practices, see:
 - Read [PIPELINE_MIGRATION.md](PIPELINE_MIGRATION.md) for Pipeline API migration
 - Report issues at [GitHub Issues](https://github.com/ArjenSchwarz/go-output/issues)
 
-The migration tool can handle most common patterns automatically. For complex migrations, refer to this guide and the API documentation.
+For complex migrations, refer to this guide and the API documentation.

--- a/v2/docs/MIGRATION.md
+++ b/v2/docs/MIGRATION.md
@@ -1448,7 +1448,8 @@ htmlOut := output.NewOutput(
 > (`output.WithTransformations(...)` passed to `Table`, etc.). For the current,
 > verified migration path see [PIPELINE_MIGRATION.md](PIPELINE_MIGRATION.md). The
 > `doc.Pipeline()` examples below are retained only to illustrate the old shape you
-> are migrating *away from* — do not copy them into new code.
+> are migrating *away from* — do not copy them into new code. Shrinking this section
+> to a pointer is tracked in T-1729.
 
 ### Overview: Two Transformation Systems
 


### PR DESCRIPTION
Fixes the T-1690 documentation drift: the primary consumer-facing v2 docs described APIs that never shipped or were removed. Every claim was grep/git-verified against the v2 source before editing.

## Ticket items

1. **GETTING-STARTED.md 30-Second Example** — rewrote it (and every other snippet in the file) to the real API: `output.New()` → `Builder.Table(title, data, opts...)` → `output.NewOutput(...).Render(ctx, doc)`. Fixed the "Quick Format Reference" table (`doc.Render("json")` → `output.JSON()` etc.).
2. **API.md phantom identifiers** — replaced everywhere they occur:
   - `HTML.WithOptions`/`WithHTMLTemplate`/`DefaultResponsiveCSS` → `HTMLWithTemplate()` / `DefaultHTMLTemplate`; corrected the `HTMLTemplate` field list (`Keywords`/`BodyAttributes` → `MetaTags`/`BodyAttrs`, added `Language`).
   - `.Add(...)` → `AddContent(...)`.
   - `CollapsibleConfig`/`WithCollapsibleConfig` (no such type/option) → the real per-renderer mechanism: `RendererConfig` + `NewTableRendererWithCollapsible`/`NewHTMLRendererWithCollapsible`/… wrapped in a `Format`.
3. **API.md removed Pipeline section** — shrank ~441 lines of worked examples for the v2.4.0-removed `doc.Pipeline()` API to a short pointer to PIPELINE_MIGRATION.md.
4. **MIGRATION.md `migrate` tool** — struck the "Automated Migration" section and every other reference to `go install …/migrate/cmd/migrate@latest` (the module was deleted in c66fe85; a v1 user hit module-not-found). Same removal in BREAKING_CHANGES.md.
5. **v2/CLAUDE.md** — removed the nonexistent `pipeline_*.go` test-split bullet and the `test-conversion/` section; kept the accurate `errors_*`/`renderer_*`/`operations_*`/`progress_*` bullets.
6. **Doc-example compile check** — added `v2/doc_examples_test.go`: `TestDocumentationExamplesCompile` extracts every complete `package main` example from `docs/*.md` and runs `go build` on it. Drift now fails `go test ./...` (which CI already runs) and `make check`; also exposed as `make doc-examples`. (Implemented as a test rather than a workflow edit so it gates the existing CI without needing `workflow` token scope.)

The check compiles only complete programs (`package main` + `func main(`); fragments are illustrative and skipped. All 6 complete examples across the docs now compile; verified the test fails on injected drift.

## Also fixed (same phantom identifiers, beyond the cited line numbers)
- MIGRATION.md carried the same `HTML.WithOptions`/`DefaultResponsiveCSS`/`BodyAttributes`, `WithCollapsibleConfig`, and `.Add(...)` phantoms in its recommended-v2 examples — fixed to match API.md.
- Its two complete examples now compile (`output.Table` → `output.Table()`, `NewFileWriter`/`NewStdoutWriter`/`NewColorTransformer` constructors, `NewProgress` → `NewProgressForFormat`, added missing `fmt` import + `main`).

## Known follow-ups (not fixed here — out of T-1690's scope)
- **DOCUMENTATION.md** documents a *wholly fictional* pre-release API (`NewBuilder`, `AddTable`, `doc.Render(...)`, `NewSchema`, `Field{Key/Header/Validator}`, `RenderOptions`, `doc.Transform`, the `UppercaseFormatter`-style formatters — none exist). Fixing it is a ground-up rewrite of code *and* prose. This PR fixes only its Quick Start (so the compile check passes) and adds an accuracy banner pointing readers to GETTING-STARTED.md/API.md. Recommend a dedicated documentation ticket for the full rewrite.
- MIGRATION.md's "Data Transformation Pipeline Migration" section still shows the removed `doc.Pipeline()` API as worked examples; added a deprecation banner pointing to PIPELINE_MIGRATION.md rather than deleting ~680 lines in this PR.

## Validation
`go build ./...`, `go vet ./...`, `go test ./...` all pass; `make doc-examples` green (6/6). `golangci-lint` not available in the authoring environment, but no library `.go` code changed and the linter config has `run.tests: false` (test files are not linted).