### PR TITLE
Fix T-1429: Pretty Progress Signal Race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
 ### Fixed
+- Fixed a data race in `prettyProgress` between `SetContext` and the signal-handling goroutine: `contextDone()` now reads the shared context under the mutex (T-1429). Previously, calling `SetContext` on a TTY-backed progress indicator while the signal goroutine was running failed `go test -race`.
 - The Builder now records an error when content or metadata is added after `Build()` has finalized the document; previously such mutations vanished silently with `HasErrors()` returning false (T-1689). The built document remains unchanged and the fluent API remains non-panicking.
 - The DOT and Mermaid renderers now propagate `NewGraphContentFromTable` errors instead of discarding them (T-1689). No behavior change today — the only current error condition is unreachable at those call sites — but future error conditions will surface through `Render`.
 - The godoc for `Builder`, `Build`, `Table`, and `Raw` now documents the fluent-chain error contract: failures are recorded on the builder, the affected content is omitted from the document, and callers should check `HasErrors()`/`Errors()` after building (T-1689).

--- a/specs/bugfixes/pretty-progress-signal-race/report.md
+++ b/specs/bugfixes/pretty-progress-signal-race/report.md
@@ -1,0 +1,102 @@
+# Bugfix Report: pretty-progress-signal-race
+
+**Date:** 2026-07-10
+**Status:** In progress
+**Ticket:** T-1429
+
+## Description of the Issue
+
+`v2/progress_pretty.go` has an unsynchronized access to `p.ctx`: the signal-handling
+goroutine started by `NewPrettyProgress` calls `handleSignals()`, which evaluates
+`p.contextDone()` on every select iteration. `contextDone()` reads the shared `p.ctx`
+field without holding `p.mu`, while `SetContext()` writes `p.ctx` under the mutex.
+Calling `SetContext()` on a TTY-backed `prettyProgress` while the signal goroutine is
+running is a data race.
+
+**Reproduction steps:**
+1. Construct a `prettyProgress` (TTY path) so `handleSignals()` is running.
+2. Concurrently call `SetContext()` from another goroutine while signals drive the
+   loop (must be a different goroutine than the one feeding `p.signals`, otherwise
+   the channel send/receive creates a happens-before edge that hides the race).
+3. Run under `go test -race`: the detector reports a write at
+   `progress_pretty.go:324` (`SetContext`) racing with a read at
+   `progress_pretty.go:100` (`contextDone`).
+
+**Impact:** Data race in any program that uses `NewPrettyProgress` on a real terminal
+and calls `SetContext` after construction. Undefined behaviour per the Go memory
+model; the signal goroutine can observe stale or inconsistent context state. Fails
+`go test -race` in consuming projects.
+
+## Investigation Summary
+
+- **Symptoms examined:** Race-detector report between `handleSignals` -> `contextDone`
+  (unsynchronized read of `p.ctx`) and `SetContext` (locked write of `p.ctx`).
+- **Code inspected:** `v2/progress_pretty.go` (all reads/writes of `p.ctx`),
+  `v2/progress_core_test.go` (existing prettyProgress test helpers).
+- **Hypotheses tested:** Audited every access to `p.ctx`:
+  - `NewPrettyProgress` write — safe (happens-before the `go` statements).
+  - `SetContext` write and its watcher goroutine's read — safe (both under `p.mu`).
+  - `contextDone()` read from the signal goroutine — unsynchronized. Confirmed as the
+    only defect by a focused failing regression test.
+
+## Discovered Root Cause
+
+`contextDone()` reads `p.ctx` without acquiring `p.mu`, while `SetContext()` mutates
+`p.ctx` under the lock.
+
+**Defect type:** Race condition (unsynchronized read of a mutex-guarded field).
+
+**Why it occurred:** `contextDone()` was introduced as a nil-safety accessor in the
+earlier `prettyprogress-handle-signals-nil-context` fix, at a time when the code was
+written as if `p.ctx` were set once at construction. The v1-compatibility
+`SetContext()` makes `p.ctx` mutable at runtime, and the reader was never revisited.
+The related `progress-setcontext-replacement-fails` fix (T-1358) synchronized the
+watcher goroutine's read of `p.ctx` but not the signal goroutine's.
+
+**Contributing factors:** `NewPrettyProgress` falls back to `textProgress` when stderr
+is not a TTY, so CI tests never exercised the signal goroutine concurrently with
+`SetContext`.
+
+## Resolution for the Issue
+
+Pending — regression test committed first (red phase).
+
+## Regression Test
+
+**Test file:** `v2/progress_core_test.go`
+**Test name:** `TestPrettyProgress_SetContext_SignalGoroutine_NoRace`
+
+**What it verifies:** Driving the signal loop (so `contextDone()` is re-evaluated on
+each iteration) while `SetContext` concurrently replaces the context is race-free.
+The `SetContext` calls run in a separate goroutine from the signal feeder so no
+accidental happens-before edge masks the race.
+
+**Run command:** `cd v2 && go test -race -run TestPrettyProgress_SetContext_SignalGoroutine_NoRace -count=1 .`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `v2/progress_core_test.go` | Added race regression test |
+| `v2/progress_pretty.go` | (pending fix) |
+
+## Verification
+
+**Automated:**
+- [x] Regression test fails before the fix (race detected at `progress_pretty.go:100` vs `:324`)
+- [ ] Regression test passes
+- [ ] Full test suite passes
+- [ ] Linters/validators pass
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- When adding an accessor for a mutex-guarded field, take the lock inside the
+  accessor rather than assuming callers hold it or that the field is immutable.
+- Run the package tests with `-race` whenever goroutines are added or modified.
+
+## Related
+
+- Transit ticket T-1429
+- Prior fixes: `specs/bugfixes/prettyprogress-handle-signals-nil-context/`,
+  `specs/bugfixes/progress-setcontext-replacement-fails/` (T-1358)

