### PR TITLE
Fix T-1583: S3Writer Content Type Map Races With Writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixed
 - Fixed a data race in `prettyProgress` between `SetContext` and the signal-handling goroutine: `contextDone()` now reads the shared context under the mutex (T-1429). Previously, calling `SetContext` on a TTY-backed progress indicator while the signal goroutine was running failed `go test -race`.
+- `S3Writer.SetContentType` is now safe to call concurrently with `Write` (T-1583). Access to the content-type configuration is synchronized with an `RWMutex`, eliminating a data race between `SetContentType` and `Write`'s content-type lookup that could panic with a concurrent map read/write.
 - The Builder now records an error when content or metadata is added after `Build()` has finalized the document; previously such mutations vanished silently with `HasErrors()` returning false (T-1689). The built document remains unchanged and the fluent API remains non-panicking.
 - The DOT and Mermaid renderers now propagate `NewGraphContentFromTable` errors instead of discarding them (T-1689). No behavior change today — the only current error condition is unreachable at those call sites — but future error conditions will surface through `Render`.
 - The godoc for `Builder`, `Build`, `Table`, and `Raw` now documents the fluent-chain error contract: failures are recorded on the builder, the affected content is omitted from the document, and callers should check `HasErrors()`/`Errors()` after building (T-1689).

--- a/specs/bugfixes/s3writer-content-type-race/report.md
+++ b/specs/bugfixes/s3writer-content-type-race/report.md
@@ -66,7 +66,24 @@ called after writes begin.
 
 ## Resolution for the Issue
 
-_To be filled in after the fix is implemented._
+**Changes made:**
+- `v2/s3_writer.go` - Added a `sync.RWMutex` (`mu`) to `S3Writer` guarding
+  `contentTypes`. `SetContentType` and `WithContentTypes` take the write
+  lock; `getContentType` takes the read lock. `SetContentType`'s godoc now
+  states it is safe to call concurrently with `Write`.
+
+**Approach rationale:** An RWMutex gives every map access a happens-before
+edge with minimal code. Reads happen on every upload while writes are rare
+configuration changes, so a read/write lock fits the access pattern. An
+uncontended `RLock` per upload is negligible next to an S3 network call, and
+the approach matches existing conventions (`FileWriter` uses `sync.Mutex`,
+`Document` uses `sync.RWMutex`).
+
+**Alternatives considered:**
+- Copy-on-write via `atomic.Pointer` to an immutable map - Lock-free reads,
+  but more code and subtlety for a config map that changes rarely; overkill.
+- Removing `SetContentType` / making configuration immutable after
+  construction - Breaking API change; rejected.
 
 ## Regression Test
 
@@ -84,19 +101,19 @@ the race detector, and all writes still succeed with the expected number of
 
 | File | Change |
 |------|--------|
-| `v2/s3_writer.go` | Synchronize access to `contentTypes` (fix pending) |
+| `v2/s3_writer.go` | Added `sync.RWMutex`; locked `SetContentType`, `getContentType`, and `WithContentTypes` |
 | `v2/s3_writer_test.go` | Added regression test `TestS3WriterSetContentTypeConcurrentWithWrite` |
 
 ## Verification
 
 **Automated:**
-- [ ] Regression test passes under `go test -race`
-- [ ] Full test suite passes
-- [ ] Linters/validators pass
+- [x] Regression test passes under `go test -race`
+- [x] Full test suite passes (`make test` and `go test -race ./...` in `v2/`)
+- [x] Linters/validators pass (`make lint`, 0 issues)
 
 **Manual verification:**
 - Confirmed the regression test fails with the documented race reports before
-  the fix.
+  the fix and passes after.
 
 ## Prevention
 

