### PR TITLE
Fix T-1625: Markdown Text Color Is Not Escaped in Style Attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Unreleased
 
 ### Fixed
-<<<<<<< HEAD
+- The Markdown renderer now HTML-escapes `TextStyle.Color` before embedding it in the `style` attribute of the `<span>` emitted for colored or sized text (T-1625). Previously a hostile color value such as `red" onclick="alert(1)` supplied via `WithColor`/`WithTextStyle` could break out of the attribute and inject HTML when the Markdown output was rendered as HTML. The value is now escaped with `html.EscapeString`, matching the HTML renderer; valid CSS colors are unaffected.
 - Fixed a data race in `prettyProgress` between `SetContext` and the signal-handling goroutine: `contextDone()` now reads the shared context under the mutex (T-1429). Previously, calling `SetContext` on a TTY-backed progress indicator while the signal goroutine was running failed `go test -race`.
 - `S3Writer.SetContentType` is now safe to call concurrently with `Write` (T-1583). Access to the content-type configuration is synchronized with an `RWMutex`, eliminating a data race between `SetContentType` and `Write`'s content-type lookup that could panic with a concurrent map read/write.
 - Fixed a data race in `FileWriter`: `Write` read the format-to-extension map while generating the filename before acquiring the writer's mutex, so a concurrent `SetExtension` call could trigger a Go concurrent map read/write fault (T-1629). `Write` now acquires the mutex before filename generation, so extension reads and writes share the same lock.

--- a/specs/bugfixes/markdown-color-escaping/report.md
+++ b/specs/bugfixes/markdown-color-escaping/report.md
@@ -1,0 +1,76 @@
+# Bugfix Report: Markdown Text Color Is Not Escaped in Style Attribute
+
+**Ticket:** T-1625
+**Date:** 2026-07-12
+**Status:** Fixed
+
+## Description of the Issue
+
+The Markdown renderer emits raw HTML when `TextStyle.Color` or `TextStyle.Size` is set, because color and size have no native Markdown equivalent. The color value was interpolated directly into the `style` attribute of the generated `<span>` without any HTML attribute escaping or validation.
+
+**Reproduction steps:**
+1. Build a document with `Text("Styled text", WithTextStyle(TextStyle{Color: "red\" onclick=\"alert(1)"}))`
+2. Render the document with the Markdown renderer
+3. Observe the output: `<span style="color: red" onclick="alert(1)">Styled text</span>` — the hostile color value closed the `style` attribute and injected an `onclick` attribute
+
+**Impact:** Any consumer that renders the Markdown output as HTML (GitHub, documentation sites, wikis) can end up with injected attributes or elements if the color value comes from untrusted input. Severity is moderated by the fact that the color value is supplied by the calling application, but the library must not be an injection vector when that value is attacker-influenced. The HTML renderer already escaped this value; only the Markdown renderer was vulnerable.
+
+## Investigation Summary
+
+The ticket identified the exact defect site, and inspection confirmed it and ruled out sibling occurrences.
+
+- **Symptoms examined:** Rendered Markdown output containing a live `onclick` attribute and a live `<script>` element when hostile color values were supplied via `WithTextStyle`/`WithColor`.
+- **Code inspected:** `v2/markdown_renderer.go` (`renderTextContentMarkdown`), `v2/html_renderer.go` (`renderTextContentHTML`, which escapes with `html.EscapeString`), and all other raw-HTML emission sites in the Markdown renderer (`<details>`/`<summary>` handling).
+- **Hypotheses tested:** Checked whether other Markdown renderer sites interpolate user data into HTML attributes — they do not. The `<details%s>` sites only interpolate a fixed `openAttr` constant; summary/detail *content* goes through `escapeHTMLContent`/`escapeMarkdown`. `TextStyle.Size` is an `int` formatted with `%d`, so it cannot carry an injection payload. The `style` attribute in `renderTextContentMarkdown` was the only injection point.
+
+## Discovered Root Cause
+
+`renderTextContentMarkdown` built the style attribute with `fmt.Sprintf("color: %s", style.Color)` and embedded it via `<span style="%s">` without escaping. A `"` in the color value therefore terminated the attribute, allowing arbitrary attribute or element injection.
+
+**Defect type:** Missing output encoding (HTML attribute escaping) of user-controlled data.
+
+**Why it occurred:** The Markdown renderer's escaping helpers focus on Markdown metacharacters. When the color/size feature required dropping down to raw HTML, the value was embedded without applying HTML escaping. The equivalent code path in the HTML renderer was hardened with `html.EscapeString`, but the duplicated logic in the Markdown renderer was overlooked.
+
+**Contributing factors:** The styled-text-to-HTML logic is duplicated between the HTML and Markdown renderers rather than shared, so a fix in one did not propagate to the other.
+
+## Resolution for the Issue
+
+_Pending — filled in after the fix is implemented._
+
+## Regression Test
+
+**Test file:** `v2/renderer_markdown_test.go`
+**Test name:** `TestMarkdownRenderer_TextStyleColorEscaping`
+
+**What it verifies:** Hostile color values cannot escape the `style` attribute. Covers a double-quote attribute breakout (`red" onclick="alert(1)`) and an element injection (`red"><script>alert(1)</script>`), asserting the escaped form is emitted and the live attribute/element is absent.
+
+**Run command:** `cd v2 && go test -run TestMarkdownRenderer_TextStyleColorEscaping ./...`
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `v2/markdown_renderer.go` | Escape `style.Color` before embedding in the style attribute |
+| `v2/renderer_markdown_test.go` | Add `TestMarkdownRenderer_TextStyleColorEscaping` regression test |
+| `CHANGELOG.md` | Add entry under Unreleased → Fixed |
+
+## Verification
+
+**Automated:**
+- [ ] Regression test passes
+- [ ] Full test suite passes
+- [ ] Linters/validators pass
+
+**Manual verification:**
+- Confirmed the existing `TestMarkdownRenderer_TextStyling` expectation (`<span style="color: red; font-size: 14px">`) still holds, since benign color values are unchanged by escaping.
+
+## Prevention
+
+**Recommendations to avoid similar bugs:**
+- Whenever a renderer emits raw HTML, every interpolated dynamic value must be HTML-escaped (attribute and text contexts alike) — mirror the existing `html.EscapeString` usage in `v2/html_renderer.go`.
+- When hardening one renderer against an injection, grep the other renderers for the same pattern; the styled-text logic exists in both the HTML and Markdown renderers.
+
+## Related
+
+- Transit ticket T-1625
+- Similar prior fix: `specs/bugfixes/escape-graph-labels/` (escaping of user data in graph output)