--- a/specs/bugfixes/pretty-progress-signal-race/report.md
+++ b/specs/bugfixes/pretty-progress-signal-race/report.md
@@ -1,7 +1,7 @@
 # Bugfix Report: pretty-progress-signal-race
 
 **Date:** 2026-07-10
-**Status:** In progress
+**Status:** Fixed
 **Ticket:** T-1429
 
 ## Description of the Issue
@@ -59,7 +59,25 @@ is not a TTY, so CI tests never exercised the signal goroutine concurrently with
 
 ## Resolution for the Issue
 
-Pending — regression test committed first (red phase).
+**Changes made:**
+- `v2/progress_pretty.go:99-109` - `contextDone()` now acquires `p.mu.RLock()` before
+  reading `p.ctx`, and documents why the lock is needed.
+
+**Approach rationale:** `p.mu` is already an `sync.RWMutex` guarding every other
+access to `p.ctx`; taking a read lock in the accessor is the minimal change that
+makes all reads and writes of the field synchronized. The lock is held only for the
+duration of the channel lookup (never while blocked in select), so there is no
+deadlock or contention concern. It matches the pattern the T-1358 fix established
+for the SetContext watcher goroutine.
+
+**Alternatives considered:**
+- Capture a stable done channel once at goroutine start (or pass it as a parameter
+  to `handleSignals`) - also race-free, but changes the function signature and the
+  goroutine's observable lifetime semantics for no additional benefit; the locked
+  accessor is smaller and keeps existing behaviour.
+- Store `p.ctx` in an `atomic.Pointer[context.Context]` - avoids the mutex but adds
+  a second synchronization mechanism for a field the mutex already guards elsewhere,
+  making the invariants harder to follow.
 
 ## Regression Test
 
@@ -78,15 +96,15 @@ accidental happens-before edge masks the race.
 | File | Change |
 |------|--------|
 | `v2/progress_core_test.go` | Added race regression test |
-| `v2/progress_pretty.go` | (pending fix) |
+| `v2/progress_pretty.go` | `contextDone()` reads `p.ctx` under `p.mu.RLock()` |
 
 ## Verification
 
 **Automated:**
 - [x] Regression test fails before the fix (race detected at `progress_pretty.go:100` vs `:324`)
-- [ ] Regression test passes
-- [ ] Full test suite passes
-- [ ] Linters/validators pass
+- [x] Regression test passes (`go test -race -run TestPrettyProgress_SetContext_SignalGoroutine_NoRace -count=5 .`)
+- [x] Full test suite passes with the race detector (`go test -race ./...`: ok for v2 and v2/icons)
+- [x] Linters/validators pass (`golangci-lint run`: 0 issues; `go vet`, `gofmt` clean)
 
 ## Prevention
 