--- a/specs/bugfixes/s3writer-content-type-race/report.md
+++ b/specs/bugfixes/s3writer-content-type-race/report.md
@@ -1,0 +1,114 @@
+# Bugfix Report: S3Writer Content Type Map Races With Writes
+
+**Date:** 2026-07-10
+**Status:** Fixed
+**Ticket:** T-1583
+
+## Description of the Issue
+
+`S3Writer.SetContentType` mutated the shared `contentTypes` map without any
+synchronization while `Write` read the same map through `getContentType`.
+Running configuration updates concurrently with writes triggered a Go data
+race and risked a `concurrent map read and map write` runtime panic.
+
+**Reproduction steps:**
+1. Create an `S3Writer` with a mock (or real) S3 client.
+2. From one goroutine, repeatedly call `writer.SetContentType(output.FormatJSON, "application/json")`.
+3. From another goroutine, repeatedly call `writer.Write(context.Background(), output.FormatJSON, []byte("{}"))`.
+4. Run under `go test -race`: the detector reports races between
+   `(*S3Writer).SetContentType` (`v2/s3_writer.go:314`) and
+   `(*S3Writer).getContentType` (`v2/s3_writer.go:341`), plus write/write
+   races between concurrent `SetContentType` calls.
+
+**Impact:** Any application sharing an `S3Writer` across goroutines while
+adjusting content types could hit undefined behaviour or crash with a map
+concurrency panic. The v2 library explicitly promises thread-safe operations,
+so this violated the documented contract.
+
+## Investigation Summary
+
+Systematic inspection (Fagan-style walkthrough) of `v2/s3_writer.go`.
+
+- **Symptoms examined:** Race detector reports referenced in T-1583
+  (reproduced 2026-06-19), pointing at the map write in `SetContentType` and
+  the map read in `getContentType`.
+- **Code inspected:** All accesses to `S3Writer.contentTypes`
+  (`NewS3Writer`, `SetContentType`, `getContentType`, `WithContentTypes`),
+  all `Write` code paths (`putS3Object`, `appendToS3Object`), and the other
+  mutable `S3Writer` fields. Also reviewed sibling writers for conventions —
+  `FileWriter` already guards mutable state with `sync.Mutex`
+  (`v2/file_writer.go:30`).
+- **Hypotheses tested:** Verified that no other post-construction setters
+  exist (`appendMode`, `maxAppendSize` are only set via options at
+  construction) and that `defaultContentTypes()` returns a fresh map per
+  instance, so the race is confined to `contentTypes` on a single writer.
+  Confirmed the existing `TestS3WriterConcurrency` never caught this because
+  it only runs concurrent `Write` calls (pure map reads).
+
+## Discovered Root Cause
+
+Mutable shared state (the `contentTypes` map) is exposed through an
+unsynchronized public setter on a type whose contract is thread safety.
+
+**Defect type:** Race condition (unsynchronized concurrent map access).
+
+**Why it occurred:** `S3Writer` was designed assuming configuration completes
+before any writes. `SetContentType` was added as a post-construction setter
+without revisiting that assumption, and nothing documents that it must not be
+called after writes begin.
+
+**Contributing factors:**
+- `WithContentTypes` also mutates the map via `maps.Copy`; it is normally
+  applied pre-publication in `NewS3WriterWithOptions`, but `S3WriterOption`
+  is an exported func type, so it can be applied to a live writer too.
+- The existing concurrency test only exercised concurrent reads, so
+  `go test -race` in CI never saw the write path race.
+
+## Resolution for the Issue
+
+_To be filled in after the fix is implemented._
+
+## Regression Test
+
+**Test file:** `v2/s3_writer_test.go`
+**Test name:** `TestS3WriterSetContentTypeConcurrentWithWrite`
+
+**What it verifies:** Two goroutines repeatedly calling `SetContentType`
+while another goroutine repeatedly calls `Write` produce no data race under
+the race detector, and all writes still succeed with the expected number of
+`PutObject` calls.
+
+**Run command:** `go test -race -run TestS3WriterSetContentTypeConcurrentWithWrite ./...` (from `v2/`)
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `v2/s3_writer.go` | Synchronize access to `contentTypes` (fix pending) |
+| `v2/s3_writer_test.go` | Added regression test `TestS3WriterSetContentTypeConcurrentWithWrite` |
+
+## Verification
+
+**Automated:**
+- [ ] Regression test passes under `go test -race`
+- [ ] Full test suite passes
+- [ ] Linters/validators pass
+
+**Manual verification:**
+- Confirmed the regression test fails with the documented race reports before
+  the fix.
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Any exported setter on a type documented as thread-safe must synchronize
+  with all readers of the state it mutates.
+- When adding concurrency tests, include configuration mutation alongside
+  reads, not just concurrent read-only operations.
+- Prefer running `go test -race` for the whole package when touching shared
+  state in writers.
+
+## Related
+
+- Transit ticket T-1583
+- Similar prior fix pattern: `FileWriter` mutex (`v2/file_writer.go`)