--- a/specs/bugfixes/markdown-color-escaping/report.md
+++ b/specs/bugfixes/markdown-color-escaping/report.md
@@ -35,7 +35,14 @@ The ticket identified the exact defect site, and inspection confirmed it and rul
 
 ## Resolution for the Issue
 
-_Pending — filled in after the fix is implemented._
+**Changes made:**
+- `v2/markdown_renderer.go:266` - Wrap `style.Color` in `html.EscapeString()` before embedding it in the `style` attribute (with the `html` import added). This matches the HTML renderer's handling at `v2/html_renderer.go:237`.
+
+**Approach rationale:** `html.EscapeString` escapes `"`, `'`, `&`, `<`, and `>`, which neutralises both attribute breakout and element injection while leaving legitimate CSS color values (`red`, `#ff0000`, `rgb(1,2,3)`) untouched. Using the same function as the HTML renderer keeps behaviour consistent across renderers, as requested by the ticket. `TextStyle.Size` needs no change: it is an `int` formatted with `%d` and cannot carry a payload.
+
+**Alternatives considered:**
+- Validate the color against a CSS color allowlist/regex and drop invalid values - Rejected: stricter than the HTML renderer (the same input would produce different output per renderer), and maintaining an allowlist of valid CSS color syntax is more code for no additional safety over escaping.
+- Extract a shared styled-span helper used by both renderers - Rejected for this fix: a larger refactor than the bug warrants; the renderers build their spans differently (the HTML renderer also emits CSS classes).
 
 ## Regression Test
 
@@ -57,9 +64,9 @@ _Pending — filled in after the fix is implemented._
 ## Verification
 
 **Automated:**
-- [ ] Regression test passes
-- [ ] Full test suite passes
-- [ ] Linters/validators pass
+- [x] Regression test passes (`go test -run TestMarkdownRenderer_TextStyleColorEscaping ./...`)
+- [x] Full test suite passes (`make test`)
+- [x] Linters/validators pass (`golangci-lint run`: 0 issues; `gofmt -l`: clean; `go vet`: clean)
 
 **Manual verification:**
 - Confirmed the existing `TestMarkdownRenderer_TextStyling` expectation (`<span style="color: red; font-size: 14px">`) still holds, since benign color values are unchanged by escaping.