--- a/v2/progress_core_test.go
+++ b/v2/progress_core_test.go
@@ -1058,6 +1058,58 @@ func TestPrettyProgress_HandleSignals_NilContext_DoesNotPanic(t *testing.T) {
 	}
 }
 
+// TestPrettyProgress_SetContext_SignalGoroutine_NoRace is a regression test
+// for T-1429: handleSignals evaluated p.contextDone(), which read the shared
+// p.ctx field without holding p.mu, while SetContext wrote p.ctx under the
+// mutex. Running the signal loop concurrently with SetContext is a data race
+// detectable with `go test -race`.
+//
+// Expected: reads and writes of p.ctx are synchronized, so driving the signal
+// loop while SetContext replaces the context is race-free.
+//
+// Note: SetContext must run in a different goroutine from the one feeding
+// p.signals — a channel send/receive pair would otherwise create a
+// happens-before edge that hides the race from the detector.
+func TestPrettyProgress_SetContext_SignalGoroutine_NoRace(t *testing.T) {
+	var buf bytes.Buffer
+	p := newTestPrettyProgress(&buf)
+
+	handlerDone := make(chan struct{})
+	go func() {
+		defer close(handlerDone)
+		p.handleSignals()
+	}()
+
+	// Hammer SetContext from a separate goroutine so its writes to p.ctx have
+	// no synchronization edge with the signal loop's reads.
+	setterDone := make(chan struct{})
+	go func() {
+		defer close(setterDone)
+		for range 200 {
+			p.SetContext(context.Background())
+		}
+	}()
+
+	// Feed non-SIGWINCH signals so the loop keeps iterating and re-evaluates
+	// contextDone() on each pass. Stop early if the handler exits (it may
+	// observe a replaced context being cancelled).
+	for range 200 {
+		select {
+		case p.signals <- os.Interrupt:
+		case <-handlerDone:
+		}
+	}
+
+	<-setterDone
+	p.Close()
+
+	select {
+	case <-handlerDone:
+	case <-time.After(time.Second):
+		t.Fatal("handleSignals did not exit after Close")
+	}
+}
+
 func TestPrettyProgress_SignalHandling(t *testing.T) {
 	var buf bytes.Buffer
 	progress := NewPrettyProgress(WithProgressWriter(&buf))

--- a/v2/progress_pretty.go
+++ b/v2/progress_pretty.go
@@ -96,7 +96,12 @@ func (p *prettyProgress) handleSignals() {
 	}
 }
 
+// contextDone returns the current context's done channel, or nil when no
+// context is set. It takes p.mu because it is called from the signal-handling
+// goroutine while SetContext may concurrently replace p.ctx.
 func (p *prettyProgress) contextDone() <-chan struct{} {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
 	if p.ctx == nil {
 		return nil
 	}


### PR DESCRIPTION
## Summary

Fixes T-1429: `prettyProgress` signal goroutine races with `SetContext`.

## Bug

`handleSignals()` (started by `NewPrettyProgress` on the TTY path) re-evaluates `p.contextDone()` on every select iteration. `contextDone()` read the shared `p.ctx` field without holding `p.mu`, while `SetContext()` writes `p.ctx` under the mutex. Calling `SetContext()` while the signal goroutine runs is a data race (`go test -race` flags the read at `progress_pretty.go:100` against the write at `progress_pretty.go:324`) and lets the goroutine observe stale context state.

## Root Cause

`contextDone()` was added as a nil-safety accessor (prettyprogress-handle-signals-nil-context fix) when `p.ctx` was effectively set once at construction. The v1-compat `SetContext()` made the field mutable at runtime; the T-1358 fix synchronized the SetContext watcher goroutine's read but the signal goroutine's read was never revisited.

## Fix

`contextDone()` now acquires `p.mu.RLock()` for the channel lookup, so every read and write of `p.ctx` is synchronized. The lock is held only for the lookup, never while blocked in select — no deadlock or contention risk, no behaviour change.

## Testing

- New regression test `TestPrettyProgress_SetContext_SignalGoroutine_NoRace` (drives the signal loop while a separate goroutine hammers `SetContext`; the setter runs in its own goroutine so no channel happens-before edge masks the race). Failed under `-race` before the fix, passes after (verified with `-count=5`).
- Full suite: `go test -race ./...` — ok for `v2` and `v2/icons`.
- `golangci-lint run`: 0 issues; `go vet` and `gofmt` clean.

Full analysis: `specs/bugfixes/pretty-progress-signal-race/report.md`.