--- a/v2/s3_writer.go
+++ b/v2/s3_writer.go
@@ -9,6 +9,7 @@ import (
 	"maps"
 	"path"
 	"strings"
+	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
@@ -66,6 +67,7 @@ type S3Writer struct {
 	client        S3PutObjectAPI
 	bucket        string
 	keyPattern    string            // e.g., "reports/{format}/output.{ext}"
+	mu            sync.RWMutex      // guards contentTypes
 	contentTypes  map[string]string // format to content-type mapping
 	appendMode    bool              // enable append mode (download-modify-upload pattern)
 	maxAppendSize int64             // maximum object size for append operations (default 100MB)
@@ -309,8 +311,11 @@ func (sw *S3Writer) combineCSVData(existing, new []byte) ([]byte, error) {
 	return append(existing, dataWithoutHeader...), nil
 }
 
-// SetContentType sets a custom content type for a format
+// SetContentType sets a custom content type for a format.
+// It is safe to call concurrently with Write and other SetContentType calls.
 func (sw *S3Writer) SetContentType(format, contentType string) {
+	sw.mu.Lock()
+	defer sw.mu.Unlock()
 	sw.contentTypes[format] = contentType
 }
 
@@ -338,6 +343,8 @@ func (sw *S3Writer) generateKey(format string) (string, error) {
 
 // getContentType returns the content type for a format
 func (sw *S3Writer) getContentType(format string) string {
+	sw.mu.RLock()
+	defer sw.mu.RUnlock()
 	if ct, ok := sw.contentTypes[format]; ok {
 		return ct
 	}
@@ -397,6 +404,8 @@ func WithMaxAppendSize(maxSize int64) S3WriterOption {
 // WithContentTypes sets custom content types
 func WithContentTypes(contentTypes map[string]string) S3WriterOption {
 	return func(sw *S3Writer) {
+		sw.mu.Lock()
+		defer sw.mu.Unlock()
 		maps.Copy(sw.contentTypes, contentTypes)
 	}
 }

--- a/v2/s3_writer_test.go
+++ b/v2/s3_writer_test.go
@@ -378,6 +378,53 @@ func TestS3WriterConcurrency(t *testing.T) {
 	}
 }
 
+// TestS3WriterSetContentTypeConcurrentWithWrite is a regression test for
+// T-1583: SetContentType mutated the shared contentTypes map without
+// synchronization while Write read it through getContentType.
+//
+// Expected behaviour: concurrent configuration updates and writes are safe.
+// Actual behaviour before the fix: `go test -race` reported a data race
+// between the map write in SetContentType and the map read in getContentType,
+// plus write/write races between concurrent SetContentType calls, risking a
+// concurrent map read/write panic.
+func TestS3WriterSetContentTypeConcurrentWithWrite(t *testing.T) {
+	client := &mockS3Client{}
+	sw := NewS3Writer(client, "test-bucket", "race/{format}.{ext}")
+	ctx := context.Background()
+
+	const iterations = 100
+	var wg sync.WaitGroup
+
+	// Concurrent configuration updates (map writes). Two goroutines also
+	// exercise the SetContentType/SetContentType write-write race.
+	for range 2 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range iterations {
+				sw.SetContentType(FormatJSON, "application/json")
+			}
+		}()
+	}
+
+	// Concurrent writes (map reads via getContentType).
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range iterations {
+			if err := sw.Write(ctx, FormatJSON, []byte("{}")); err != nil {
+				t.Errorf("concurrent write failed: %v", err)
+			}
+		}
+	}()
+
+	wg.Wait()
+
+	if got := len(client.getCalls()); got != iterations {
+		t.Errorf("PutObject call count = %d, want %d", got, iterations)
+	}
+}
+
 func TestGenerateKey(t *testing.T) {
 	sw := &S3Writer{
 		keyPattern: "reports/{format}/output.{ext}",


### PR DESCRIPTION
## Summary

Fixes T-1583: `S3Writer.SetContentType` mutated the shared `contentTypes` map without synchronization while `Write` read it through `getContentType`, triggering a Go data race and risking a concurrent map read/write panic.

## Root Cause

Mutable shared state (the `contentTypes` map) was exposed through an unsynchronized public setter on a type whose contract is thread safety. `S3Writer` was designed assuming configuration completes before writes begin, and `SetContentType` was added without revisiting that assumption. The existing concurrency test only exercised concurrent `Write` calls (pure map reads), so the race was never caught.

## Fix

Added a `sync.RWMutex` to `S3Writer` guarding `contentTypes`:
- `SetContentType` and `WithContentTypes` take the write lock
- `getContentType` (used by both upload paths in `Write`) takes the read lock
- `SetContentType`'s godoc now states it is safe to call concurrently with `Write`

This matches existing conventions (`FileWriter` uses `sync.Mutex`, `Document` uses `sync.RWMutex`).

## Regression Test

`TestS3WriterSetContentTypeConcurrentWithWrite` in `v2/s3_writer_test.go` runs two goroutines calling `SetContentType` concurrently with a goroutine calling `Write`. It reproduced both reported races before the fix (verified red) and passes under `go test -race` after.

## Verification

- `go test -race ./...` in `v2/`: all packages pass
- `make test`: pass
- `make lint`: 0 issues

Full details in `specs/bugfixes/s3writer-content-type-race/report.md`.