--- a/v2/markdown_renderer.go
+++ b/v2/markdown_renderer.go
@@ -3,6 +3,7 @@ package output
 import (
 	"context"
 	"fmt"
+	"html"
 	"io"
 	"maps"
 	"os"
@@ -261,7 +262,9 @@ func (m *markdownRenderer) renderTextContentMarkdown(text *TextContent) ([]byte,
 		if style.Color != "" || style.Size > 0 {
 			var htmlAttrs []string
 			if style.Color != "" {
-				htmlAttrs = append(htmlAttrs, fmt.Sprintf("color: %s", style.Color))
+				// Escape the color so it cannot break out of the style
+				// attribute (matches the HTML renderer's handling).
+				htmlAttrs = append(htmlAttrs, fmt.Sprintf("color: %s", html.EscapeString(style.Color)))
 			}
 			if style.Size > 0 {
 				htmlAttrs = append(htmlAttrs, fmt.Sprintf("font-size: %dpx", style.Size))

--- a/v2/renderer_markdown_test.go
+++ b/v2/renderer_markdown_test.go
@@ -213,6 +213,55 @@ func TestMarkdownRenderer_TextStyling(t *testing.T) {
 	}
 }
 
+// TestMarkdownRenderer_TextStyleColorEscaping is a regression test for T-1625:
+// a hostile TextStyle.Color value must not be able to break out of the style
+// attribute of the emitted <span> when the Markdown output is rendered as HTML.
+// The color value must be HTML-escaped, matching the HTML renderer's behaviour.
+func TestMarkdownRenderer_TextStyleColorEscaping(t *testing.T) {
+	tests := map[string]struct {
+		color   string
+		want    string
+		notWant string
+	}{
+		"attribute breakout via double quote": {
+			color: `red" onclick="alert(1)`,
+			// Expected: quotes escaped so the value stays inside the style attribute
+			want: `<span style="color: red&#34; onclick=&#34;alert(1)">`,
+			// Actual (bug): the quote closes the attribute and injects onclick
+			notWant: `onclick="alert(1)"`,
+		},
+		"tag injection via angle brackets": {
+			color: `red"><script>alert(1)</script>`,
+			// Expected: angle brackets escaped so no element can be injected
+			want: `color: red&#34;&gt;&lt;script&gt;alert(1)&lt;/script&gt;`,
+			// Actual (bug): a live <script> element appears in the output
+			notWant: `<script>`,
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			doc := New().
+				Text("Styled text", WithTextStyle(TextStyle{Color: tt.color})).
+				Build()
+
+			renderer := &markdownRenderer{headingLevel: 1}
+			result, err := renderer.Render(context.Background(), doc)
+			if err != nil {
+				t.Fatalf("Render() error = %v", err)
+			}
+
+			got := string(result)
+			if strings.Contains(got, tt.notWant) {
+				t.Errorf("Render() output contains unescaped hostile input %q:\n%s", tt.notWant, got)
+			}
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("Render() output missing escaped style value %q:\n%s", tt.want, got)
+			}
+		})
+	}
+}
+
 func TestMarkdownRenderer_MarkdownEscaping(t *testing.T) {
 	specialText := "Text with *asterisks* and _underscores_ and [brackets] and |pipes|"
 


### PR DESCRIPTION
## Summary

Fixes T-1625: the Markdown renderer emitted raw HTML for colored/sized text (`TextStyle.Color`/`Size`) with the color value interpolated directly into the `style` attribute, unescaped. A hostile color such as `red" onclick="alert(1)` supplied via `WithColor` broke out of the attribute and injected HTML into the Markdown output.

## Root Cause

`renderTextContentMarkdown` in `v2/markdown_renderer.go` built the style attribute with `fmt.Sprintf("color: %s", style.Color)` and embedded it via `<span style="%s">` without HTML attribute escaping. The equivalent code path in the HTML renderer already escaped the value with `html.EscapeString`; the duplicated Markdown-renderer path was overlooked.

## Fix

- Wrap `style.Color` in `html.EscapeString()` before embedding it in the style attribute, matching the HTML renderer's handling (`v2/html_renderer.go:237`). Valid CSS colors are unchanged; `Size` is an `int` and needs no escaping.
- Regression test `TestMarkdownRenderer_TextStyleColorEscaping` covers attribute breakout (`red" onclick="alert(1)`) and element injection (`red"><script>...`) inputs.
- Also removes a stray `<<<<<<< HEAD` merge conflict marker that was committed to `CHANGELOG.md` on main, in the Unreleased section this change edits.

Full report: `specs/bugfixes/markdown-color-escaping/report.md`

## Verification

- Regression test fails before the fix, passes after
- `make test` passes; `golangci-lint run` reports 0 issues; `gofmt`/`go vet` clean